### PR TITLE
Adds Node and Grunt dependencies to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Mac
     * `gem install kramdown`
 1. Install [Jekyll](http://jekyllrb.com/)
     * `gem install jekyll`
+1. Install [Node.js](http://nodejs.org/)
+1. Install the [Grunt CLI](http://gruntjs.com/)
+    * `npm install -g grunt-cli
 
 
 Using project-level meta data

--- a/src/README.md
+++ b/src/README.md
@@ -3,7 +3,9 @@
 
 ## Prerequisites
 
-- [NodeJS with NPM](http://nodejs.org)
+- [Node.js with npm](http://nodejs.org)
+- The [Grunt CLI](http://gruntjs.com/)
+	* `npm install -g grunt-cli`
 - [Jekyll](http://jekyllrb.com)
 
 


### PR DESCRIPTION
Specifies the `node` and more importantly `grunt-cli` dependencies in the README(s). Without installing `grunt-cli` the project won't run, and doing so is often overlooked :wink: :

Is there a reason there are two READMEs?
