### PR TITLE
Apple status bar style doesn't support hex color

### DIFF
--- a/src/content/en/fundamentals/design-and-ui/browser-customization/theme-color.markdown
+++ b/src/content/en/fundamentals/design-and-ui/browser-customization/theme-color.markdown
@@ -30,7 +30,8 @@ colors for elements of the browser, and even the platform using meta tags.
 <!-- Windows Phone -->
 <meta name="msapplication-navbutton-color" content="#4285f4">
 <!-- iOS Safari -->
-<meta name="apple-mobile-web-app-status-bar-style" content="#4285f4">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 {% endhighlight %}
 
 <img src="imgs/theme-color.png" alt="Theme colors styling the address bar in Chrome">


### PR DESCRIPTION
According to [Apple's documentation](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html) and some tests on the simulator the only options available are `default`, `black` and `black-translucent`.

Also, in order to Safari to use this meta information, the `apple-mobile-web-app-capable` needs to be set to `yes`.