### PR TITLE
Copyedit src readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -12,6 +12,7 @@
 - Clone this repo
 - Move to the `src` directory in your working copy
 - Install dependencies: `npm install`
+- Install fontforge if required for grunt-webfont on your OS.  See [grunt-webfont installation instructions](https://github.com/sapegin/grunt-webfont/blob/master/Readme.md#installation) for details.
 
 
 ## Running the build


### PR DESCRIPTION
- spelling: dependancies -> dependencies
- edit for brevity
- Go to the `src` directory before `npm install`, not the project root
