### PR TITLE
Updated "view source" path to source file in github

### DIFF
--- a/src/_includes/beta.liquid
+++ b/src/_includes/beta.liquid
@@ -1,3 +1,3 @@
 <span id="beta" class="beta">
-  <a href="{{site.github.root}}/tree/master/src/{{page.path| uri_escape }}" target="_blank">{{"view_source" | localize_string}}</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="{{site.github.root}}/issues/new?title={{"[" | uri_escape }}{{page.langcode | upcase}}{{"] Feedback for: " | uri_escape }}{{page.url| uri_escape }}" target="_blank">{{"submit_feedback" | localize_string}}</a>
+  <a href="{{site.github.root}}/blob/master/src/_langs/{{page.path| uri_escape }}" target="_blank">{{"view_source" | localize_string}}</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="{{site.github.root}}/issues/new?title={{"[" | uri_escape }}{{page.langcode | upcase}}{{"] Feedback for: " | uri_escape }}{{page.url| uri_escape }}" target="_blank">{{"submit_feedback" | localize_string}}</a>
 </span>


### PR DESCRIPTION
Source for https://developers.google.com/web/fundamentals/ currently goes to 
```
https://github.com/Google/WebFundamentals/tree/master/src/site/_en/fundamentals/index.html
```
but should be   
```
https://github.com/Google/WebFundamentals/blob/master/src/_langs/en/fundamentals/index.html
```