### PR TITLE
Fix typo in category title

### DIFF
--- a/src/site/_de/_betterbook.yaml
+++ b/src/site/_de/_betterbook.yaml
@@ -23,7 +23,7 @@ toc:
             path: /fundamentals/layouts/layout-patterns/
           - title: Elemente der Nutzeroberfläche
             path: /fundamentals/layouts/ui-elements/
-      - title: Formen und Nutzereingabe
+      - title: Formulare und Nutzereingabe
         path: /fundamentals/input/
         id: user-input
         section:


### PR DESCRIPTION
As reported by @Vanvox, title should say 'Formen' instead of
'Formrn'.

Fixes #989.
