### PR TITLE
Add language tag to issue reporter

### DIFF
--- a/src/site/_includes/beta.liquid
+++ b/src/site/_includes/beta.liquid
@@ -1,5 +1,5 @@
 <span id="beta" class="beta">
   <i class="icon icon-cog"></i>
-   <a href="{{site.github.root}}/tree/master/src/site/{{page.path| uri_escape }}" target="_blank">{{"view_source" | localize_string}}</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="{{site.github.root}}/issues/new?title={{"Feedback for: " | uri_escape }}{{page.url| uri_escape }}" target="_blank">{{"submit_feedback" | localize_string}}</a>
+   <a href="{{site.github.root}}/tree/master/src/site/{{page.path| uri_escape }}" target="_blank">{{"view_source" | localize_string}}</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="{{site.github.root}}/issues/new?title={{"[" | uri_escape }}{{page.langcode | upcase}}{{"] Feedback for: " | uri_escape }}{{page.url| uri_escape }}" target="_blank">{{"submit_feedback" | localize_string}}</a>
 </span>
 


### PR DESCRIPTION
Prepend a tag such as '[EN]' to an issue, so that it's easier to
determine which language is the user referring to when she gives
feedback.

Fixes #1001.
