### PR TITLE
fixes tool icon by setting the correct class in sass

### DIFF
--- a/src/_sass/_components/_icons.scss
+++ b/src/_sass/_components/_icons.scss
@@ -175,7 +175,7 @@ $icon-tick: "\e01d";
 }
 
 $icon-tools: "\e01e";
-.icon-tools:before {
+.icon-wf-tools:before {
   content:"\e01e";
 }
 


### PR DESCRIPTION
https://developers.google.com/web/fundamentals/ changes class in sass to match front end class name of icon-wf-tools to display tool icon