### PR TITLE
Framebox emulate origin

### DIFF
--- a/devsiteHelper.py
+++ b/devsiteHelper.py
@@ -214,6 +214,8 @@ def renderDevSiteContent(content, lang='en'):
     else:
       replaceWith += 'height: 100px;'
     replaceWith += '" '
+    # The sandbox attr will emulate being on a different origin
+    replaceWith += '" sandbox="allow-forms allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts allow-top-navigation" '
     replaceWith += 'src="' + fbMemcacheKey + '"></iframe>'
     content = content.replace(framebox, replaceWith)
     memcache.set(fbMemcacheKey, fbContent)

--- a/devsiteHelper.py
+++ b/devsiteHelper.py
@@ -211,6 +211,8 @@ def renderDevSiteContent(content, lang='en'):
     replaceWith += 'style="width: 100%;'
     if fbHeight:
       replaceWith += 'height:' + fbHeight.group(1) + ';'
+    else:
+      replaceWith += 'height: 100px;'
     replaceWith += '" '
     replaceWith += 'src="' + fbMemcacheKey + '"></iframe>'
     content = content.replace(framebox, replaceWith)


### PR DESCRIPTION
I'm assuming our framebox code doesn't run on live, and its intent is to emulate live.

This builds on top of https://github.com/google/WebFundamentals/pull/3579 and adds a `sandbox` attribute. This means the iframe runs on a different origin, more like it does on live.