### PR TITLE
Adds installation of kramdown to README.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -11,7 +11,7 @@
 
 - Clone this repo
 - Move to the `src` directory in your working copy
-- Install dependencies: `npm install`
+- Install dependencies: `npm install` and `gem install kramdown`
 - Install fontforge if required for grunt-webfont on your OS.  See [grunt-webfont installation instructions](https://github.com/sapegin/grunt-webfont/blob/master/Readme.md#installation) for details.
 
 


### PR DESCRIPTION
[Jekyll uses the kramdown gem](https://github.com/google/WebFundamentals/blob/master/src/site/_config.yml#L5) for markdown compilation. Without it the project won't build.

Suggestion: it would probably be neater to install all ruby dependencies through a `Gemfile` and a `gem install`, rather than a specific `gem install kramdown`. Would such a pull request be welcome?
