### PR TITLE
Ignore .bundle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor/
 appengine/build
 tools/shows-gen/yt-api-key.json
 src/jekyll/_includes/svgs/
+.bundle/


### PR DESCRIPTION
I'm using a slightly different build / preview setup. Rather than RVM I'm just installing the bundle stuff via `bundler install --path vendor/bundle`, which automatically creates a config file at `.bundle/config`.