### PR TITLE
Fix issue #829

### DIFF
--- a/src/site/_plugins/sample_builder.rb
+++ b/src/site/_plugins/sample_builder.rb
@@ -233,7 +233,7 @@ module SampleBuilder
 
     def render_sample(sample, site)
       url = File.join(site.config["sample_link_base"],
-          sample.url.sub("/fundamentals/resources/samples/", ""))
+          sample.url.sub("fundamentals/resources/samples/", ""))
       name = sample.title
       section = sample.section
       output = ""


### PR DESCRIPTION
The current [sample_builder.rb](https://github.com/google/WebFundamentals/blob/b8bf67413349d74c318eb63f9f229bde02ac709b/src/site/_plugins/sample_builder.rb#L236) is looking for an extra '/' in the url portion to substitute away.
