### PR TITLE
queryCommandSupported() now returns true for cut or copy

### DIFF
--- a/src/content/en/updates/posts/2015/04/cut-and-copy-commands.markdown
+++ b/src/content/en/updates/posts/2015/04/cut-and-copy-commands.markdown
@@ -144,9 +144,7 @@ Safari does not support these commands.
 
 # Known Bugs
 
-* Calling queryCommandSupported() for cut or copy [always returns false until after a user interaction](//crbug.com/476508).
-  This prevents you from disabling your UI for browsers which don't actually
-  support it.
+* ~~Calling queryCommandSupported() for cut or copy [always returns false until after a user interaction](//crbug.com/476508). This prevents you from disabling your UI for browsers which don't actually support it.~~ Fixed on Chrome 48.
 * [Calling queryCommandSupported() from devtools will always return
   false](//crbug.com/475868).
 * At the moment [cut only works when you programmatically select


### PR DESCRIPTION
https://code.google.com/p/chromium/issues/detail?id=476508