### PR TITLE
Fix issue #929

### DIFF
--- a/src/site/_en/fundamentals/media/video/provide-alternatives-for-legacy-platforms.markdown
+++ b/src/site/_en/fundamentals/media/video/provide-alternatives-for-legacy-platforms.markdown
@@ -9,7 +9,7 @@ introduction: "Not all video formats are supported on all platforms.
               and make sure your video works in each of these."
 article:
   written_on: 2014-04-16
-  updated_on: 2014-04-29
+  updated_on: 2014-10-23
   order: 2
 collection: videos
 authors:
@@ -61,7 +61,7 @@ Use `canPlayType()` to find out which video formats are supported. The method
 takes a string argument consistent of a `mime-type` and optional codecs and
 returns one of the following values:
 
-<table class="table">
+<table class="table-2">
   <thead>
     <tr>
       <th>Return value</th>
@@ -92,7 +92,7 @@ Here are some examples of `canPlayType()` arguments and return values when
 run in Chrome:
 
 
-<table class="table">
+<table class="table-2">
   <thead>
     <tr>
       <th>Type</th>

--- a/src/site/_en/fundamentals/media/video/quick-reference.markdown
+++ b/src/site/_en/fundamentals/media/video/quick-reference.markdown
@@ -5,7 +5,7 @@ description: "A quick overview of properties on the video element."
 introduction: "A quick overview of properties on the video element."
 article:
   written_on: 2014-04-16
-  updated_on: 2014-04-29
+  updated_on: 2014-10-23
   order: 5
 collection: videos
 authors:
@@ -53,7 +53,7 @@ remember:
 For the complete list of video element attributes and their definitions,
 see [the video element spec](//www.w3.org/TR/html5/embedded-content-0.html#the-video-element).
 
-<table class="table">
+<table class="table-3">
   <thead>
       <th>Attribute</th>
       <th>Availability</th>
@@ -116,7 +116,7 @@ It defaults to true but a WebView app can choose to disable it.
 The `preload` attribute provides a hint to the browser as to how much
 information or content should be preloaded.
 
-<table>
+<table class="table-2">
   <thead>
     <tr>
       <th>Value</th>
@@ -154,7 +154,7 @@ updating it with mobile-specific concerns where relevant.
 
 ### Properties
 
-<table class="table">
+<table class="table-2">
   <thead>
     <th>Property</th>
     <th>Description</th>
@@ -199,7 +199,7 @@ Neither playbackRate ({% link_sample _code/scripted.html %}see demo{% endlink_sa
 
 ### Methods
 
-<table class="table">
+<table class="table-2">
   <thead>
     <th>Method</th>
     <th>Description</th>
@@ -233,7 +233,7 @@ These are only a subset of the media events that may be fired. Refer to
 the [Media events](//developer.mozilla.org/docs/Web/Guide/Events/Media_events)
 page on the Mozilla Developer Network for a complete listing.
 
-<table class="table">
+<table class="table-2">
   <thead>
     <th>Event</th>
     <th>Description</th>


### PR DESCRIPTION
Use .table-n classes to add a bit of whitespace between columns
to improve readability as reported by @jacquerie.

(I feel all kinds of stupid when I write "as reported by @jacquerie". What should I write instead?)
