### PR TITLE
Fix issue #924

### DIFF
--- a/src/site/_en/fundamentals/tools/devices/deviceemulators.markdown
+++ b/src/site/_en/fundamentals/tools/devices/deviceemulators.markdown
@@ -87,8 +87,8 @@ simple:
         Use Host GPU
       </td>
       <td data-th="Description">
-        Make sure you **check this** field as it can drastically improve the
-        emulators performance.
+        Make sure you <strong>check this</strong> field as it can drastically
+        improve the emulators performance.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
As reported by @cvan, this Markdown syntax won't work inside of a
raw HTML table. Use a &lt;strong&gt; tag instead.
