### PR TITLE
Add mention to Network Conditioning feature

### DIFF
--- a/src/site/_en/fundamentals/tools/test/mobilenetwork.markdown
+++ b/src/site/_en/fundamentals/tools/test/mobilenetwork.markdown
@@ -17,6 +17,10 @@ notes:
 ---
 {% wrap content %}
 
+If you're running Google Chrome, you can use the [Network
+Conditioning](https://developer.chrome.com/devtools/docs/device-mode#network-conditions)
+feature offered by the DevTools.
+
 If you're on a Mac, try out the Network Link Conditioner tool found in the Lion
 Developer Tools.
 


### PR DESCRIPTION
Google Chrome has added a feature to its DevTools that throttles
the speed of a connection, emulating limited network conditions.

Fixes #964.
