### PR TITLE
translate images-in-css.markdown into Chinese

### DIFF
--- a/src/site/_zh-cn/fundamentals/media/images/images-in-css.markdown
+++ b/src/site/_zh-cn/fundamentals/media/images/images-in-css.markdown
@@ -1,15 +1,12 @@
 ---
 layout: article
-title: "Images in CSS"
-description: "The CSS `background` property is a powerful tool for adding complex images to
-elements, making it easy to add multiple images, cause them to repeat, and more."
-introduction: "The CSS `background` property is a powerful tool for adding complex images to
-elements, making it easy to add multiple images, cause them to repeat, and more.
- When combined with media queries, the background property becomes even more
-powerful, enabling conditional image loading based on screen resolution,
-viewport size and more."
+title: "CSS 中的图片"
+description: "CSS 的 `background` 属性是一个强大的工具，用于给元素添加复杂图片，多图片、重复图片、等等都是易如反掌。"
+introduction: "CSS 的 `background` 属性是一个强大的工具，用于给元素添加复杂图片，多图片、重复图片、等等都是易如反掌。结合媒体查询的话，背景属性变得更加强大，能够基于屏幕分辨率、视口尺寸等有选择地加载图片。"
 authors:
   - petelepage
+translators:
+  - 陈三
 article:
   written_on: 2014-04-30
   updated_on: 2014-04-30
@@ -17,16 +14,10 @@ article:
 collection: images
 key-takeaways:
   use-right-image:
-    - Use the best image for the characteristics of the display, consider
-      screen size, device resolution and page layout.
-    - Change the <code>background-image</code> property in CSS for high DPI
-      displays using media queries with <code>min-resolution</code> and
-      <code>-webkit-min-device-pixel-ratio</code>.
-    - Use srcset to provide high resolution images in addition to the 1x
-      image in markup.
-    - Consider the performance costs when using JavaScript image replacement
-      techniques or when serving highly compressed high resolution images to
-      lower resolution devices.
+    - 针对屏幕特征如尺寸、设备分辨率及页面布局使用最适图片。
+    - 高 DPI 显示屏上，使用媒体查询结合 <code>min-resolution</code> 和 <code>-webkit-min-device-pixel-ratio</code> 改变 CSS 中的 <code>background-image</code> 属性。
+    - 除了标记中的 1x 图片外，使用 srcset 提供高分辨率图片。
+    - 使用 JavaScript 图片替换技术或是提供高分辨率图片给低分辨率设备时，请考虑性能上的成本。
   avoid-images:
     - Avoid images whenever possible, instead, leverage browser capabilities,
       use unicode characters in place of images, and replace complex icons
@@ -66,26 +57,17 @@ remember:
 
 {% include modules/takeaway.liquid list=page.key-takeaways.use-right-image %}
 
-## Use media queries for conditional image loading or art direction
+## 使用媒体查询有条件地加载图片或是艺术指导
 
-Media queries not only affect the page layout, but can also be used to
-conditionally load images or to provide art direction depending on the viewport
-width.
+媒体查询不仅影响页面布局，还可以用于有条件地加载图片，或是基于视口宽度提供艺术指导。
 
-For example in the sample below, on smaller screens, only `small.png` is
-downloaded and applied to the content `div`, while on larger screens,
-`background-image: url(body.png)` is applied to the body and `background-image:
-url(large.png)` is applied to the content `div`.
+举下面的例子说，在小屏幕上，只有 `small.png` 被下载然后应用于内容 `div`，而在大屏幕上，`background-image: url(body.png)` 应用于 body，`background-image: url(large.png)` 应用于内容 `div`。
 
 {% include_code _code/conditional-mq.html conditional css %}
 
-## Use image-set to provide high res images
+## 使用 image-set 提供高分辨率图片
 
