### PR TITLE
Fix list formatting that got removed during doc conversion

### DIFF
--- a/src/content/en/updates/posts/2016/02/css-variables-why-should-you-care.markdown
+++ b/src/content/en/updates/posts/2016/02/css-variables-why-should-you-care.markdown
@@ -45,9 +45,10 @@ the form of CSS custom properties.
 
 Custom properties add two new features to our CSS toolbox:
 
-The ability for an author to assign arbitrary values to a property with an
-author-chosen name. The `var()` function, which allows an author to use these
-values in other properties.
+- The ability for an author to assign arbitrary values to a property with an
+author-chosen name.
+- The `var()` function, which allows an author to use these values in other
+properties.
 
 Here’s a quick example to demonstrate
 


### PR DESCRIPTION
This turns the two items into a bulleted list. I think this part got lost when converting from docs. @petele PTAL