### PR TITLE
Add npm start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ access to the original Doc files. This will likely only work for Googlers.
 1. Check the latest changes into GitHub
 
 ## Start the development server
-1. Run `./start-appengine.sh`
+1. Run `npm start`
 
 ## Test your changes before submitting a PR
 Please run your changes through gulp test before submitting a PR. The test

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "run-sequence": "^1.2.2"
   },
   "scripts": {
-    "postinstall": "gulp build"
+    "postinstall": "gulp build",
+    "start": "./start-appengine.sh"
   }
 }


### PR DESCRIPTION
I always forget the command to run the local server. This adds it to npm scripts so folks can just run `npm start`.