### PR TITLE
Link to latest wsk release, rather than the releases page.

### DIFF
--- a/src/site/tools/setup/setup_kit.markdown
+++ b/src/site/tools/setup/setup_kit.markdown
@@ -29,7 +29,7 @@ notes:
 
 To use the Web Starter Kit,
 simply clone the repository or download the
-[latest release](https://github.com/google/web-starter-kit/releases) and build on
+[latest release](https://github.com/google/web-starter-kit/releases/latest) and build on
 what's included in the `app` directory:
 
 `git clone https://github.com/google/web-starter-kit.git`


### PR DESCRIPTION
Link to [web-starter-kit/releases/latest](https://github.com/google/web-starter-kit/releases/latest) rather than [web-starter-kit/releases](https://github.com/google/web-starter-kit/releases/latest)

See #547 
