### PR TITLE
Fix two typos.

### DIFF
--- a/src/site/_en/fundamentals/performance/critical-rendering-path/constructing-the-object-model.markdown
+++ b/src/site/_en/fundamentals/performance/critical-rendering-path/constructing-the-object-model.markdown
@@ -94,7 +94,7 @@ Curious to know how long the CSS processing took? Record a timeline in DevTools 
 
 <img src="images/cssom-timeline.png" class="center" alt="Tracing CSSOM construction in DevTools">
 
-Our trivial stylesheet takes ~0.6ms to process and affects 8 elements on the page -- not much, but once again, not free. However, where did the 8 elements come from? The CSSOM and DOM and are independent data structures! Turns out, the browser is hiding an important step. Next, lets talk about the render tree that links the DOM and CSSOM together.
+Our trivial stylesheet takes ~0.6ms to process and affects 8 elements on the page -- not much, but once again, not free. However, where did the 8 elements come from? The CSSOM and DOM are independent data structures! Turns out, the browser is hiding an important step. Next, lets talk about the render tree that links the DOM and CSSOM together.
 
 {% include modules/nextarticle.liquid %}
 

--- a/src/site/_en/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer.markdown
+++ b/src/site/_en/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer.markdown
@@ -203,7 +203,7 @@ What’s the best config for your server? The HTML5 Boilerplate project contains
 
 <img src="images/transfer-vs-actual-size.png" class="center" alt="DevTools demo of actual vs transfer size">
 
-A quick and simple way to see GZIP in action is to open Chrome DevTools and inspect the “Size / Content” column in the Network panel: “Size” indicates the transfer size of the asset, and “Content” the uncompressed size of the asset. For the HTML asset in above example, GZIP saved 24.8 KB during transfer!
+A quick and simple way to see GZIP in action is to open Chrome DevTools and inspect the “Size / Content” column in the Network panel: “Size” indicates the transfer size of the asset, and “Content” the uncompressed size of the asset. For the HTML asset in above example, GZIP saved 98.8 KB during transfer!
 
 {% include modules/remember.liquid list=page.notes.gzip %}
 


### PR DESCRIPTION
1. Removes extra "and". Link to the [page](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/constructing-the-object-model).
2. Uses correct number for saved KB based on [image](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/images/transfer-vs-actual-size.png). Link to the [page](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer#text-compression-with-gzip).
