### PR TITLE
Remove Install NodeJS step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Mac
     * `easy_install pygments`
 1. Install [RubyGems](https://rubygems.org/) dependencies ([Jekyll](http://jekyllrb.com/) and [Kramdown](http://kramdown.gettalong.org/))
     * `rvm . do bundle install`
-1. Install [Node.js](http://nodejs.org/)
 1. Install the [Grunt CLI](http://gruntjs.com/)
     * `npm install -g grunt-cli`
 1. Install [npm](https://www.npmjs.org) dependencies


### PR DESCRIPTION
NodeJS is installed with nvm in step 3. This is a redundant instruction.