### PR TITLE
Switch the featured case study to SW in Production

### DIFF
--- a/src/content/en/showcase/index.markdown
+++ b/src/content/en/showcase/index.markdown
@@ -31,7 +31,7 @@ description: "Showcase is a page highlighting some of the great web apps availab
 
 {% assign caseStudyDir = page.context.subdirectories[0] %}
 {% assign caseStudies = caseStudyDir.pages %}
-{% assign caseStudy = caseStudies[0] %}
+{% assign caseStudy = caseStudies[1] %}
 
 {% if caseStudy %}
 <div class="wf-showcase__featured-casestudy">


### PR DESCRIPTION
R: @gauntface @PaulKinlan all

Swaps out CDS 2014 case study for the I/O 2015 as featured on the landing page.

![image](https://cloud.githubusercontent.com/assets/1749548/10516712/9940faa4-7327-11e5-90a2-8ad7f6c9eff2.png)
