### PR TITLE
Run jekyll builds in parallel for each language

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -220,25 +220,6 @@ module.exports = function(grunt) {
 			}
 		},
 
-		jekyll: {
-			appengine: {
-				options: {
-					config: 'config/wsk-version.yml,config/appengine.yml'
-				}
-			},
-			develop: {
-				options: {
-					config: 'config/wsk-version.yml,config/local.yml'
-				}
-			},
-			devsite: {
-				options: {
-					config: 'config/wsk-version.yml,config/devsite.yml'
-				}
-			}
-
-		},
-
 		jshint: {
 			options: {
 				jshintrc: 'src/.jshintrc'
@@ -357,7 +338,71 @@ module.exports = function(grunt) {
 		});
 	});
 
+	// jekyll:target [--lang <lang_code,lang_code,...|all>]
+	// where 'target' is config/target.yml file.
+	// defaults to '--lang all'.
+	// 'all' builds for all languages specified in config.yml/langs_available + 'en'.
+	// builds w/o multilang support if config.yml is missing langs_available.
+	grunt.registerTask('jekyll', 'Run jekyll build.\nOptions:\n  [--lang]: list of languages or "all"', function() {
+		var langs = grunt.option('lang') || 'all';
 
+		var cfgname = this.args[0] || 'develop';
+		if (cfgname === 'develop') {
+			cfgname = 'local';
+		}
+
+		// read langs from config/target.yml
+		// returns langs_available + prime_lang
+		//         or [] if langs_available is not defined.
+		var langsFromConfig = function() {
+			/*jshint camelcase: false */
+			var cfg = grunt.file.readYAML('config/' + cfgname + '.yml');
+			if (typeof cfg.langs_available === 'undefined') {
+				return [];
+			}
+			cfg.langs_available.unshift(cfg.prime_lang);
+			return cfg.langs_available;
+			/*jshint camelcase: true */
+		};
+
+		if (langs === 'all' ) {
+			langs = langsFromConfig();
+		} else {
+			langs = langs.split(/,|\s/).filter(function(item) {
+				return item.length > 0;
+			});
+		}
+
+		var cfgfiles = 'config/wsk-version.yml,config/' + cfgname + '.yml';
+		var args = ['build', '--config', cfgfiles, '-t'];
+		var spawnJekyll = function(lang, callback) {
+			var opts = {env: process.env, stdio: 'inherit'};
+			if (lang !== null) {
+				opts.env.TRANS_LANG = lang;
+			}
+			grunt.util.spawn({cmd: 'jekyll', args: args, opts: opts}, callback);
+		};
+
+		var done = this.async();
+		var count = 0;
+		var waitAll = function(err, res, code) {
+			if (err) {
+				grunt.fatal(String(res), code);
+			}
+			if (++count >= langs.length) {
+				done();
+			}
+		};
+
+		// multilang build
+		for (var i = 0; i < langs.length; i++) {
+			spawnJekyll(langs[i], waitAll);
+		}
+		// simple build (no multilang support)
+		if (langs.length === 0) {
+			spawnJekyll(null, waitAll);
+		}
+	});
 
 	// Test task
 	grunt.registerTask('test', 'Lints all javascript and CSS sources.', 'jshint:source');

--- a/config/appengine.yml
+++ b/config/appengine.yml
@@ -9,7 +9,6 @@ baseurl: /web
 fundamentals: /web/fundamentals
 url: /web
 highlighter: pygments
-pygments: true
 spotlights: false
 github:
   root: https://github.com/Google/WebFundamentals
@@ -21,6 +20,9 @@ kramdown:
   entity_output: :as_input
 include: ['.htaccess']
 exclude: ['config.rb']
+keep_files: ['_langs\/[a-z\-]+']
 # comment this for plain jekyll serve usage.
 langs_available: ['ar', 'de', 'es', 'fr', 'he', 'it', 'ja', 'ko', 'nl', 'pl', 'pt-br', 'ru', 'tr', 'zh-cn', 'zh-tw']
+# primary language, source of translations.
+prime_lang: en
 sample_link_base: "/web/fundamentals/resources/samples/"

--- a/config/devsite.yml
+++ b/config/devsite.yml
@@ -9,7 +9,6 @@ fundamentals: /web/fundamentals
 baseurl: /web
 url: /web
 highlighter: pygments
-pygments: true
 github:
   root: https://github.com/Google/WebFundamentals
   content: tree/master/src/site
@@ -21,5 +20,8 @@ kramdown:
   entity_output: :as_input
 include: ['.htaccess', '_project.yaml', '_book.yaml']
 exclude: ['README.md', '*.rb', '*.psd', 'js/*', '*.pxm', 'npm-debug.log']
