### PR TITLE
March 2016 update for increasing-engagement-with-app-install-banners-in-chrome-for-android

### DIFF
--- a/src/content/en/updates/posts/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android.markdown
+++ b/src/content/en/updates/posts/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android.markdown
@@ -3,7 +3,7 @@ layout: updates/post
 title: "Increasing Engagement with Web App Install Banners"
 description: "Web App Manifest ✔︎, Service Worker ✔.Get ready for Web App Install banners "
 published_on: 2015-03-12
-updated_on: 2015-03-12
+updated_on: 2016-03-01
 authors:
   - paulkinlan
 tags:
@@ -15,7 +15,7 @@ tags:
 We recently enhanced the "Add to Home Screen" function in Chrome which allows users
 to add your Web App to their home screen with the addition of the
 standards-based "[web app manifest](http://updates.html5rocks.com/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android)".
-The manifest gives you extra control over the Add to home screen experience,
+The manifest gives you extra control over the "Add to home screen" experience,
 allowing you to tell the browser what to launch, how to launch your app
 (fullscreen or in a browser window) and how it should appear to users on the
 home screen.
@@ -23,14 +23,14 @@ home screen.
 This improved things for users, but the ability to Add to home screen is still
 hidden behind a menu, meaning that your apps still aren't as discoverable as
 they should be.  To increase the chance of a user adding their app to the home
-screen a developer would have to try and guess if the site was already running
-as an Added to home screen app and if not, then tactically decide to give them an
-overlay that asked them to work around our poor UX.  This isn't great for users,
-and it is not good for developers.
+screen, a developer would have to try and guess if the site was already running
+as an "Added to home screen" app and if not, then tactically decide to give them an
+overlay that asked them to work around our poor UX.  This wasn't great for users,
+and it was not good for developers.
 
-In Chrome 42 (M42 - that is now in Beta) we are introducing "App Install
-Banners".  App Install Banners give you the ability to have your users quickly
-and seamlessly install your Web App as per the images below.
+In Chrome 42, we introduced "App Install Banners".  App Install Banners give you
+the ability to have your users quickly and seamlessly install your Web App as per
+the images below.
 
 <p style="text-align: center;">
   <img style="max-width: 100%; height: auto;" src="{{site.WFBaseUrl}}/updates/images/2015-03-03/add-to-home-screen.gif" alt="IO Site with install banner" />
