### PR TITLE
Fixes #2257: instructions for removing Service Worker

### DIFF
--- a/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-4.markdown
+++ b/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-4.markdown
@@ -7,7 +7,6 @@ translation_priority: 1
 order: 4
 authors:
   - paulkinlan
-  - rupl
 ---
 
 

--- a/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-4.markdown
+++ b/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-4.markdown
@@ -7,23 +7,18 @@ translation_priority: 1
 order: 4
 authors:
   - paulkinlan
+  - rupl
 ---
 
 
-Turn up your speakers to full volume. Click the horn and it should make a sound.  
+Go back to the command line and switch from `master` to the `code-lab` branch:
 
-<img src="images/image01.png"  />  
+{% highlight bash %}
+git checkout -b code-lab
+{% endhighlight %}
 
-Now kill the server (ctrl-c in the command line).  This simulates the network 
-going offline. Then reload the site. The page should fully reload and you should 
-be able to still use the horn.
+This will remove all assets that were supplying offline functionality so you can add them back in by following the tutorial.
 
-<img src="images/image01.png" />  
-
-The reason why this works offline is the basis of this codelab: offline support 
-with service worker.
-
-We are now going to remove all offline support and you are going to learn how to 
-use Service Worker offline by adding it back into this application.
+Additionally, you will need to unregister the Service Worker. In Chrome you can do this by visiting `chrome://serviceworker-internals/` and clicking the **Unregister** button underneath the appropriate URL.
 
 


### PR DESCRIPTION
As described in #2257, the Airhorn tutorial skipped the part where the Service Worker is removed. This repurposes the duplicate Step 4, allowing the reader to remove it and then continue to Step 5 where they begin to create it from scratch.