### PR TITLE
Add link to description of Web App reqs to 'stickyness' intro.

### DIFF
--- a/src/_langs/en/fundamentals/device-access/stickyness/index.markdown
+++ b/src/_langs/en/fundamentals/device-access/stickyness/index.markdown
@@ -5,7 +5,7 @@ description: "Almost all of the major browser vendors allow users to pin or inst
 introduction: "Almost all of the major browser vendors allow users to pin or install your web app. So-called “stickyness” is a common argument for native apps but can be achieved with just a few tweaks to your markup."
 article:
   written_on: 2014-09-22
-  updated_on: 2014-12-17
+  updated_on: 2015-06-12
   order: 1
 id: stickyness
 collection: device-access
@@ -15,16 +15,20 @@ priority: 1
 ---
 {% wrap content%}
 
-To the user, the “add to homescreen” functionality works similarly to a 
+To the user, the “add to home screen” functionality works similarly to a 
 supercharged bookmark: but without giving the browser instructions on how to 
 display your app, mobile browsers will take the favicon or screenshot of your 
 page for the bookmark and show the browser’s default UI when the user launches
-your web app from the homescreen. Let’s look at the ways you can improve the
+your web app from the home screen. Let’s look at the ways you can improve the
 built-in behaviour.
 
-Chrome and Safari support a very similar syntax by using `<meta>` and `<link>`
-tags in the `<head>` of your page, and keep the overall feature relatively
-lightweight.
+Browser support varies. To use "add to home screen" in Chrome you'll need to 
+[meet a few requirements]({{site.baseurl}}/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android)
+other than adding a WebApp manifest.
+
+For inclusion of the manifest, Chrome and Safari support a very similar syntax
+by using `<meta>` and `<link>` tags in the `<head>` of your page, and keep the
+overall feature relatively lightweight.
 
 Internet Explorer 10 introduced "Pinned Sites", a concept that offers 
 additional functionality such as changing the presentation of the icon and 


### PR DESCRIPTION
Ideally, the 'Add to Home Screen' section would be enhanced to include instructions for how trigger adding to the home screen across platforms. Since the only method thus far implemented appears to be Chrome's method, I've instead added a link to Paul Kinlan's install banners article. 

Notice that I've linked to the version in /web/updates and not the one in HTML5Rocks.