### PR TITLE
Remove double file ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.pyc
 *.swp
 .idea
-*.DS_Store
 build
 .DS_Store
 .sass-cache/


### PR DESCRIPTION
The asterisk DS_Store ignore is not required. The regular one will also match files in sub directories.