### PR TITLE
Forms: Add sign-{in,up} autocomplete attributes.

### DIFF
--- a/src/_langs/en/fundamentals/input/form/label-and-name-inputs.markdown
+++ b/src/_langs/en/fundamentals/input/form/label-and-name-inputs.markdown
@@ -239,6 +239,29 @@ The `autocomplete` attributes can be accompanied with a section name, such as **
         </ul>
       </td>
     </tr>
+    <tr>
+      <td data-th="Content type">Usernames</td>
+      <td data-th="name attribute">
+        <code>username</code>
+      </td>
+      <td data-th="autocomplete attribute">
+        <ul>
+          <li><code>username</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td data-th="Content type">Passwords</td>
+      <td data-th="name attribute">
+        <code>password</code>
+      </td>
+      <td data-th="autocomplete attribute">
+        <ul>
+          <li><code>current-password</code> (for sign-in forms)</li>
+          <li><code>new-password</code> (for sign-up and password-change forms)</li>
+        </ul>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Adding the following autocomplete attribute values which we use in Chrome's password manager:

* `username` (https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username)
* `current-password` (https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password)
* `new-password` (https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password)