### PR TITLE
fix description of mixed-content

### DIFF
--- a/src/content/en/updates/posts/2015/10/devtools-digest-reordering-tabs.markdown
+++ b/src/content/en/updates/posts/2015/10/devtools-digest-reordering-tabs.markdown
@@ -41,7 +41,7 @@ But with the new “Framework Listeners” option in the Event Listener tab, Dev
   * [Custom Object Formatters](https://docs.google.com/document/d/1FTascZXT9cxfetuPRT2eXPQKXui4nWFivUnS_335T3U/preview?usp=sharing) allow transpiled languages such as CoffeeScript [to better format their objects](https://github.com/binaryage/cljs-devtools) in the DevTools Console.
   * The Timeline has a new better looking dialog during recording that shows you status, time and buffer usage at a glance. <br>![Timeline Hint](/web/updates/images/2015-10-05/timeline_hint.png)
   * Along the same lines, the Network Panel shows a helpful hint when empty now: ![Network Hint](/web/updates/images/2015-10-05/network_hint.png)
-  * You can now filter for mixed content in the Network Panel by using the filter input and set it to “mixed-content:true”
+  * You can now filter for mixed content in the Network Panel by using the filter input and set it to `mixed-content:displayed`
 
 - - -
 


### PR DESCRIPTION
@pbakaus looks like the only two valid options for `mixed-content` are `displayed` and `all`

<img width="472" alt="screen shot 2015-12-21 at 3 37 35 pm" src="https://cloud.githubusercontent.com/assets/4713486/11944155/c88fa0e8-a7f8-11e5-81e7-8a2491fda4f5.png">
