### PR TITLE
[EN] Feedback for: /web/fundamentals/getting-started/your-first-offline-web-app/step-8/?hl=en

### DIFF
--- a/src/content/_contributors.yaml
+++ b/src/content/_contributors.yaml
@@ -595,6 +595,23 @@ jeffposnick:
   description:
     en: "Web DevRel @ Google"
 
+rupl:
+  name:
+    given: Chris
+    family: Ruppel
+  org:
+    name:
+    unit:
+  country: DE
+  role:
+    - author
+  homepage: https://chrisruppel.com
+  google: +ChrisRuppel
+  twitter: rupl
+  email: chris.ruppel@gmail.com
+  description:
+    en: "Chris is a frontend developer and web performance advocate."
+
 glenshires:
   name:
     given: Glen

--- a/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-4.markdown
+++ b/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-4.markdown
@@ -7,6 +7,7 @@ translation_priority: 1
 order: 4
 authors:
   - paulkinlan
+  - rupl
 ---
 
 
@@ -19,5 +20,3 @@ git checkout -b code-lab
 This will remove all assets that were supplying offline functionality so you can add them back in by following the tutorial.
 
 Additionally, you will need to unregister the Service Worker. In Chrome you can do this by visiting `chrome://serviceworker-internals/` and clicking the **Unregister** button underneath the appropriate URL.
-
-

--- a/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-8.markdown
+++ b/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-8.markdown
@@ -10,7 +10,13 @@ authors:
 ---
 
 Give a little honk of the air horn. You now have a web app that can work 
-offline.
+offline. If everything was set up correctly, you should see yoru debug
+statements appearing in the Log section of your Service Worker on the
+`chrome://serviceworker-internals/` page.
+
+Give it a functional test by stopping the Python server from Step 5. Hit **Ctrl C**
+to stop the server, then refresh the air horn page now that the server is no
+longer running. If the app still loads, the Service Worker is functioning properly.
 
 ### What we've covered
 

--- a/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-8.markdown
+++ b/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-8.markdown
@@ -7,6 +7,7 @@ translation_priority: 1
 order: 8
 authors:
   - paulkinlan
+  - rupl
 ---
 
 Give a little honk of the air horn. You now have a web app that can work 

--- a/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-8.markdown
+++ b/src/content/en/fundamentals/getting-started/your-first-offline-web-app/step-8.markdown
@@ -11,7 +11,7 @@ authors:
 ---
 
 Give a little honk of the air horn. You now have a web app that can work 
-offline. If everything was set up correctly, you should see yoru debug
+offline. If everything was set up correctly, you should see your debug
 statements appearing in the Log section of your Service Worker on the
 `chrome://serviceworker-internals/` page.
 


### PR DESCRIPTION
I found this tutorial to be very easy to follow and got to the end successfully. (Bonus, the `chrome://serviceworker-internals` page seems way more reliable in Chrome 46!)

However, only because I have read many recent articles on Service Workers did I know that the real test of the offline app comes by removing the network (or server) from the equation in order to see how the Service Worker performs on its own.

I added some instructions to Step 8 so that others will know how they can do a basic functional test of the Service Worker.

(I also figured out the contributors process and added myself for Steps 4 and 8, the pages I've helped with)