### PR TITLE
Removed paired bluetooth device property in article

### DIFF
--- a/src/content/en/updates/posts/2015/07/interact-with-ble-devices-on-the-web.markdown
+++ b/src/content/en/updates/posts/2015/07/interact-with-ble-devices-on-the-web.markdown
@@ -4,7 +4,7 @@ title: "Interact with BLE devices on the Web"
 description: "A Web API has been added to Chrome that makes it possible for websites to discover and communicate with devices over the Bluetooth 4 wireless standard using GATT."
 featured_image: /web/updates/images/2015-07-22-interact-with-ble-devices-on-the-web/featured.png
 published_on: 2015-07-22
-updated_on: 2015-11-17
+updated_on: 2015-12-04
 authors:
   - beaufortfrancois
 tags:
@@ -138,8 +138,6 @@ navigator.bluetooth.requestDevice({ filters: [{ services: ['battery_service'] }]
 .then(device => {
   // Human-readable name of the device.
   console.log(device.name);
-  // Indicates whether or not the device is paired with the system.
-  console.log(device.paired);
   // Filtered UUIDs of GATT services the website origin has access to.
   console.log(device.uuids);
 


### PR DESCRIPTION
As suggested in https://github.com/WebBluetoothCG/web-bluetooth/issues/189, we want to get rid of the `paired` property.

R=@petele