### PR TITLE
Adding hl=en to the page URLs and making language selection full heig…

### DIFF
--- a/src/jekyll/_includes/page-structure/out-of-date.liquid
+++ b/src/jekyll/_includes/page-structure/out-of-date.liquid
@@ -1,6 +1,6 @@
 {% if page.outOfDate %}
 <div class="wf-translation-warning">
   <p class="mdl-typography--caption wf-translation-warning__title">Out of Date!</p>
-  <p class="mdl-typography--caption-color-contrast wf-translation-warning__description">This article's translation is out of date with the <a href="{{page.raw_canonical_url}}">original version</a>.</p>
+  <p class="mdl-typography--caption-color-contrast wf-translation-warning__description">This article's translation is out of date with the <a href="{{page.primary_lang_canonical_url}}">original version</a>.</p>
 </div>
 {% endif%}

--- a/src/jekyll/_plugins/pages/WFPage.rb
+++ b/src/jekyll/_plugins/pages/WFPage.rb
@@ -373,6 +373,13 @@ module Jekyll
       site.config['WFAbsoluteUrl'] + getFilteredUrl()
     end
 
+    # WARNING: This should be used with caution. It will force the user to
+    # visit the english version regardless of available translations
+    def primary_lang_canonical_url
+      fullUrl = raw_canonical_url() + "?hl=" + site.config['primary_lang']
+      fullUrl
+    end
+
     def canonical_url
       fullUrl = raw_canonical_url() + "?hl=" + @langcode || site.config['primary_lang']
       fullUrl
@@ -458,7 +465,8 @@ module Jekyll
   # Returns <Hash>
   def to_liquid(attrs = ATTRIBUTES_FOR_LIQUID)
     super(attrs + %w[ raw_canonical_url ] + %w[ canonical_url ] +
-      %w[ relative_url ] + %w[ context ] + %w[ nextPage ] +
+      %w[ relative_url ] + %w[ primary_lang_canonical_url ] +
+      %w[ context ] + %w[ nextPage ] +
       %w[ previousPage ] + %w[ outOfDate ])
   end
   end

--- a/src/jekyll/_plugins/pages/WFPage.rb
+++ b/src/jekyll/_plugins/pages/WFPage.rb
@@ -374,22 +374,12 @@ module Jekyll
     end
 
     def canonical_url
-      if @langcode == site.config['primary_lang']
-        fullUrl = raw_canonical_url()
-      else
-        fullUrl = raw_canonical_url() + "?hl=" + @langcode || site.config['primary_lang']
-      end
-
+      fullUrl = raw_canonical_url() + "?hl=" + @langcode || site.config['primary_lang']
       fullUrl
     end
 
     def relative_url
-      if @langcode == site.config['primary_lang']
-        relativeUrl = getFilteredUrl()
-      else
-        relativeUrl = getFilteredUrl() + "?hl=" + @langcode || site.config['primary_lang']
-      end
-
+      relativeUrl = getFilteredUrl() + "?hl=" + @langcode || site.config['primary_lang']
       relativeUrl
     end
 

--- a/src/static/styles/partials/components/_wf-translation.scss
+++ b/src/static/styles/partials/components/_wf-translation.scss
@@ -19,7 +19,9 @@
   content: none;
 }
 
+// Display block to anchor fills height of the list item
 .wf-translation-link__link {
+  display: block;
   text-decoration: none;
 }
 


### PR DESCRIPTION
…ht of list items

@petele @PaulKinlan this is to address: #2143

This does mean all links will have a language code. The canonical URLs will not change with this (i.e. canonical urls in head of pages will not have a hl query param).

Is there any negative side effects to this change?