### PR TITLE
Update site oath target improvements

### DIFF
--- a/src/appengine/scripts/update_site_oauth_target.sh
+++ b/src/appengine/scripts/update_site_oauth_target.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 
 versionStr="${1:-master}"
 


### PR DESCRIPTION
Some small tweaks to make the `update_site_oauth_target.sh` script more robust.
- Prevent shell expansion in the case it's called with an argument containing a space
- Set errorexit to prevent update from being called if make exits with an error
- Use `pushd` and `popd` rather than a subshell
