### PR TITLE
PWA Landing page: Point Service Workers to primer

### DIFF
--- a/src/content/en/progressive-web-apps/_index.yaml
+++ b/src/content/en/progressive-web-apps/_index.yaml
@@ -99,7 +99,7 @@ landing_page:
         path: /web/updates/2015/11/app-shell
       - heading: Service Workers
         description: Service workers are a key technology needed for your app.
-        path: https://slightlyoff.github.io/ServiceWorker/spec/service_worker/
+        path: /web/fundamentals/primers/service-worker/
       - heading: Get support
         description: Get your questions answered on Stack Overflow
         path: http://stackoverflow.com/questions/tagged/progressive-web-apps


### PR DESCRIPTION
For the average developer, pointing to the primer is going to be a lot more illuminating than a spec page/repo imo :) cc @jpmedley 