### PR TITLE
rm unnecessary sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ curl -sSL https://get.rvm.io | bash
 
 ### Set RVM Default to 2.0.0
 
-rvm install ruby-2.0.0-p451  
+rvm install ruby-2.0.0-p451
 rvm --default use 2.0.0
 
 ### Install Pygments
@@ -54,7 +54,7 @@ easy_install pygments
 
 ### Install Kramdown
 
-sudo gem install kramdown
+gem install kramdown
 
 ### Install Jekyll
  [http://jekyllrb.com/](http://jekyllrb.com/)


### PR DESCRIPTION
Because the instructions specify rvm instead of the system ruby, there is no need to use sudo on the gem install (and, in fact, it's already left off the install for the jekyll gem).

While we're at it, removing some trailing space, because that's how my IDE rolls.
