### PR TITLE
Replaced incorrect `cardholderNumber` with `cardNumber` credit card f…

### DIFF
--- a/src/content/en/fundamentals/getting-started/primers/payment-request/index.md
+++ b/src/content/en/fundamentals/getting-started/primers/payment-request/index.md
@@ -234,7 +234,7 @@ Upon a user approval for a payment request, the [`show`](https://www.w3.org/TR/p
 For credit card payments, the response is standardized. For non-credit card payments (e.g., Android Pay), the response will be documented by the provider. A credit card response contains the following dictionary:  
 
 `cardholderName`  
-`cardholderNumber`  
+`cardNumber`  
 `expiryMonth`  
 `expiryYear`  
 `cardSecurityCode`  


### PR DESCRIPTION
…ield name.

PaymentResponse details for credit cards `cardholderNumber` field should be replaced with `cardNumber` reflecting Chrome 53 on Android implementation and the [W3C spec](https://www.w3.org/TR/payment-method-basic-card/#basiccardresponse).