### PR TITLE
Fixing typo in Udacity course upsell.

### DIFF
--- a/src/content/en/fundamentals/performance/critical-rendering-path/index.markdown
+++ b/src/content/en/fundamentals/performance/critical-rendering-path/index.markdown
@@ -12,7 +12,7 @@ authors:
 udacity:
   id: ud884
   title: Website Performance Optimization
-  description: "Interested in taking a deep dive into the Critical Rendering Path? Check out or companion course and learn how the browser converts HTML, CSS, and JavaScript to pixels on the screen, how to use DevTools to measure performance, and how to optimize the Critical Rendering Path of your pages."
+  description: "Interested in taking a deep dive into the Critical Rendering Path? Check out our companion course and learn how the browser converts HTML, CSS, and JavaScript to pixels on the screen, how to use DevTools to measure performance, and how to optimize the Critical Rendering Path of your pages."
   image: images/crp-udacity.png
 ---
 

--- a/src/jekyll/_data/localized_strings/en.json
+++ b/src/jekyll/_data/localized_strings/en.json
@@ -60,7 +60,7 @@
   "@try_sample": {"description": "Link/Button - text used on a link or button to tell people to try the embedded sample."},
   "udacity_course": "Udacity course",
   "@udacity_course": {"description": "Link - Udacity is a brand name/company"},
-  "udacity_course_description_crp": "Interested in taking a deep dive into the Critical Rendering Path? Check out or companion course and learn how the browser converts HTML, CSS, and JavaScript to pixels on the screen, how to use DevTools to measure performance, and how to optimize the Critical Rendering Path of your pages.",
+  "udacity_course_description_crp": "Interested in taking a deep dive into the Critical Rendering Path? Check out our companion course and learn how the browser converts HTML, CSS, and JavaScript to pixels on the screen, how to use DevTools to measure performance, and how to optimize the Critical Rendering Path of your pages.",
   "udacity_description": "Get hands on with videos, quizzes, discussions and more.",
   "@udacity_description": {"description": "Text - A short description of the online training courses that Udacity offers"},
   "updated_on": "Updated on",


### PR DESCRIPTION
Fix for #2628 

Following the precedent set by other PRs for typo fixes, this change has been scoped just to the base EN strings (though this change can be updated to fix this string in other languages' files, also).