### PR TITLE
RSS + ATOM feeds for UPDATES

### DIFF
--- a/src/_includes/head.liquid
+++ b/src/_includes/head.liquid
@@ -42,7 +42,10 @@
 {% endfor %}
 
 {% if page.nofeed != true %}
-	{% if page.feedPath %}
+  {% if page.filepath contains "updates"%}
+<link rel="alternate" type="application/rss+xml" title="Updates RSS" href="{{site.baseurl}}/updates/rss.xml">
+<link rel="alternate" type="application/atom+xml" title="Updates RSS" href="{{site.baseurl}}/updates/atom.xml">	
+  {% elsif page.feedPath %}
 <link rel="alternate" type="application/rss+xml" title="{{page.feedName}}" href="{{site.baseurl}}/{{page.feedPath}}">
 	{% elsif include.feedURL %}
 <link rel="alternate" type="application/rss+xml" title="{{include.feedName}}" href="{{include.feedURL}}">

--- a/src/_layouts/atom.liquid
+++ b/src/_layouts/atom.liquid
@@ -1,0 +1,39 @@
+---
+layout: null
+spec: https://tools.ietf.org/html/rfc4287 
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  {% assign pages = page.items | deepsort: 'article', 'updated_on' | reverse %}
+  {% assign tld = "https://developers.google.com/web" %}
+  <title>{{ page.title | xml_escape }} - Google Developers</title>
+  <subtitle>{{ page.description | xml_escape }}</subtitle>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ tld | append: '/' | append: page.section | append: "/" }}</id>
+  {% if page.image %}<logo>{{ tld | append: "/" | append: page.section | append: page.image }}</logo>{% endif %}
+  {% if page.icon %}<icon>{{ '/favicon.ico' | prepend: tld }}</icon>{% endif %}
+  <link href="{{ tld | append: '/' | append: page.section | append: '/atom.xml' }}" rel="self" />
+  <link href="{{ tld | append: '/' | append: page.section }}/" />
+  {% for post in pages limit:10 %}
+  <entry>
+    <title>{{ post.title | xml_escape }}</title>
+    <link href="{{ post.url | prepend: tld | canonicalize }}" />
+    <id>{{ post.url | prepend: tld | canonicalize }}</id>
+    <published>{{ post.article.written_on | date: "%Y-%m-%dT%H:%M:%SZ" }}</published>
+    {% if post.article.updated_on %}<updated>{{ post.article.updated_on | date: "%Y-%m-%dT%H:%M:%SZ" }}</updated>{% endif %}
+    <content type="html">
+      <![CDATA[
+        <img src="https://ga-beacon.appspot.com/UA-52746336-1/feed{{ post.url }}?pixel">
+        {{ post.content }}
+      ]]>
+    </content>
+    {% if post.tags %}{% for tag in post.tags %}
+    <category term="{{tag}}" label="{{tag}}" />{% endfor %}{% endif %}
+    {% if post.authors %}<author>
+      {% for author in post.authors %}{% assign contributor = site.data["contributors"][author] %}
+      <name>{{contributor.name.given}} {{contributor.name.family}}</name>
+      {% endfor %}
+    </author>{% endif %}
+  </entry>
+  {% endfor %}
+</feed>

