### PR TITLE
Adds the "Instant Loading with Service Workers" video embed

### DIFF
--- a/src/content/en/tools/service-worker-libraries/index.markdown
+++ b/src/content/en/tools/service-worker-libraries/index.markdown
@@ -148,4 +148,13 @@ feedURL: https://github.com/googlechrome/sw-toolbox/releases.atom
     <code>sw-toolbox</code> libraries were used together to power the
     <a href="https://events.google.com/io2015/">Google I/O 2015 web app</a>.
   </p>
+  <p>
+    <a href="https://twitter.com/jeffposnick">Jeff Posnick</a>'s
+    <a href="https://speakerdeck.com/jeffposnick/instant-loading-with-service-workers-chrome-dev-summit-15">presentation</a>
+    from the Chrome Dev Summit 2015, <em>Instant Loading with Service
+    Workers</em>, describes how to effectively use <code>sw-precache</code>
+    alongside <code>sw-toolbox</code> to build web apps that load quickly and
+    work offline.
+  </p>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/jCKZDTtUA2A" frameborder="0" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
R: @PaulKinlan @petele @gauntface 

I don't know whether there's any editorial policy around video embeds on WF, but it seemed like the CDS 2015 video/deck would be a good resource under "Learn More" on the service worker libraries page.