### PR TITLE
fixed featured images and missing descriptions for two tips

### DIFF
--- a/src/_langs/en/updates/2015-08-10-easily-duplicate-dom-nodes.markdown
+++ b/src/_langs/en/updates/2015-08-10-easily-duplicate-dom-nodes.markdown
@@ -6,14 +6,16 @@ title: Easily duplicate DOM nodes
 date: 2015-08-10
 article:
   written_on: 2015-08-10
-  updated_on: 2015-08-10
+  updated_on: 2015-08-20
 authors:
 - umarhansa
 collection: updates
 type: tip
 category: tools
 product: chrome-devtools
-featured-image: /web/updates/images/2015-08-10-duplicate-dom-nodes/gplus-8f4a2ba4.png
+description: You can easily change the DOM without having to edit the HTML as a giant
+  string.
+featured-image: /web/updates/images/2015-08-10-duplicate-dom-nodes/duplicate-dom.gif
 source_name: DevTips
 source_url: https://umaar.com/dev-tips/58-duplicate-dom/
 teaserblocks:

--- a/src/_langs/en/updates/2015-08-10-edit-html-in-the-console-panel.markdown
+++ b/src/_langs/en/updates/2015-08-10-edit-html-in-the-console-panel.markdown
@@ -6,14 +6,16 @@ title: Edit HTML in the Console Panel
 date: 2015-08-10
 article:
   written_on: 2015-08-10
-  updated_on: 2015-08-10
+  updated_on: 2015-08-20
 authors:
 - umarhansa
 collection: updates
 type: tip
 category: tools
 product: chrome-devtools
-featured-image: /web/updates/images/2015-08-10-edit-html-in-the-console-panel-of-devtools/gplus-8f4a2ba4.png
+description: The DOM node context menu, which you may recognize from the elements
+  panel, is also present in the console panel.
+featured-image: /web/updates/images/2015-08-10-edit-html-in-the-console-panel-of-devtools/console-edit-html.gif
 source_name: DevTips
 source_url: https://umaar.com/dev-tips/60-console-edit-html/
 teaserblocks:


### PR DESCRIPTION
This is just a quick fix for missing feature images in the two new DevTools tips. No content changes, the description is pulled from the first sentence of the actual tip.