### PR TITLE
Firefox fullscreen API typo, fix for  #2441

### DIFF
--- a/src/content/en/updates/posts/2011/10/Let-Your-Content-Do-the-Talking-Fullscreen-API.markdown
+++ b/src/content/en/updates/posts/2011/10/Let-Your-Content-Do-the-Talking-Fullscreen-API.markdown
@@ -33,7 +33,7 @@ Then to exit fullscreen, the `document` exposes a method for that:
 
 {% highlight javascript %}
 document.webkitExitFullscreen();
-document.mozCancelFullscreen();
+document.mozCancelFullScreen();
 document.msExitFullscreen();
 document.exitFullscreen();
 {% endhighlight %}


### PR DESCRIPTION
In the page https://developers.google.com/web/updates/2011/10/Let-Your-Content-Do-the-Talking-Fullscreen-API, the `document.mozCancelFullscreen()` method is mentioned.

 However, according to [the mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#Getting_out_of_full_screen_mode), `document.mozCancelFullscreen()` takes a capital S

This is a fix for issue #2441