### PR TITLE
Keep GUID static

### DIFF
--- a/src/content/en/shows/http203/podcast/feed.xml
+++ b/src/content/en/shows/http203/podcast/feed.xml
@@ -21,8 +21,8 @@
     <itunes:subtitle>Paul and Jake talk about CORS, Layout, and which of them has the evolutionary advantage.</itunes:subtitle>
     <itunes:summary><![CDATA[Why does nobody seem to include CORS headers on their files? And can Paul answer Jake's dreaded CORS pre-flight quiz?]]></itunes:summary>
     <itunes:image href="https://developers.google.com/web/shows/http203/podcast/http203-podcast-art.jpg" />
-    <enclosure url="https://developers.google.com/web/shows/http203/podcast/episode-2.mp3" length="29803546" type="audio/mpeg"/>
-    <guid>https://storage.googleapis.com/http-203-podcast/episode-2.mp3</guid>
+    <enclosure url="https://storage.googleapis.com/http-203-podcast/episode-2.mp3" length="29803546" type="audio/mpeg"/>
+    <guid isPermaLink="false">https://developers.google.com/web/shows/http203/podcast/episode-2.mp3</guid>
     <pubDate>Wed, Oct 7 2015 16:00:00 +0100</pubDate>
     <itunes:duration>00:30:37</itunes:duration>
   </item>
@@ -33,8 +33,8 @@
     <itunes:subtitle>Paul and Jake talk about making burgers and maintainable code.</itunes:subtitle>
     <itunes:summary>How can writing code be like making a burger? Turns out, by the power of weird segues, it can!</itunes:summary>
     <itunes:image href="https://developers.google.com/web/shows/http203/podcast/http203-podcast-art.jpg" />
-    <enclosure url="https://developers.google.com/web/shows/http203/podcast/episode-1.mp3" length="31517231" type="audio/mpeg"/>
-    <guid>https://storage.googleapis.com/http-203-podcast/episode-1.mp3</guid>
+    <enclosure url="https://storage.googleapis.com/http-203-podcast/episode-1.mp3" length="31517231" type="audio/mpeg"/>
+    <guid isPermaLink="false">https://developers.google.com/web/shows/http203/podcast/episode-1.mp3</guid>
     <pubDate>Mon Sep 21 2015 15:23:55 GMT+0100 (BST)</pubDate>
     <itunes:duration>00:30:13</itunes:duration>
   </item>

--- a/src/content/en/shows/http203/podcast/feed.xml
+++ b/src/content/en/shows/http203/podcast/feed.xml
@@ -35,7 +35,7 @@
     <itunes:image href="https://developers.google.com/web/shows/http203/podcast/http203-podcast-art.jpg" />
     <enclosure url="https://storage.googleapis.com/http-203-podcast/episode-1.mp3" length="31517231" type="audio/mpeg"/>
     <guid isPermaLink="false">https://developers.google.com/web/shows/http203/podcast/episode-1.mp3</guid>
-    <pubDate>Mon Sep 21 2015 15:23:55 GMT+0100 (BST)</pubDate>
+    <pubDate>Mon, Sep 21 2015 15:23:55 +0100</pubDate>
     <itunes:duration>00:30:13</itunes:duration>
   </item>
 


### PR DESCRIPTION
Feels like we should keep the GUID static, but update the enclosure url. What do you think @paullewis?