### PR TITLE
Adds jeffposnick's homepage; cleans up link title

### DIFF
--- a/src/content/_contributors.yaml
+++ b/src/content/_contributors.yaml
@@ -572,10 +572,12 @@ jeffposnick:
   country: USA
   role:
     - author
-  homepage:
+  homepage: https://twitter.com/jeffposnick
   google: 117780118136555864520
   twitter: jeffposnick
   email: jeffy@google.com
+  description:
+    en: "Web DevRel @ Google"
 
 glenshires:
   name:

--- a/src/jekyll/_includes/page-structure/author.liquid
+++ b/src/jekyll/_includes/page-structure/author.liquid
@@ -14,7 +14,7 @@
 
       <div class="wf-author__info">
         <div class="wf-author__name">
-          {% if include.linkauthor and author.homepage %}<a href="{{author.homepage}}" target="_blank" title="{{contributor.name.given}} {{contributor.name.family}}">{% endif %}
+          {% if include.linkauthor and author.homepage %}<a href="{{author.homepage}}" target="_blank" title="{{author.name.given}} {{author.name.family}}'s Homepage">{% endif %}
           {{author.name.given}} {{author.name.family}}
           {% if include.linkauthor %}</a>{% endif %}
         </div>


### PR DESCRIPTION
R: @petele @gauntface

This adds some more metadata for my `_contributors.yaml` entry, and fixes up the `title` attribute that's used for the link.