### PR TITLE
Fix formatting

### DIFF
--- a/src/content/en/tools/chrome-devtools/profile/evaluate-performance/timeline-tool.markdown
+++ b/src/content/en/tools/chrome-devtools/profile/evaluate-performance/timeline-tool.markdown
@@ -67,6 +67,7 @@ The **Overview** pane consists of three graphs:
 
    Bars are color coded as follows:
    <!-- source: https://goo.gl/eANVFf -->
+   
    * HTML files are **<span style="color:hsl(214, 67%, 66%)">blue</span>**.
    * Scripts are **<span style="color:hsl(43, 83%, 64%)">yellow</span>**.
    * Stylesheets are **<span style="color:hsl(256, 67%, 70%)">purple</span>**.


### PR DESCRIPTION
Missing an empty line before the bulleted list—formats correctly on GitHub, but not on WF:

https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool?hl=en#overview-pane