### PR TITLE
Fix "Complete build chain" description

### DIFF
--- a/src/content/en/tools/polymer-starter-kit/index.markdown
+++ b/src/content/en/tools/polymer-starter-kit/index.markdown
@@ -39,7 +39,7 @@ feedURL: https://github.com/polymerelements/polymer-starter-kit/releases.atom
         {%include svgs/build-chain.svg %}
       </div>
       <h3 class="mdl-typography--title">Complete build chain</h3>
-      <p>Get started quickly with the complete set of the same paper and iron elements used by Google products.</p>
+      <p>Build your app using a suite of gulp tasks that leverage the full range of Polymer-related tools, such as vulcanize, crisper, and more.</p>
     </div>
     <div class="mdl-cell mdl-cell--4-col">
       <div class="icon">


### PR DESCRIPTION
As reported in #2317

Revert to previous description (commit here -> https://github.com/google/WebFundamentals/blob/07f2d0be9c71e0f9945d763b8adefbf678d8cc79/src/content/en/tools/polymer-starter-kit/index.markdown) that had the correct description.

I assume this is the correct description, please change if this is not the correct one.