### PR TITLE
Typo causes hyperlink to appear as text

### DIFF
--- a/src/content/en/fundamentals/performance/critical-rendering-path/constructing-the-object-model.markdown
+++ b/src/content/en/fundamentals/performance/critical-rendering-path/constructing-the-object-model.markdown
@@ -16,7 +16,7 @@ key-takeaways:
     - "Chrome DevTools Timeline allows us to capture and inspect the construction and processing costs of DOM and CSSOM."
 notes:
   devtools:
-    - "We'll assume that you have basic familiarity with Chrome DevTools - i.e. you know how to capture a network waterfall, or record a timeline. If you need a quick refresher, check out the <a href='/web/tools/chrome-devtools'>Chrome DevTools documentation</a>, or if you're new to DevTools, we recommend taking the Codeschool <a href='http://discover-devtools.codeschool.com/''>Discover DevTools</a> course."
+    - "We'll assume that you have basic familiarity with Chrome DevTools - i.e. you know how to capture a network waterfall, or record a timeline. If you need a quick refresher, check out the <a href='/web/tools/chrome-devtools'>Chrome DevTools documentation</a>, or if you're new to DevTools, we recommend taking the Codeschool <a href='http://discover-devtools.codeschool.com/'>Discover DevTools</a> course."
 ---
 
 <p class="intro">


### PR DESCRIPTION
Fix typo that causes hyperlink to appear as normal text as reported in #2277

**Page where the problem occurs :** https://developers.google.com//web/fundamentals/performance/critical-rendering-path/constructing-the-object-model?hl=en

**Screenshot :**
![screen shot 2015-11-10 at 13 59 23](https://cloud.githubusercontent.com/assets/3033040/11064163/52e507d0-87b3-11e5-885b-2545a3d40470.png)
 

**Change in File :** Removed extra  '  sign inside <a> tag.