### PR TITLE
Fix duplicate shortcut.

### DIFF
--- a/src/content/en/tools/chrome-devtools/iterate/inspect-styles/shortcuts.markdown
+++ b/src/content/en/tools/chrome-devtools/iterate/inspect-styles/shortcuts.markdown
@@ -145,8 +145,8 @@ The following keyboard shortcuts are available in all DevTools panels:
     </tr>
     <tr>
       <td data-th="Global Shortcuts">Search by filename (except on Timeline)</td>
-      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd>, <kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd></td>
-      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd>, <kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd></td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd>, <kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">P</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd>, <kbd class="kbd">Cmd</kbd> + <kbd class="kbd">P</kbd></td>
     </tr>
     <tr>
       <td data-th="Global Shortcuts">Zoom in (while focused in DevTools)</td>


### PR DESCRIPTION
Fixes [crbug 486222](https://code.google.com/p/chromium/issues/detail?id=486222). Shows both possible shortcuts to find by a filename.

cc @kaycebasques or @pbakaus for review.