### PR TITLE
Don't color code fragments white

### DIFF
--- a/src/site/documentation/introduction-to-media/images/avoid-images-completely.markdown
+++ b/src/site/documentation/introduction-to-media/images/avoid-images-completely.markdown
@@ -94,6 +94,10 @@ webfonts to achieve the style you need.
     box-shadow: 5px 5px 4px 0 rgba(9,130,154,0.2);
     background: linear-gradient(rgba(9, 130, 154, 1), rgba(9, 130, 154, 0.5));
   }
+  
+  p#noImage code {
+    color: rgb(64, 64, 64);
+  }
 </style>
 <p id="noImage">
   Modern browsers can use CSS features to create styles that would previously


### PR DESCRIPTION
Set code fragment to default text color instead of white in the gradient example. Previously they were invisible because it was white-on-white.

This is how it currently looks:

![Example](http://imageshack.com/a/img843/1795/kpms.png)
