### PR TITLE
Corrected a misplaced underscore

### DIFF
--- a/src/content/en/fundamentals/getting-started/push-notifications/step-09.markdown
+++ b/src/content/en/fundamentals/getting-started/push-notifications/step-09.markdown
@@ -22,7 +22,7 @@ notification.
 
 ## 1. Add showNotification() code
 
-Update _sw.js _to look like this, replacing the _TODO_ comment:
+Update _sw.js_ to look like this, replacing the _TODO_ comment:
 
 {% highlight javascript %}
 console.log('Started', self);


### PR DESCRIPTION
The misplaced underscore was causing a wrong placement of em tags in the resulting HTML page.