### PR TITLE
Fix top scrolling behaviour from mdl

### DIFF
--- a/src/static/styles/partials/_base.scss
+++ b/src/static/styles/partials/_base.scss
@@ -139,6 +139,10 @@ figcaption {
   }
 }
 
+.mdl-layout {
+  height: auto !important;
+}
+
 .mdl-layout__drawer-button.wf-header__menu-btn {
   display: inline-block;
 


### PR DESCRIPTION
Material Design Lite suffers from a bug where top scroll behaviour happens even if an anchor is defined in the URL. 
For instance, even though https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web#before-we-start should start at the "Before we start" section, it starts at the very top ;(

This patch adresses this issue. Note that it is not fixed in 1.1.3 version.
 
R= @petele @sgomes 