### PR TITLE
Use /bin/bash over /bin/sh

### DIFF
--- a/tools/docker.sh
+++ b/tools/docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 image=${WF_DOCKER_IMAGE:-google/webfundamentals}
 cmd=$1


### PR DESCRIPTION
The docker tool script currently doesn't run in a fresh Ubuntu 15.04 build from what I can tell. The script runs against *dash* in this circumstance which fails, switching to directly use bash fixes this.