@@ -41,20 +41,20 @@ to add it!".  The good news is if you currently meet the following criteria Chro
 manage the prompting of users:
 
 * You have a [web app manifest
-  file](/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android)
-  - The manifest defines how your app appears on the user's system and how it
-  should be launched - and you are required to have a \`short\_name\`, a `name` for
-  display in the Banner and *at least* an \`144x144\` png icon
-  - Your icon declaration's should include a mime type of `image/png`
+  file](/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android), which defines how your app appears on the user's system and how itshould be launched
+  - The manifest must have a \`short\_name\`, a `name` for
+  display in the banner,
+  - A start URL (e.g. `/` or `index.html`) which must be loadable,
+  - *At least* an \`144x144\` PNG icon
+  - Your icon declarations should include a mime type of `image/png`
 * You have a [service
-  worker](http://www.html5rocks.com/en/tutorials/service-worker/introduction/)
+  worker](/web/fundamentals/primers/service-worker/)
   registered on your site. We recommend a [simple custom offline page](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/custom-offline-page/service-worker.js)
   service worker
 * Your site is served over
   [HTTPS](https://docs.google.com/document/d/1oRXJUIttqQxuxmjj2tgYjj096IKw4Zcw6eAoIKWZ2oQ/edit)
-  (you need a service worker after all)
-* The user has visited your site twice over two separate days during the course
-  of two weeks.
+  (service worker requires HTTPS for security)
+* The user has visited your site at least twice, with at least five minutes between visits.
 
 **Note:** The criteria will change over time.  For more information read the [FAQ](#criteria-faq).
 
@@ -77,18 +77,14 @@ A sample manifest is [provided in our samples](https://github.com/GoogleChrome/s
 {% endhighlight %}
 
 If you are interested in the implementation, check out [crbug
-452825](https://code.google.com/p/chromium/issues/detail?id=452825).  If you are
-interested in tracking what other things we are working on in this space, follow
-the
-[Cr-UI-Browser-AppShortcuts](https://code.google.com/p/chromium/issues/list?q=label:Cr-UI-Browser-AppShortcuts)
-label.
+452825](https://bugs.chromium.org/p/chromium/issues/detail?id=452825).
 
 
 ## <span id="cancel">Cancelling the prompt</span>
 
 Chrome manages when to trigger the prompt and for some sites this might not be ideal.
 
-As of Chrome 43 (Beta as of May 2015), you can now [cancel the prompt](http://googlechrome.github.io/samples/app-install-banner/cancelable-banner/index.html) by intercepting the `onbeforinstallprompt` event and preventing default on the event.
+Since Chrome 43, you can now [cancel the prompt](http://googlechrome.github.io/samples/app-install-banner/cancelable-banner/index.html) by intercepting the `onbeforinstallprompt` event and preventing default on the event.
 
 {% highlight javascript %}
  window.addEventListener('beforeinstallprompt', function(e) {
@@ -98,15 +94,11 @@ As of Chrome 43 (Beta as of May 2015), you can now [cancel the prompt](http://go
 });
 {% endhighlight %}
 
-I would say though, I am not sure why you would do this... But you can.
-
-A more interesting future update will the ability to defer the prompt until later in the page lifecycle,
-i.e, just after a user has performed an action, or hit the bottom of the page (something to indicate
-that they are engaging with your site).
+One use case is to defer the prompt until later in the page lifecycle, for example just after a user has performed an action, or hit the bottom of the page (something to indicate that they are engaging with your site).
 
 ## <span id="action">Did a user install our web app</span>
 
-A recent addition in Chrome 43 (Beta as of May 2015) is the ability to discern if the user clicked "Yes" or "No" to the App install banner.
+Anoter addition in Chrome 43 was the ability to discern if the user clicked "Yes" or "No" to the App install banner.
 
 The `beforeinstallprompt` event will return a promise called `userChoice` that will resolve when the user
 actions the prompt.  The promise will return an object with a value of `dismissed` on the `outcome`
@@ -142,7 +134,7 @@ A new powerful feature for native app developers also landed in Chrome 44 Beta. 
   <img style="max-width: 100%; height: auto;" src="{{site.WFBaseUrl}}/updates/images/2015-03-03/inlineinstall.gif" alt="Native app install banner" />
 </p>
 
-The criteria is similar to the Web App install banner except for the need of a Serivce Worker:
+The criteria are similar to the Web App install banner except for the need of a Serivce Worker:
 
 * You have a [web app manifest
   file](http://updates.html5rocks.com/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android)
@@ -181,11 +173,10 @@ a good experience.  We will likely be changing all the heuristics over time.
 **Can I decide when to prompt the user****?**
 No, we are not letting developers actively prompt the user to "Add to Home Screen".
 
-**You said that I will only get the banner if I visit the site on two different
-days.  How on earth do I test it?**
-Yeah, we had the same problem when we were building this.  Enable
-chrome://flags/\#bypass-app-banner-engagement-checks and you will see it as long
-as you have a manifest (configured correctly) and are on HTTPS and have a
+**You said that I will only get the banner if I visit the site over a certain period
+of time.  How can I test this faster?**
+Enable chrome://flags/\#bypass-app-banner-engagement-checks and you will see the banner
+as long as you have a manifest (configured correctly) and are on HTTPS and have a
 service worker.
 
 **Why do I need a service worker?**
@@ -199,13 +190,13 @@ starting point](https://github.com/GoogleChrome/samples/blob/gh-pages/app-instal
 Yes.
 
 **How will the criteria for App Banner activation change over time?**
-We can't say specifics right now but as we better understand what makes an experience the user will want to install we will want to make sure the criteria are updated and also well understood for developers.
+We can't give specifics right now but as we better understand what makes an experience the user will want to install we will want to make sure the criteria are updated and also well understood for developers.
 
 **What could one of the critria for App Banner activation be?**
-Again, it is hard to say.  One example could be: supporting offline scenarios in your app could indicate that your app is more resiliant to connectivity issues and therefore would offer a better launchable experience.
+Again, it is hard to say.  One example could be: supporting offline scenarios in your app could indicate that your app is more resilient to connectivity issues and therefore would offer a better launchable experience.
 
 **Why do I need SSL?**
-Because you need a service worker, and we believe it is the best option for the future of the platform.
+Because you need a service worker, and since service workers can completly redirect any HTTP requests, we wouldn't want a man-in-the-middle attack to insert a different service worker than the one your app and user expects.
 
 **Are there any good examples of this in action?**
 Yes, Glad you asked:


### PR DESCRIPTION
- removed the Cr-UI-Browser-AppShortcuts paragraph because the link no longer points to any issues
- added having a `start_url` in the manifest as a requirement for the app install banner

The other changes are pretty straight-forward.