### PR TITLE
Properly format markdown links.

### DIFF
--- a/src/_langs/en/shows/lazyweb/2015/episode-10.markdown
+++ b/src/_langs/en/shows/lazyweb/2015/episode-10.markdown
@@ -26,35 +26,35 @@ tools, and Ilya Grigorik explains how old best practices are obsolete in HTTP/2.
 
 
 ## THE NEXT BILLIONS
-https://www.youtube.com/watch?v=BHO70H9tvqo
+<https://www.youtube.com/watch?v=BHO70H9tvqo>
 
 ## A11Y CHEAT SHEET
-http://bitsofco.de/2015/the-accessibility-cheatsheet/
-http://www.w3.org/WAI/intro/wcag.php
-http://leaverou.github.io/contrast-ratio/
+<http://bitsofco.de/2015/the-accessibility-cheatsheet/>
+<http://www.w3.org/WAI/intro/wcag.php>
+<http://leaverou.github.io/contrast-ratio/>
 
 ## NEXT GEN WEB
-https://www.youtube.com/watch?v=iZZdhTUP5qg
+<https://www.youtube.com/watch?v=iZZdhTUP5qg>
 
 ## NEW PERF TOOLS
-https://www.youtube.com/watch?v=WBmttwfA_k8
+<https://www.youtube.com/watch?v=WBmttwfA_k8>
 
 ## HTTP2 EXPLAINED
-https://docs.google.com/presentation/d/1r7QXGYOLCh4fcUq0jDdDwKJWNqWK1o4xMtYpKZCJYjM/present?slide=id.gfd0e3427_015
+<https://docs.google.com/presentation/d/1r7QXGYOLCh4fcUq0jDdDwKJWNqWK1o4xMtYpKZCJYjM/present?slide=id.gfd0e3427_015>
 
 ## Demos
 
 Box Physics by fluuuid
-http://fluuu.id/experiment.html#box-physics
+<http://fluuu.id/experiment.html#box-physics>
 
 QuadTree approximation of an ellipse By Marian-COJOC-ro
-http://codepen.io/marian-cojoc-ro/full/rVmEdj
+<http://codepen.io/marian-cojoc-ro/full/rVmEdj>
 
 YEAH BUT CAN YOUR BROWSER DO THIS??? By Alex Bergin
-http://codepen.io/abergin/full/KpqNwo
+<http://codepen.io/abergin/full/KpqNwo>
 
 Stewart toroid: 6 hexagonal prisms no JS By Ana Tudor
-http://codepen.io/thebabydino/full/QbvoqL
+<http://codepen.io/thebabydino/full/QbvoqL>
 
 ## Thanks
 


### PR DESCRIPTION
The current one's don't work on the live site.