### PR TITLE
Adds line highlighting support to {% highlight blocks %}

### DIFF
--- a/src/jekyll/_includes/page-structure/close-page.liquid
+++ b/src/jekyll/_includes/page-structure/close-page.liquid
@@ -54,4 +54,4 @@
 
 </main>
 </div>
-<link href='https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:400,300,500,700,400italic,700italic' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Roboto:400,300,500,700,400italic,700italic' rel='stylesheet' type='text/css'>

--- a/src/static/styles/partials/_syntax.scss
+++ b/src/static/styles/partials/_syntax.scss
@@ -58,3 +58,4 @@ div.highlight > pre .vc, code .highlight .vc { color: #008080 } /* Name.Variable
 div.highlight > pre .vg, code .highlight .vg { color: #008080 } /* Name.Variable.Global */
 div.highlight > pre .vi, code .highlight .vi { color: #008080 } /* Name.Variable.Instance */
 div.highlight > pre .il, code .highlight .il { color: #009999 } /* Literal.Number.Integer.Long */
+div.highlight > pre .hll { font-weight: 700; } /* Highlighted lines should be bold */


### PR DESCRIPTION
In a `{% highlight %}` block, this will make certain lines bold so that they are more apparent.

Use: `{% highlight javascript hl_lines="3 4 5 6" %}` 