### PR TITLE
Fix the link to the Bluetooth logs-gathering instructions.

### DIFF
--- a/src/_langs/en/updates/2015-07-22-interact-with-ble-devices-on-the-web.markdown
+++ b/src/_langs/en/updates/2015-07-22-interact-with-ble-devices-on-the-web.markdown
@@ -254,7 +254,7 @@ be done in two ways:
 - Enter `remove 01:23:45:67:89:01` in the Bluetooth Console where
   `01:23:45:67:89:01` is the Bluetooth address of the first device.
 
-I would recommend you check out the official [Bluetooth debug page](https://sites.google.com/a/chromium.org/dev/developers/how-tos/get-bluetooth-logs) as debugging Bluetooth can be hard sometimes. 
+I would recommend you check out the official [Bluetooth debug page](https://sites.google.com/a/chromium.org/dev/developers/how-tos/file-web-bluetooth-bugs) as debugging Bluetooth can be hard sometimes.
 
 ## What's next
 


### PR DESCRIPTION
I moved it after Francois added the link. Sorry.

@petele @beaufortfrancois 