### PR TITLE
Suggest Clumsy as a testing option on Windows

### DIFF
--- a/src/_langs/en/fundamentals/tools/test/mobilenetwork.markdown
+++ b/src/_langs/en/fundamentals/tools/test/mobilenetwork.markdown
@@ -40,7 +40,8 @@ you'll be able to test for different network types.
 
 <img src="imgs/network-panel.png" alt="OS X Network Panel" />
 
-On Windows, options also include [Fiddler](http://www.telerik.com/fiddler) and
+On Windows, options also include [Fiddler](http://www.telerik.com/fiddler), 
+[clumsy](https://jagt.github.io/clumsy/), and
 [Charles](http://www.charlesproxy.com/), an HTTP proxy which can throttle your
 connection speeds. These are the network characteristics you can simulate:
 


### PR DESCRIPTION
The open-source utility is very easy to use and has a lower barrier to entry than the other tools. It is very close to Network Link Conditioner on OS X.

Disclaimer: I have no relation to Clumsy or their website other than having used it as a user for eight months.