### PR TITLE
Include link to latest web-starter-kit release.

### DIFF
--- a/src/site/tools/setup/setup_kit.markdown
+++ b/src/site/tools/setup/setup_kit.markdown
@@ -28,8 +28,9 @@ notes:
 ## Clone repository
 
 To use the Web Starter Kit,
-simply clone the repository and
-build on what's included in the `app` directory:
+simply clone the repository or download the
+[latest release](https://github.com/google/web-starter-kit/releases) and build on
+what's included in the `app` directory:
 
 `git clone https://github.com/google/web-starter-kit.git`
 


### PR DESCRIPTION
Might be best to link to the latest release, which is more likely to be stable and can be downloaded directly without requiring `git`.
