### PR TITLE
Helper script to publish WF samples to GitHub pages

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -20,6 +20,10 @@ handlers:
   static_dir: build/imgs
   expiration: 1d
 
+- url: /web/fundamentals/resources/samples
+  static_dir: build/_langs/en/fundamentals/resources/samples
+  expiration: 1d
+
 - url: /web/(.*\.(png|gif|jpg|svg|xml|mp4))
   static_files: build/_langs/en/\1
   expiration: 1d

--- a/tools/publishSamples.sh
+++ b/tools/publishSamples.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Script to sync the GitHub web fundamentals samples contents onto GitHub Pages.
+# Run from the location of a clone of the fundamentals repo.
+
+WEBDIR="$(pwd)"
+GHDIR="/tmp/WF-gh-pages"
+
+# - are we in the web dir?
+if [ ! -f "Gruntfile.js" ]; then
+  echo "Please make sure you're in the git checkout location."
+  exit
+fi
+
+echo "----- Getting latest sources from GitHub"
+
+# Git pull
+git checkout master
+git pull https://github.com/Google/WebFundamentals master
+LASTCOMMIT=$(git rev-list HEAD --max-count=1)
+
+if [ $? -ne 0 ]; then
+  echo "Updating the git repo failed, please check for errors."
+  exit
+fi
+
+echo "----- Building WebFundamentals (en only)"
+
+# Make devsite
+grunt devsite --lang=en
+
+if [ $? -ne 0 ]; then
+  echo "Build failed - please fix before continuing"
+  exit
+fi
+
+echo "----- Syncing samples to Github Pages clone"
+
+pushd .
+
+if [[ ! -d $GHDIR ]]; then
+  mkdir $GHDIR
+  git clone -b gh-pages https://github.com/googlesamples/web-fundamentals.git $GHDIR
+fi
+cd $GHDIR
+git pull
+cp -r $WEBDIR/appengine/build/_langs/en/fundamentals/resources/samples/* $GHDIR/samples
+git commit -a -m "Updating Web Fundamentals Samples to $LASTCOMMIT"
+git push origin gh-pages
+
+popd
+
+echo "----- Samples pushed live.
+  To clean up after yourself, run:
+  rm -rf $GHDIR"

--- a/tools/publishSamples.sh
+++ b/tools/publishSamples.sh
@@ -3,31 +3,39 @@
 # Run from the location of a clone of the fundamentals repo.
 
 WEBDIR="$(pwd)"
-GHDIR="/tmp/WF-gh-pages"
+GHSAMPLESDIR="/tmp/WF-gh-pages"
 
-# - are we in the web dir?
+# Verifies we are in the WF Root Dir by checking for the existance of 
+# Gruntfile.js
 if [ ! -f "Gruntfile.js" ]; then
+  # TODO: this should be more robust, right now any Gruntfile.js will work.
   echo "Please make sure you're in the git checkout location."
   exit
 fi
+
 
 echo "----- Getting latest sources from GitHub"
 
 # Git pull
 git checkout master
 git pull https://github.com/Google/WebFundamentals master
-LASTCOMMIT=$(git rev-list HEAD --max-count=1)
 
+# Checks the exit code, if it is Not Equal to zero, fail.
 if [ $? -ne 0 ]; then
   echo "Updating the git repo failed, please check for errors."
   exit
 fi
+
+# Save the last commit ID for use later
+LASTCOMMIT=$(git rev-list HEAD --max-count=1)
+
 
 echo "----- Building WebFundamentals (en only)"
 
 # Make devsite
 grunt devsite --lang=en
 
+# Checks the exit code, if it is Not Equal to zero, fail.
 if [ $? -ne 0 ]; then
   echo "Build failed - please fix before continuing"
   exit
@@ -37,18 +45,26 @@ echo "----- Syncing samples to Github Pages clone"
 
 pushd .
 
-if [[ ! -d $GHDIR ]]; then
-  mkdir $GHDIR
-  git clone -b gh-pages https://github.com/googlesamples/web-fundamentals.git $GHDIR
+# Checks if the $GHSAMPLEDIR exists, if not, create and clone repo there
+if [[ ! -d $GHSAMPLESDIR ]]; then
+  mkdir $GHSAMPLESDIR
+  git clone -b gh-pages https://github.com/googlesamples/web-fundamentals.git $GHSAMPLESDIR
 fi
-cd $GHDIR
+
+cd $GHSAMPLESDIR
+# Make sure we've got the latest bits
 git pull
-cp -r $WEBDIR/appengine/build/_langs/en/fundamentals/resources/samples/* $GHDIR/samples
+
+# Copy the samples from the build directory to the $GHSAMPLEDIR
+cp -r $WEBDIR/appengine/build/_langs/en/fundamentals/resources/samples/* $GHSAMPLESDIR/samples
+
+# Commit and push changes up to repo
 git commit -a -m "Updating Web Fundamentals Samples to $LASTCOMMIT"
 git push origin gh-pages
 
 popd
 
 echo "----- Samples pushed live.
+  View the samples at: https://googlesamples.github.io/web-fundamentals/samples/
   To clean up after yourself, run:
-  rm -rf $GHDIR"
+  rm -rf $GHSAMPLESDIR"


### PR DESCRIPTION
@gauntface @PaulKinlan - can I get a quick code review/LGTM on this.

Background - I almost always forget to publish the samples after pushing to DevSite, this separates that logic out and makes it easier to do it in a quick, one off way. The code is essentially the same (copied/pasted) from the DevSite script with a few minor modification.

I've left the original logic in the DevSite script so it can still be used there if necessary, but this makes it easier for one of pushes and doesn't require G3/DevSite/etc.