### PR TITLE
Updates: Fix for super annoying FF bug that made images blow up (max-…

### DIFF
--- a/src/_sass/_pages/_updates.scss
+++ b/src/_sass/_pages/_updates.scss
@@ -55,6 +55,11 @@
 
   .update-content {
 
+    max-width: 100%;
+    @include medium {
+      width: -moz-calc(100% - 150px);
+    }
+
     img.block {
       display: block;
       margin-top: 1em;
@@ -78,6 +83,10 @@
     hr + h4,
     hr + h5 {
       padding-top: 0.3em;
+    }
+    
+    p, li {
+        max-width: 100%;
     }
 
   }


### PR DESCRIPTION
Turns out Firefox has a nasty issue with max-width inside tables and display: flex containers. It's a Firefox bug: https://webcompat.com/issues/1461

However, this workaround, while ugly, makes it work acceptable for the time being in the Updates section.