### PR TITLE
Check for null to avoid issue #848

### DIFF
--- a/src/site/_includes/scripts.liquid
+++ b/src/site/_includes/scripts.liquid
@@ -37,18 +37,20 @@
           var documentationIsOpenedClass = 'subnav-is-opened';
           var documentationIsOpened = false;
 
-          documentationLink.addEventListener('click', function (event) {
-            event.preventDefault();
+          if (documentationLink) {
+            documentationLink.addEventListener('click', function (event) {
+              event.preventDefault();
 
-            if (!documentationIsOpened) {
-              documentationIsOpened = true;
-              addClass(documentationItem, documentationIsOpenedClass);
-            } else {
-              documentationIsOpened = false;
-              removeClass(documentationItem, documentationIsOpenedClass);
-            }
+              if (!documentationIsOpened) {
+                documentationIsOpened = true;
+                addClass(documentationItem, documentationIsOpenedClass);
+              } else {
+                documentationIsOpened = false;
+                removeClass(documentationItem, documentationIsOpenedClass);
+              }
 
-          });
+            });
+          }
         }
 
         var isTouch = function() {


### PR DESCRIPTION
[AFAIK](https://developer.mozilla.org/en-US/docs/Web/API/document.querySelector), `document.querySelector` can't return `0` or `false`. This means that [this styleguide entry](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml?showone=Tips_and_Tricks#Tips_and_Tricks) applies, and I can simply write `if (documentationLink) { ... }`.
