### PR TITLE
setup-preprocessors: Fix syntax highlighting

### DIFF
--- a/src/content/en/tools/setup/setup-preprocessors.markdown
+++ b/src/content/en/tools/setup/setup-preprocessors.markdown
@@ -55,7 +55,7 @@ Each CSS file contains an annotation that specifies the URL of its source map fi
 
 For instance, given an Sass source file named **styles.scss**:
 
-{% highlight css %}$textSize: 26px;
+{% highlight scss %}$textSize: 26px;
 $fontColor: red;
 $bgColor: whitesmoke;
 h2 {
@@ -77,7 +77,7 @@ Sass generates a CSS file, **styles.css**, with the sourceMappingURL annotation:
 
 Below is an example source map file:
 
-{% highlight css %}{
+{% highlight json %}{
   "version": "3",
   "mappings":"AAKA,EAAG;EACC,SAAS,EANF,IAAI;EAOX,KAAK"
   "sources": ["sass/styles.scss"],


### PR DESCRIPTION
Highlight SCSS as SCSS instead of CSS.
Highlight sourcemap as JSON.
(The `X-SourceMap` header example isn't CSS, but the `http` highlighter just treats it as an error, so I don't have a better alternative to offer there.)