### PR TITLE
_base.scss: Remove erroneous quoting of generic font family

### DIFF
--- a/src/static/styles/partials/_base.scss
+++ b/src/static/styles/partials/_base.scss
@@ -89,7 +89,7 @@ pre, code {
   font-size: 10pt;
   line-height: $base-line;
   word-wrap: normal;
-  font-family: 'Roboto Mono', 'Inconsolata', 'monospace';
+  font-family: 'Roboto Mono', 'Inconsolata', monospace;
 }
 
 a {


### PR DESCRIPTION
Per https://drafts.csswg.org/css-fonts-3/#generic-family-value :
> `<generic-family>`
>
>> The following generic family keywords are defined: [...] and ‘monospace’. [...]
>> As keywords, **they must not be quoted**.

This was causing `<pre>`s and `<code>`s to render using serif fonts when the Web fonts were unavailable.