### PR TITLE
fixes tool icon by setting the correct class in sass and matching the…

### DIFF
--- a/src/_sass/_components/_icons.scss
+++ b/src/_sass/_components/_icons.scss
@@ -174,8 +174,8 @@ $icon-tick: "\e01d";
   content:"\e01d";
 }
 
-$icon-tools: "\e01e";
-.icon-tools:before {
+$icon-wf-tools: "\e01e";
+.icon-wf-tools:before {
   content:"\e01e";
 }
 


### PR DESCRIPTION
https://developers.google.com/web/fundamentals/ changes class in sass to match front end class name of icon-wf-tools displaying the tool icon