### PR TITLE
style guide link has been broken(404).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ the CLA.
 ## Writing Code ##
 
 If your contribution contains code, please make sure that it follows 
-[the style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+[the style guide](https://google.github.io/styleguide/javascriptguide.xml).
 Otherwise, we will have to ask you to make changes, and that's no fun for anyone.
 
 ## Formatting HTML ##


### PR DESCRIPTION
updated to 'https://google.github.io/styleguide/javascriptguide.xml' from 'http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml'