### PR TITLE
Fixed G+ comments URL

### DIFF
--- a/src/jekyll/_layouts/updates/post.liquid
+++ b/src/jekyll/_layouts/updates/post.liquid
@@ -9,7 +9,7 @@
 
 <div class="page-content">
   <div id="gplus-comment-container" class="update-post__gplus-comment-container">
-    <div id="gplus-comments" data-url="{{page.canonical_url}}"></div>
+    <div id="gplus-comments" data-url="{{page.raw_canonical_url}}"></div>
   </div>
 </div>
 


### PR DESCRIPTION
DO NOT MERGE YET.

@gauntface I'm not 100% sure this is THE solution but that simple fix wouldn't return the updates URL suffixed with "?hl=en" which causes all G+ comments to not show up anymore.

For info, I used to have 34 comments on the Web Bluetooth article. And they're not anymore :crying_cat_face: 

![screenshot 2015-10-23 at 2 14 36 pm](https://cloud.githubusercontent.com/assets/634478/10692254/83a0bcec-7990-11e5-8599-d2f66caf643d.png)

