### PR TITLE
Add CDS talk embed to DevTools homepage

### DIFF
--- a/src/content/en/tools/chrome-devtools/index.markdown
+++ b/src/content/en/tools/chrome-devtools/index.markdown
@@ -12,6 +12,7 @@ translation_priority: 1
     <div class="page-content">
         <h1><img src="{{site.WFBaseUrl}}/tools/chrome-devtools/images/chrome_devtools.svg" alt="Chrome DevTools Logo">Chrome DevTools</h1>
     </div>
+
     <div class="page-content mdl-grid">
       <div class="mdl-cell mdl-cell--6-col">
         <p>The Chrome DevTools are a set of web authoring and debugging tools built into Google Chrome. Use the DevTools to iterate, debug and profile your site.</p>
@@ -26,6 +27,13 @@ translation_priority: 1
           <li>Use <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> (<a href="/web/tools/chrome-devtools/iterate/inspect-styles/shortcuts">more shortcuts</a>)</li>
         </ul>
       </div>
+    </div>
+  </div>
+
+  <div class="wf-devtools-announcement">
+    <div class="page-content">
+      <h3>Rewatch the future of mobile-first authoring in DevTools.</h3>
+      {% ytvideo dJR-n8szgBc %}
     </div>
   </div>
 

--- a/src/static/styles/tools.scss
+++ b/src/static/styles/tools.scss
@@ -171,3 +171,7 @@ $color-accent: unquote("rgb(#{$palette-blue-300})");
     padding-bottom: 24px;
   }
 }
+
+.wf-devtools-announcement {
+  text-align: center;
+}


### PR DESCRIPTION
This PR adds an embed of the DevTools announcements talk to the top of the DevTools homepage.