+keep_files: ['_langs\/[a-z\-]+']
 langs_available: ['ar', 'de', 'es', 'fr', 'he', 'it', 'ja', 'ko', 'nl', 'pl', 'pt-br', 'ru', 'tr', 'zh-cn', 'zh-tw']
+# primary language, source of translations.
+prime_lang: en
 sample_link_base: "http://googlesamples.github.io/web-fundamentals/samples/"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-gae": "^0.2.4",
-    "grunt-jekyll": "~0.4.2",
     "grunt-open": "~0.2.3",
     "grunt-webfont": "~0.4.8",
     "js-yaml": "^3.2.2",

--- a/src/site/_en/fundamentals/layouts/index.markdown
+++ b/src/site/_en/fundamentals/layouts/index.markdown
@@ -7,7 +7,7 @@ snippet: "Create flexible, not fixed, layouts."
 article:
   written_on: 2014-01-01
   updated_on: 2014-01-06
-  order: 1
+  order: 0
 id: multi-device-layouts
 collection: home
 priority: 0

--- a/src/site/_layouts/landing.liquid
+++ b/src/site/_layouts/landing.liquid
@@ -22,13 +22,7 @@
 
       <ul class="guides-list container">
 
-        {% for guide in page.articles.[page.id] %}
-        {% comment %} Include all guides if: it is localized to the language of the page,
-        there are no localizations, or it is English and there is no localized version.
-        {% endcomment %}
-        {% if guide.published != false %}
-        {% if guide.langcode == page.langcode or guide.has_localization[page.langcode] == false %}
-        {% if guide.langcode == page.langcode or guide.is_localization == false %}
+      {% for guide in page.articles[page.id] %}
         <li class="guides-list__item g--half theme--{{ guide.id }} {% cycle '', 'g--last' %}">
           <div class="primary-content">
             <h3 class="xlarge"><a href="{{site.baseurl}}{{guide.url | canonicalize | localize_link:guide}}" title="Go to {{guide.title}}" class="themed">{{guide.title}}</a></h3>
@@ -38,19 +32,12 @@
             <span class="icon-circle themed--background"><i class="icon icon-lessons"></i></span>
             <ol class="list-links list-links--secondary">
             {% for article in page.articles[guide.id] %}
-              {% if article.langcode == page.langcode or article.langcode == guide.langcode %}
-              {% if article.langcode == page.langcode or article.has_localization[page.langcode] == false %}
               <li><a href="{{site.baseurl}}{{article.url | canonicalize | localize_link:article}}" title="{{"read_the_lesson" | localize_string}} {{article.title}}">{{article.title}}</a></li>
-              {% endif %}
-              {% endif %}
             {% endfor %}
             </ol>
           </div>
         </li>
-        {% endif %}
-        {% endif %}
-        {% endif %}
-        {% endfor %}
+      {% endfor %}
 
       </ul>
     </div>

--- a/src/site/_plugins/breadcrumbs.rb
+++ b/src/site/_plugins/breadcrumbs.rb
@@ -7,9 +7,15 @@ module Jekyll
   class Page
 
     ##
+    # Caching version of find_ancestors
+    def ancestors
+      @ancestors ||= find_ancestors
+    end
+
+    ##
     # We add a custom method to the page variable, that returns an ordered list of its
     # parent pages ready for iteration.
-    def ancestors
+    def find_ancestors
       a = []
       url = self.url.sub("/fundamentals", "")
       while url != "/index.html"
@@ -48,10 +54,10 @@ module Jekyll
 
     ##
     # Gets Page object that has given url. Very in-efficient O(n) solution.
-    def get_page_from_url(url)
-      site.pages.each do |page|
-        return page if page.url == ("/fundamentals" + url)
-      end
+    def get_page_from_url(pageurl)
+      pageurl = "/fundamentals" + pageurl
+      return site.data['primes'][pageurl] if site.data.key? 'primes'
+      site.pages.find { |page| page.url == pageurl }
     end
   end
 end


### PR DESCRIPTION
This should reduce `grunt jekyll:<appengine|devsite>` (all langs) to about 15 sec.

Pending issues to solve before merging:
- [x] `en` generation is fine. only `data-current-lesson` attr values are different but consistent 
- [x] generation for languages other than `en`
- [x] check sitemap.xml
- [x] don't copy over `_code` and `_assets` dirs: `master` branch doesn't
- [x] test `grunt develop`, i.e. `local.yml` config
