### PR TITLE
Fixes #2310 - all reference to material-branch -> master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Web Fundamentals <material-branch> [![Build Status](https://travis-ci.org/google/WebFundamentals.svg?branch=material-branch)](https://travis-ci.org/google/WebFundamentals)
+# Web Fundamentals <master> [![Build Status](https://travis-ci.org/google/WebFundamentals.svg?branch=master)](https://travis-ci.org/google/WebFundamentals)
 
-`material-branch` staging: https://material-dot-web-central.appspot.com/web/
+`master` staging: https://master-dot-web-central.appspot.com/web/
 <hr>
 
 Web Fundamentals is a technical documentation center for multi-device web

--- a/src/jekyll/_config/devsite.yml
+++ b/src/jekyll/_config/devsite.yml
@@ -2,4 +2,4 @@
 sample_link_base: "https://googlesamples.github.io/web-fundamentals/samples/"
 
 WFAbsoluteUrl: "https://developers.google.com"
-WFGithubBranch: material-branch
+WFGithubBranch: master

--- a/src/jekyll/_config/localhost.yml
+++ b/src/jekyll/_config/localhost.yml
@@ -1,2 +1,2 @@
 WFAbsoluteUrl: "http://localhost:7331"
-WFGithubBranch: material-branch
+WFGithubBranch: master

--- a/src/jekyll/_config/staging.yml
+++ b/src/jekyll/_config/staging.yml
@@ -1,4 +1,4 @@
-WFAbsoluteUrl: "https://material-dot-web-central.appspot.com"
-WFGithubBranch: material-branch
+WFAbsoluteUrl: "https://master-dot-web-central.appspot.com"
+WFGithubBranch: master
 
 sample_link_base: "https://googlesamples.github.io/web-fundamentals/samples/"

--- a/tools/auto-deploy.sh
+++ b/tools/auto-deploy.sh
@@ -6,7 +6,7 @@ CLOUDSDK_URL=https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz
 SDK_DIR=google-cloud-sdk
 
 # deploy only master builds
-if [ "$TRAVIS_BRANCH" != "material-branch" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$TRAVIS_BRANCH" != "master" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo "Skip deploy."
   exit 0
 fi
@@ -35,4 +35,4 @@ $SDK_DIR/bin/gcloud config set project web-central
 # We do this as the new behaviour doesn't work for our content :(
 $SDK_DIR/bin/gcloud config set app/use_appengine_api false
 
-$SDK_DIR/bin/gcloud --verbosity info preview app deploy --version material ./build/app.yaml
+$SDK_DIR/bin/gcloud --verbosity info preview app deploy --version master ./build/app.yaml

--- a/tools/bigrig/config.js
+++ b/tools/bigrig/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var rootUrl = 'https://material-dot-web-central.appspot.com/web/';
+var rootUrl = 'https://master-dot-web-central.appspot.com/web/';
 
 module.exports = {
   'tasks': {


### PR DESCRIPTION
### This will cause a regeneration of every file when we deploy it to production

* Staging service also updated as changes to master we getting by-passed (auto-deploy.sh)
* All WFGithubBranches are now mater
* View Source points to master
* Big Rig is also changed

R: @gauntface @petele 