### PR TITLE
Update _mdl-overrides.scss

### DIFF
--- a/src/static/styles/partials/_mdl-overrides.scss
+++ b/src/static/styles/partials/_mdl-overrides.scss
@@ -11,6 +11,8 @@
 // From Git Issue https://github.com/google/WebFundamentals/issues/2022
 .mdl-layout__content {
    will-change: transform;
+   // From Git issue https://github.com/google/WebFundamentals/issues/2949
+   transform: translateZ(0);
 }
 
 @media screen and (max-width: $grid-desktop-breakpoint) {


### PR DESCRIPTION
Workaround for Safari scrolling bug.

@petele @PaulKinlan Please test.