### PR TITLE
Removed link to Mixture.io as reported in #2283

### DIFF
--- a/src/content/en/tools/setup/setup-buildtools.markdown
+++ b/src/content/en/tools/setup/setup-buildtools.markdown
@@ -76,10 +76,6 @@ will be less flexible.
       <td data-th="Gulp"><a href="http://alphapixels.com/prepros/">Prepros</a></td>
     </tr>
     <tr>
-      <td data-th="Supported Platforms">OS X / Windows</td>
-      <td data-th="Gulp"><a href="http://mixture.io/">Mixture</a></td>
-    </tr>
-    <tr>
       <td data-th="Supported Platforms">OS X</td>
       <td data-th="Gulp"><a href="https://incident57.com/codekit/">CodeKit</a></td>
     </tr>


### PR DESCRIPTION
As reported in #2283 Mixture.io is no longer available.

**From their site:**
*"The time has come for us to turn off the download and recommend that users investigate alternatives, we highly recommend you try Gulp or Grunt"*