### PR TITLE
Use ... in window for feature detection

### DIFF
--- a/src/content/en/updates/posts/2016/03/device-orientation-changes.markdown
+++ b/src/content/en/updates/posts/2016/03/device-orientation-changes.markdown
@@ -60,9 +60,9 @@ determine whether they’re on a browser that supports the new
 `DeviceOrientationAbsoluteEvent` event:
 
 {% highlight javascript %}
-if (window.hasOwnProperty('ondeviceorientationabsolute')) {
+if ('ondeviceorientationabsolute' in window) {
   // We can listen for the new deviceorientationabsolute event.
-} else if (window.hasOwnProperty('ondeviceorientation')) {
+} else if ('ondeviceorientation' in window) {
   // We can still listen for deviceorientation events.
   // The `absolute` property of the event tells us whether
   // or not the degrees are absolute.


### PR DESCRIPTION
R: @petele @PaulKinlan @gauntface 

As per @webreflection's [recommendation](https://plus.google.com/108461295186427019068/posts/g71kJbSqxA7).

@timvolodine, you're using `window.hasOwnProperty()` in https://github.com/timvolodine/deviceorientation-test/blob/master/index.html#L218, as a heads-up.