### PR TITLE
Content layout/typo optimizations

### DIFF
--- a/src/static/styles/partials/_base.scss
+++ b/src/static/styles/partials/_base.scss
@@ -75,7 +75,6 @@ img, video {
 
 li {
   line-height: $base-line;
-  margin-bottom: $base-line / 2;
 }
 
 pre {
@@ -203,8 +202,11 @@ blockquote {
 .intro {
   @include typo-subhead-2($usePreferred: false);
   font-weight: normal;
+  letter-spacing: 0;
   margin-bottom: $base-line;
   margin-top: $base-line * 2;
+  padding-bottom: $base-line / 2;
+  border-bottom: 1px solid #eee;
 }
 
 .mdl-cell > .intro {

--- a/src/static/styles/partials/components/_wf-border-container.scss
+++ b/src/static/styles/partials/components/_wf-border-container.scss
@@ -20,3 +20,8 @@
   border-bottom-width: 1px;
   border-bottom-color: $grey-border-color;
 }
+
+p.intro + .wf-border-container .wf-border-container__content {
+    border-top: 0;
+    padding-top: 0;
+}

--- a/src/static/styles/partials/components/_wf-highlight-list.scss
+++ b/src/static/styles/partials/components/_wf-highlight-list.scss
@@ -31,6 +31,7 @@ body[dir="rtl"] .wf-highlight-list {
 
 .wf-highlight-list__list li {
   @include typo-subhead();
+  letter-spacing: 0;
 
   margin-bottom: $base-line / 2;
 

--- a/src/static/styles/partials/components/_wf-nav-drawer.scss
+++ b/src/static/styles/partials/components/_wf-nav-drawer.scss
@@ -76,8 +76,13 @@
   padding: $nav-drawer-vertical-padding $nav-drawer-horizontal-padding;
 }
 
+// No horizontal padding for first indentation, bold title already covers it
+.wf-main-nav__list-level-2 .wf-main-nav__item {
+  padding: ($nav-drawer-vertical-padding / 2) 0;
+}
+
 // Less padding on the lower levels
-.wf-main-nav__list-level-2 .wf-main-nav__item, .wf-main-nav__list-level-3 .wf-main-nav__item {
+.wf-main-nav__list-level-3 .wf-main-nav__item {
   padding: ($nav-drawer-vertical-padding / 2) $nav-drawer-vertical-padding;
 }
 

--- a/src/static/styles/partials/components/_wf-subdirectory-list.scss
+++ b/src/static/styles/partials/components/_wf-subdirectory-list.scss
@@ -34,5 +34,5 @@
 }
 
 .wf-subdirectory-list__pages-list-item {
-
+  margin-bottom: 12px;
 }


### PR DESCRIPTION
These are small, but powerful optimizations that improve the look and feel across Web Fundamentals. Explanation:

 - no margin on li's: They usually don't have them, and this has been blowing up list-heavy pages like crazy.
 - no letter spacing: Removed letter spacing from three places where they've been used. Weirdly, they come from MDL, yet in the Material Design spec, I couldn't find any note about letter spacing. Letter spacing is arguably a bad idea, as it messes with the font and decreases readability, and should be reserved for big, bold headings.
- The indentation of the second level in the nav drawer was redundant, as the title above from the first level nav is already bold, suggesting it's the title. W3C Specs have been doing something similar, [looking quite nice](https://drafts.css-houdini.org/worklets/).  This gives us a few much needed horizontal pixels back.

**Before:**
![before](https://cloud.githubusercontent.com/assets/43004/13622053/c4e7a23e-e550-11e5-9cbc-04660666f94a.png)

**After**
![after](https://cloud.githubusercontent.com/assets/43004/13622054/c4e7c084-e550-11e5-86ce-1eb551c19f59.png)

@petele and @gauntface, would be awesome if you could take a look.