--- a/src/_layouts/rss.liquid
+++ b/src/_layouts/rss.liquid
@@ -1,0 +1,42 @@
+---
+layout: null
+spec: http://cyber.law.harvard.edu/rss/rss.html
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  {% assign pages = page.items | deepsort: 'article', 'updated_on' | reverse %}
+  {% assign tld = "https://developers.google.com/web" %}
+  <channel>
+    <title>{{ page.title | xml_escape }}</title>
+    <link>{{ tld | append: "/" | append: page.section | append: "/" }}</link>
+    <description>{{ page.description | xml_escape }}</description>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% if page.image %}<image>
+      <url>{{ tld | append: "/" | append: page.section | append: page.image }}</url>
+      <title>{{ page.title | xml_escape }}</title>
+      <link>{{ tld | append: "/" | append: page.section | append: "/" }}</link>
+    </image>{% endif %}
+    <atom:link href="{{tld | append: '/' | append: page.section | append: '/rss.xml'}}" rel="self" type="application/rss+xml" />
+    {% for post in pages limit:10 %}
+    <item>
+      <title>{{ post.title | xml_escape }}</title>
+      <pubDate>{{ post.article.updated_on | date: "%a, %d %b %Y" }} 00:00:01 GMT</pubDate>
+      <link>{{ post.url | prepend: tld | canonicalize }}</link>
+      <guid isPermaLink="true">{{ post.url | prepend: tld | canonicalize }}</guid>
+      <description>
+        <![CDATA[
+          <img src="https://ga-beacon.appspot.com/UA-52746336-1/feed{{ post.url }}?pixel">
+          {{ post.content }}
+        ]]>
+      </description>
+      {% if post.tags %}{% for tag in post.tags %}<category>{{ tag | xml_escape }}</category>
+      {% endfor %}{% endif %}
+      {% if post.authors %}{% for author in post.authors %}{% assign contributor = site.data["contributors"][author] %}
+      <author>{{contributor.name.given}} {{contributor.name.family}}</author>
+      {% endfor %}{% endif %}
+    </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/src/_plugins/updates_generator.rb
+++ b/src/_plugins/updates_generator.rb
@@ -72,8 +72,25 @@ module Jekyll
       # generate main page
       generatePaginatedPage(site, site.source, File.join('updates'), "all", "all", true)
 
-      # generate feed
-      site.pages << UpdatesFeedPage.new(site, site.source, File.join('_langs', site.data['curr_lang'], 'updates'), updates)
+      # generate feed from a cleaned list of updates
+      cur_dir = File.join('_langs', site.data['curr_lang'], 'updates')
+      posts = []
+      updates.each do |post|
+        if post['published'] == false || post['rss'] == false
+          # NoOp - ignore these posts
+        else
+          posts.push(post)
+        end
+      end
+      # Generate the ATOM feed
+      site.pages << UpdatesFeedPage.new(site, site.source, cur_dir, 'atom.liquid', 'atom.xml', posts)
+
+      # Generate the RSS feed
+      site.pages << UpdatesFeedPage.new(site, site.source, cur_dir, 'rss.liquid', 'rss.xml', posts)
+
+      # Generate the old feed for backwards compatibility
+      site.pages << UpdatesFeedPage.new(site, site.source, cur_dir, 'feed.liquid', 'feed.xml', posts)
+
 
       site.data['tags_updates'] = tags
     end
@@ -186,21 +203,19 @@ module Jekyll
   class UpdatesFeedPage < Page
     attr_accessor :tag
 
-    def initialize(site, base, dir, updates)
+    def initialize(site, base, dir, template, fname, updates)
         @site = site
         @base = base
         @dir  = dir
-        @name = "feed.xml"
+        @name = fname
+        @template = template
         @tag = tag
         @updates = updates
         @langcode = site.data['curr_lang']
 
         self.process(@name)
 
-        self.read_yaml(File.join(base, '_layouts'), 'feed.liquid')
-
-        title_text = "All updates tagged '%s'"
-        description_text = "Tag page for updates tagged %s."
+        self.read_yaml(File.join(base, '_layouts'), @template)
 
         self.data['title'] = 'Web Updates'
         self.data['description'] = 'The latest and freshest updates from the Web teams at Google. Chrome, Tooling and more.'


### PR DESCRIPTION
This is a temporary fix to provide full content RSS & ATOM feeds for /updates/ and it *only* affects **updates**.

Essential changes:
* adds `atom.liquid` and `rss.liquid` 
* validated output of atom and rss feeds against the W3C feed validator
* adding the feed links to the document head is a hack: in `_includes/head.liquid`, it checks if the file path contains `updates` if it does, it uses the new feed links.
* modified the `UpdatesFeedPage` in `update_generator.rb` to take a `template` and `fname`, then when it is called, it generates the feed page based on the `template`, and outputs it to `fname`.
* For *backwards* compat it still generates the old rss feed, but that should get yanked.