### PR TITLE
Correct "The easiest way create command-line"

### DIFF
--- a/src/_langs/en/fundamentals/tools/setup/commandlinetools.markdown
+++ b/src/_langs/en/fundamentals/tools/setup/commandlinetools.markdown
@@ -29,7 +29,7 @@ notes:
 
 ## How to Set Them Up
 
-The easiest way create command-line shortcuts is to add aliases for common
+The easiest way to create command-line shortcuts is to add aliases for common
 commands to your bashrc file. On Mac or Linux:
 
 1. From the command line anywhere, type:


### PR DESCRIPTION
Correct "The easiest way create command-line", now "The easiest way to create command-line"