### PR TITLE
Add stricter syntax to run on Linux

### DIFF
--- a/src/_sass/_utils.scss
+++ b/src/_sass/_utils.scss
@@ -151,19 +151,19 @@
 
 
   @mixin keyframes($animation-name){
-    @-webkit-keyframes $animation-name{
+    @-webkit-keyframes #{$animation-name}{
       @content;
     }
 
-    @-moz-keyframes $animation-name{
+    @-moz-keyframes #{$animation-name}{
       @content;
     }
 
-    @-ms-keyframes $animation-name{
+    @-ms-keyframes #{$animation-name}{
       @content;
     }
 
-    @keyframes $animation-name{
+    @keyframes #{$animation-name}{
       @content;
     }
   }

--- a/src/_sass/styles.scss
+++ b/src/_sass/styles.scss
@@ -30,7 +30,7 @@
 }
 
 // We'll need Roboto after MD redesign, and for showcase/tools section.
-@import url(//fonts.googleapis.com/css?family=Roboto:400,300,500);
+@import url('//fonts.googleapis.com/css?family=Roboto:400,300,500');
 
 @import "_utils";
 @import "_normalize";


### PR DESCRIPTION
Here are two places where the syntax was changed so that the sass task will run on Linux. I have confirmed that this does not break on Mac. To demonstrate I've pulled the following fragments out of DevTools when running from Docker. Note that these are the same as what is output without the changes.

@import url(//fonts.googleapis.com/css?family=Roboto:400,300,500);

@-webkit-keyframes showNav {
  0% {
    opacity: 0
  }

  100% {
    opacity: 1
  }
}

@-moz-keyframes showNav {
  0% {
    opacity: 0
  }

  100% {
    opacity: 1
  }
}

@-ms-keyframes showNav {
  0% {
    opacity: 0
  }

  100% {
    opacity: 1
  }
}

@keyframes showNav {
  0% {
    opacity: 0
  }

  100% {
    opacity: 1
  }
}