### PR TITLE
Fix shortcut for 'Delete individual words' for Windows

### DIFF
--- a/src/content/en/tools/chrome-devtools/iterate/inspect-styles/shortcuts.markdown
+++ b/src/content/en/tools/chrome-devtools/iterate/inspect-styles/shortcuts.markdown
@@ -383,7 +383,7 @@ Shortcuts available in the Styles sidebar:
     </tr>
     <tr>
       <td data-th="Sources Panel">Delete individual words</td>
-      <td data-th="Windows"><kbd class="kbd">Alt</kbd> + <kbd class="kbd">Delete</kbd></td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Delete</kbd></td>
       <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">Delete</kbd></td>
     </tr>
     <tr>
@@ -679,4 +679,3 @@ Here are some additional Chrome shortcuts which are useful for general use withi
     </tr>
   </tbody>
 </table>
-


### PR DESCRIPTION
The guide was showing `Alt` instead of `Ctrl`for Windows, which was not
correct. Fixes issue: https://github.com/google/WebFundamentals/issues/2879