### PR TITLE
setting-up changes for Sass install instructions

### DIFF
--- a/src/_langs/en/fundamentals/getting-started/web-starter-kit/setting-up.markdown
+++ b/src/_langs/en/fundamentals/getting-started/web-starter-kit/setting-up.markdown
@@ -53,8 +53,8 @@ Essentially it’s CSS with some extra features. For example, it adds support fo
 variables and functions, which help you structure your CSS in a modular and 
 reusable fashion.
 
-Once you have installed the NPM packages, along with Gulp (globally), Sass will 
-be available to you.
+Once you have installed the NPM packages, along with Gulp (globally), install Sass
+by running the following Ruby command to make Sass available to you: `gem install sass`
 
 ## Set Up Your Web Starter Kit Project
 


### PR DESCRIPTION
I may be mistaken here, but going through a clean install of NPM, Gulp, and then Sass led me to not have Sass available (this was on Mac OSX Mavericks), Feb 2 2015. 

The existing doc seems to imply that Sass will magically appear somehow when you set up npm and gulp, but no such thing happened and I got a lot of CSS-less websites when I ran `gulp serve`. 

I tried to get it via npm (found a few sass related things) but they didn't cut it.

Eventually I got it the official way via Ruby: `gem install sass`

Feel free to edit the wording of the edit.