### PR TITLE
Moves fonts from template to jekyll

### DIFF
--- a/appengine-config/wrapper.tpl
+++ b/appengine-config/wrapper.tpl
@@ -13,8 +13,6 @@
 
     <!-- This is mdl version 1.0.5 -->
     <script src="/web/scripts/material-design-lite/dist/material.js"></script>
-    <link href='https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:400,300,500,700,400italic,700italic' rel='stylesheet' type='text/css'>
-
     {% comment %}
       This helper script checks if a G+ comment block should be loaded and loads it if needed.
     {% endcomment %}

--- a/src/jekyll/_includes/page-structure/close-page.liquid
+++ b/src/jekyll/_includes/page-structure/close-page.liquid
@@ -50,3 +50,4 @@
 
 </main>
 </div>
+<link href='https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:400,300,500,700,400italic,700italic' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
If it's in the template we need to go to DevSite to change it, if it's in Jekyll we can change it more easily.

cc @gauntface 