-The `image-set()` function in CSS enhances the behavior `background` property,
-making it easy to provide multiple image files for different device
-characteristics.  This allows the browser to choose the best image depending on
-the characteristics of the device, for example using a 2x image on a 2x display,
-or a 1x image on a 2x device when on a limited bandwidth network.
+CSS 中的 `image-set` 函数加强了 `background` 属性的功能，使它能够为不同设备特征提供多种图片文件。这样浏览器就可以基于设备特征选择最适图片，比如在 2x 显示屏上使用 2x 图片，而在有限的带宽网络中，2x 的设备仍使用 1x 图片。
 
 {% highlight css %}
 background-image: image-set(
@@ -94,26 +76,17 @@ background-image: image-set(
 );
 {% endhighlight %}
 
-In addition to loading the correct image, the browser will also scale it
-accordingly. In other words, the browser assumes that 2x images are twice as
-large as 1x images, and so will scale the 2x image down by a factor of 2, so
-that the image appears to be the same size on the page.
+除了加载合适的图片外，浏览器也会相应调整其大小。换句话说，浏览器假定了 2x 图片是 1x 图片的两倍大，因此会将 2x 图片缩小一半，最后图片在页面上看上去就一样大小。
 
-Support for `image-set()` is still new and is only supported in Chrome and
-Safari with the `-webkit` vendor prefix.  Care must also be taken to include a
-fallback image for when `image-set()` is not supported, for example:
+对 `image-set()` 的支持目前还很少，仅 Chrome 和 Safari 上通过 `-webkit` 浏览器前缀支持。对于 `image-set()` 不被支持的情况，一定要小心加入后备图片，比如：
 
 {% include_code _code/image-set.html imageset css %}
 
-The above will load the appropriate asset in browsers that support image-set,
-and fall back to the 1x asset otherwise. The obvious caveat is that while
-`image-set()` browser support is low, most browsers will get the 1x asset.
+上例中，支持 image-set 的浏览器会加载合适的图片，不支持的则回落到 1x 图片。明显需要提醒你的是，`image-set()` 的浏览器支持非常少，大部分浏览器会取到 1x 图片。
 
-## Use media queries to provide high res images or art direction
+## 使用媒体查询提供高分辨率图片或是艺术指导
 
-Media queries can create rules based on the [device pixel
-ratio](http://www.html5rocks.com/en/mobile/high-dpi/#toc-bg), making it possible
-to specify different images for 2x vs 1x displays.
+媒体查询能基于[设备像素比](http://www.html5rocks.com/en/mobile/high-dpi/#toc-bg)创建规则，于是就能给 2x 及 1x 显示屏指定不同图片。
 
 {% highlight css %}
 @media (min-resolution: 2dppx),
@@ -123,19 +96,12 @@ to specify different images for 2x vs 1x displays.
 }
 {% endhighlight %}
 
-Chrome, Firefox and Opera all support the standard `(min-resolution: 2dppx)`,
-while Safari and Android Browser both require the older vendor prefixed syntax
-without the `dppx` unit.  Remember, these styles are only loaded if the device
-matches the media query, and you must specify styles for the base case.  This
-also provides the benefit of ensuring something will be rendered if the browser
-doesn't support resolution specific media queries.
+Chrome、Firefox 和 Opera 都支持标准的 `(min-resolution: 2dppx)`，Safari 和 Android 浏览器则均需要旧的浏览器前缀语法 - 无 `dppx` 单位。记住，这些样式只有在设备匹配媒体查询时才被加载，切记要给基础情况指定样式。这能确保浏览器不支持分辨率特有的媒体查询时，仍有东西被渲染。
 
 {% include_code _code/media-query-dppx.html mqdppx css %}
 
-You can also use the min-width syntax to display alternative images depending on
-the viewport size.  This technique has the advantage that the image is not
-downloaded if media query doesn't match.  For example, `bg.png` is only
-downloaded and applied to the `body` if the browser width is 500px or greater:
+你也可以使用 min-width 语法基于视口尺寸显示不同图片。这个技术的好处是，如果媒体查询不匹配，则图片不会被下载。如下，`bg.png` 只有在浏览器宽度是 500px 或更大时才被下载，然后应用于 `body`。
+
 
 {% highlight css %}
 @media (min-width: 500px) {


### PR DESCRIPTION
The '_avoid-images_', '_optimize-images_' and '_remember_' parts are not rendered in the front page so I'll leave them here until they are removed from the en source.
