### PR TITLE
Fix layout-shifter.html at and slightly above 600px screen width

### DIFF
--- a/src/content/en/fundamentals/design-and-ui/responsive/patterns/_code/layouts-common.css
+++ b/src/content/en/fundamentals/design-and-ui/responsive/patterns/_code/layouts-common.css
@@ -1,3 +1,6 @@
+body {
+  margin: 0;
+}
 
 .container {
   margin: 0;


### PR DESCRIPTION
The responsive layout in *src/content/en/fundamentals/design-and-ui/responsive/patterns/_code/layout-shifter.html* was broken in Chrome 47 (and likely other browsers) when the screen width was exactly equal to 600px, and up to 615px. See screenshot below.

![layoutshifterissue](https://cloud.githubusercontent.com/assets/3519160/12400068/e14a19fc-bdeb-11e5-9823-6767f855458a.png)

This is because the browser sets a default margin of 8px on the `<body>` element. Combined with `.c1` having its `min-width` set to 150px, and `.c4` being set to 75% relative width, this caused `.c4` to go on the next row for the screen width range of 600 to 615px.