### PR TITLE
Fix assignment in condition

### DIFF
--- a/src/site/sass-visit-mixin-monkey-patch.rb
+++ b/src/site/sass-visit-mixin-monkey-patch.rb
@@ -6,7 +6,7 @@ class Sass::Tree::Visitors::Perform < Sass::Tree::Visitors::Base
     include_loop = false
 
     @stack.push(:filename => node.filename, :line => node.line, :name => node.name)
-    raise Sass::SyntaxError.new("Undefined mixin '#{node.name}'.") unless mixin = @environment.mixin(node.name)
+    raise Sass::SyntaxError.new("Undefined mixin '#{node.name}'.") unless mixin == @environment.mixin(node.name)
 
     if node.children.any? && !mixin.has_content
       raise Sass::SyntaxError.new(%Q{Mixin "#{node.name}" does not accept a content block.})


### PR DESCRIPTION
Corrects the use of assignment operator ('=') rather than boolean ('==') in conditional expression.
