### PR TITLE
microdata image must be `link` element

### DIFF
--- a/src/site/_includes/head.liquid
+++ b/src/site/_includes/head.liquid
@@ -40,7 +40,7 @@
 <link rel="publisher" href="https://plus.google.com/+GoogleChromeDevelopers">
 
 <meta itemprop="name" content="{{ page_title }}">
-<meta itemprop="image" content="/imgs/logo.png">
+<link itemprop="image" href="/imgs/logo.png">
 <meta itemprop="description" content="{% if page.description %}{{ page.description }}{% else %}Google Web Fundamentals{% endif %}">
 
 <meta property="og:site_name" content="Web Fundamentals" />


### PR DESCRIPTION
Otherwise, won't be recognized.
