### PR TITLE
Replace vim for sublime

### DIFF
--- a/src/site/tools/setup/devtools.markdown
+++ b/src/site/tools/setup/devtools.markdown
@@ -61,7 +61,7 @@ The easiest way create command-line short-cuts is to
 add aliases for common commands to your `bashrc` file.
 On Mac or Linux:
 
-* From the command line anywhere, type `vim ~/.bashrc`.
+* From the command line anywhere, type `open -a 'Sublime Text' ~/.bashrc`.
 * Add a new alias, for example, `alias master='git checkout master'`.
 * From your source directory, run `master`.
 


### PR DESCRIPTION
As suggested in #493 by @xiongchiamiov, Vim might be a tool with too steep a learning curve for users unfamiliar with a command line interface.

This PR replaces the suggested tool with Sublime.
