### PR TITLE
Fix typo in remote debugging markdown

### DIFF
--- a/src/content/en/tools/chrome-devtools/debug/remote-debugging/local-server.markdown
+++ b/src/content/en/tools/chrome-devtools/debug/remote-debugging/local-server.markdown
@@ -42,7 +42,7 @@ Need a simple way to run a web server locally?
 To start the server, run:
 
 {% highlight bash %}
-python -m SimpleHTTPServe
+python -m SimpleHTTPServer
 {% endhighlight %}
 
 ## Use port-forwarding when site and device on different networks


### PR DESCRIPTION
- SimpleHTTPServer was missing the last "r"