### PR TITLE
design-and-ui/input/touch/active-states: Fix disable-user-select callout

### DIFF
--- a/src/content/en/fundamentals/design-and-ui/input/touch/active-states.markdown
+++ b/src/content/en/fundamentals/design-and-ui/input/touch/active-states.markdown
@@ -150,7 +150,7 @@ on a button for too long. You can prevent this from happening using the
 user-select: none;
 {% endhighlight %}
 
-{% include shared/remember.liquid title="Remember" list=page.remember.disable-user-select %}
+{% include shared/remember.liquid title="Remember" list=page.notes.disable-user-select %}
 
 ## Reference
 


### PR DESCRIPTION
This was rendering as an empty "Remember" callout box; see https://developers.google.com/web/fundamentals/design-and-ui/input/touch/active-states?hl=en#disable-user-select-on-ui-which-responds-to-touch