### PR TITLE
Remove JSHint `trailing` option

### DIFF
--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -18,7 +18,6 @@
 	"undef": true,
 	"unused": true,
 	"strict": true,
-	"trailing": true,
 
 
 

--- a/src/.jshintrc-documented
+++ b/src/.jshintrc-documented
@@ -18,7 +18,6 @@
   "undef"           // warns if variables are used but not defined (defined, not necessarily source order)
   "unused"          // warns if there are unused variables
   "strict"          // warns if use strict is missing somewhere
-  "trailing"        // warns if there is trailing whitespace
   "maxparams"       // the maximum number of parameters for a function
   "maxdepth"        // the maximum depth of a the code blocks
   "maxstatements"   // the maximum number of statements in a function
@@ -68,15 +67,3 @@
   "nonstandard"     // defines non-standard but widely adopted globals such as escape and unescape
   "globals"         // exposed globals
 }
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
The JSHint option `trailing` got deprecated (https://github.com/jshint/jshint/commit/0c0e19319b276b019d285bdfd2cfc49126abd814) but was still in the `.jshintrc` file.
