### PR TITLE
Strip html tag from css class

### DIFF
--- a/src/_includes/navigation.liquid
+++ b/src/_includes/navigation.liquid
@@ -44,7 +44,7 @@
     {% assign stripTitle = section.title | strip_html %}
     {% assign currentPath = section.path | append:"index.html" %}
     {% if section.in_header != false  %}
-    <li class="main-nav__item main-nav__item--{% if section.en_title %}{{ section.en_title | downcase | replace:' ','-' }}{% else %}{{ section.title | downcase | replace:' ','-' }}{% endif %} {% if section.home %} main-nav__item--home {% endif %}{% unless section.home %}{% if page.url contains section.path %} main-nav__item--current{% endif %}{% endunless %}{% if section.home and page.url == currentPath %} main-nav__item--current{% endif %} {% if section.hasSubNav %} main-nav__item--has-child{% endif %}">
+    <li class="main-nav__item main-nav__item--{% if section.en_title %}{{ section.en_title | downcase | replace:' ','-' }}{% else %}{{ section.title | strip_html | downcase | replace:' ','-' }}{% endif %} {% if section.home %} main-nav__item--home {% endif %}{% unless section.home %}{% if page.url contains section.path %} main-nav__item--current{% endif %}{% endunless %}{% if section.home and page.url == currentPath %} main-nav__item--current{% endif %} {% if section.hasSubNav %} main-nav__item--has-child{% endif %}">
       <a class="main-nav__link main-nav__link--parent" href="{% if section.external != true %}{{site.baseurl}}{% endif %}{{ section.path }}?hl={{page.langcode}}" title="Go to {{ stripTitle }}">
 
         {{ section.title }}
@@ -68,9 +68,9 @@
                   <li class="main-nav__item--child nav-theme--{{subsection.id}}">
                     <a class="main-nav__link main-nav__link--child themed--hover" title="Go to {{ subsection.title }}" href="{{site.baseurl}}{{ subsection.path }}?hl={{page.langcode}}">
                       {% if subsection.id %}
-                      <span class="main-nav__guide-icon icon-circle--nav themed--background"><i class="icon icon-{{subsection.id}}"></i></span> 
+                      <span class="main-nav__guide-icon icon-circle--nav themed--background"><i class="icon icon-{{subsection.id}}"></i></span>
                       {% endif %}
-                      {{ subsection.title }} 
+                      {{ subsection.title }}
                       <i class="main-nav__icon icon icon-chevron-right"></i>
                     </a>
                   </li>


### PR DESCRIPTION
I happened to inspect the HTML source code in firefox and found that Google web fundamentals sites are using BEM for css naming. One thing I noticed was a weird css class `main-nav__item main-nav__item--<strong>fundamentals</strong> main-nav__item--home main-nav__item--current`, you can check the screenshot below:

![screen shot 2015-04-22 at 06 05 41](https://cloud.githubusercontent.com/assets/1091472/7263639/facb2e9a-e8b5-11e4-8272-89a5aef8abb3.png)

I checked the [navigation.liquid](https://github.com/google/WebFundamentals/blob/master/src/_includes/navigation.liquid) files, it has [codes as below](https://github.com/google/WebFundamentals/blob/master/src/_includes/navigation.liquid#L47):

```
<li class="main-nav__item main-nav__item--{% if section.en_title %}{{ section.en_title | downcase | replace:' ','-' }}{% else %}{{ section.title | downcase | replace:' ','-' }}{% endif %} 
```

So I think we need to strip the html tag, and here's a screenshot after what I've done:

![screen shot 2015-04-22 at 09 44 21](https://cloud.githubusercontent.com/assets/1091472/7266030/172997a0-e8d6-11e4-9151-0b71c878b9b3.png)
