### PR TITLE
fixed SharedWorker link

### DIFF
--- a/src/content/en/updates/posts/2016/03/access-usb-devices-on-the-web.markdown
+++ b/src/content/en/updates/posts/2016/03/access-usb-devices-on-the-web.markdown
@@ -356,7 +356,7 @@ where `[yourdevicevendor]` is `2341` if your device is an Arduino for instance.
 
 ## What's next
 
-A second iteration of the WebUSB API will look at [Shared Worker](https://developer.mozilla.org/fr/docs/Web/API/SharedWorker)
+A second iteration of the WebUSB API will look at [Shared Worker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker)
 and [Service Worker](https://jakearchibald.github.io/isserviceworkerready/resources.html)
 support. Imagine for instance a security key website using the WebUSB API that
 would install a service worker to act as a middle man to authenticate users.


### PR DESCRIPTION
Fixed the SharedWorker link for article "Access USB devices on the Web".