### PR TITLE
Tweaks to capturing-images article

### DIFF
--- a/src/content/en/fundamentals/native-hardware/capturing-images/index.md
+++ b/src/content/en/fundamentals/native-hardware/capturing-images/index.md
@@ -201,3 +201,9 @@ settings.
 
 Warning: Asking for access to the camera on page load will result in most of 
 your users rejecting access to it.
+
+## Compatibility
+
+More information about mobile and desktop browser implementation:
+* [srcObject](https://www.chromestatus.com/feature/5989005896187904)
+* [navigator.mediaDevices.getUserMedia()](https://www.chromestatus.com/features/5755699816562688)

--- a/src/content/en/fundamentals/native-hardware/capturing-images/index.md
+++ b/src/content/en/fundamentals/native-hardware/capturing-images/index.md
@@ -17,21 +17,21 @@ experience, or it could be delegated to another app on the user's device.
 
 The easiest thing to do is simply ask the user for a pre-recorded
 file. Do this by creating a simple file input element and adding 
-an `accept` filter that indicates we can only accept audio files and ideally we 
+an `accept` filter that indicates we can only accept image files and ideally we 
 will get them directly from the camera.
 
-    <input type="file" accept="image/*" capture="camera">
+    <input type="file" accept="image/*" capture>
 
 This method works on all platforms. On desktop it will prompt the user to 
-upload an image file from the file system (ignoring `capture="camera"`). In Safari
-on iOS it will open up the camera app, allowing you to capture an image and 
-then send it back to the web page; on Android it will give the user the 
-choice of which app to use to capture the image before sending it back to the
+upload an image file from the file system. In Safari
+on iOS this method will open up the camera app, allowing you to capture an image 
+and then send it back to the web page; on Android this method will give the user 
+a choice of which app to use to capture the image before sending it back to the
 web page.
 
 The data can then be attached to a `<form>` or manipulated with JavaScript by 
 listening for an `onchange` event on the input element and then reading 
-the `files` property of the event object.
+the `files` property of the event `target`.
 
 ### Capture a single frame
 
@@ -53,51 +53,47 @@ Getting access to the image file is simple.
 Once you have access to the file you can do anything you want with it. For 
 example, you can:
 
-* Attach it directly to an `<canvas>` element so that you can manipulate it
+* Attach it directly to a `<canvas>` element so that you can manipulate it
 * Download it to the user's device
 * Upload it to a server by attaching to an `XMLHttpRequest` 
 
-Whilst using the input element method of getting access to image is 
-ubiquitous, it is the least appealing option because on desktop at least
-it doesn't access the user's Web Cam and it is not integrated directly into 
-your web page.
+Whilst using the input element method of getting access to images is 
+ubiquitous, it is the least appealing option because it is not integrated 
+directly into the web page, and on desktop can't access the user's webcam.
 
 ## Access the camera interactively
 
-Modern browsers can have a direct line to the camera allowing us to build
-experiences that are fully integrated with the web page and the user will never
+Modern browsers can get direct acccess to cameras, allowing us to build
+experiences that are fully integrated with the web page, so the user need never
 leave the browser.
 
-Warning: Direct access to the camera is a powerful feature, it requires consent from the user and your site needs to be on a secure origin (https)
+Warning: Direct access to the camera is a powerful feature, it requires consent 
+from the user and your site needs to be on a secure origin (HTTPS).
 
 ### Acquire access to the camera
 
-We can directly access the Microphone by using an API in the WebRTC 
-specification called `getUserMedia()`. `getUserMedia()` will prompt the user for 
+We can directly access a camera and microphone by using an API in the WebRTC 
+specification called `getUserMedia()`. This will prompt the user for 
 access to their connected microphones and cameras.
 
-If successful the API will return a `Stream` that will contain the data from
-the camera, and we can then either attach it to an `<video>` element and play it
-to show a real time preview or we could attach it to a `<canvas>` to get a
+If successful the API will return a `MediaStream` that contains data from
+the camera, and we can then either attach it to a `<video>` element and play it
+to show a real time preview, or attach it to a `<canvas>` to get a
 snapshot.
 
 To get data from the camera we just set `video: true` in the constraints 
-object that is passed to the `getUserMedia()` API
+object that is passed to the `getUserMedia()` API.
 
     <video id="player" controls autoplay></video>
     <script>  
       var player = document.getElementById('player');
 
       var handleSuccess = function(stream) {
-        if (window.URL) {
-          player.src = window.URL.createObjectURL(stream);
-        } else {
-          player.src = stream;
-        }
+        player.srcObject = stream;
       };
 
-      navigator.mediaDevices.getUserMedia({ audio: false, video: true })
-          .then(handleSuccess)
+      navigator.mediaDevices.getUserMedia({audio: false, video: true})
+          .then(handleSuccess);
     </script>
 
 By itself, this isn't that useful. All we can do is take the video data and play
@@ -107,16 +103,16 @@ it back.
 
 To access the raw data from the camera we have to take the stream created by
 `getUserMedia()` and process the data. Unlike `Web Audio`, there isn't a 
-dedicated stream processing API for video on the web so we have to resort to a
-tiny bit of hackery to capture a snapshot from the user's camera.
+dedicated stream processing API for video on the web so we have to resort to 
+a tiny bit of hackery to capture a snapshot from the user's camera.
 
 The process is as follows:
 
 1. Create a canvas object that will hold the frame from the camera
 2. Get access to the camera stream
 3. Attach it to a video element
-4. When you want to capture a precise frame, add the video element to a 
-   canvas object using `addImage()` and it will appear in the canvas element.
+4. When you want to capture a precise frame, add the data from the video element 
+   to a canvas object using `drawImage()`.
 
 Done.
 
@@ -130,20 +126,21 @@ Done.
 
       var handleSuccess = function(stream) {
         // Attach the video stream to the video element and autoplay.
-        player.src = URL.createObjectURL(stream);
+        player.srcObject = stream;
       };
 
       captureButton.addEventListener('click', function() {
         var context = snapshot.getContext('2d');
         // Draw the video frame to the canvas.
-        context.drawImage(player, 0, 0, snapshotCanvas.width, snapshotCanvas.height);
+        context.drawImage(player, 0, 0, snapshotCanvas.width, 
+            snapshotCanvas.height);
       });
 
-      navigator.mediaDevices.getUserMedia({ audio: false, video: true })
+      navigator.mediaDevices.getUserMedia({audio: false, video: true})
           .then(handleSuccess);
     </script>
 
-Once you have the data from the camera stored in the canvas you can do Many
+Once you have data from the camera stored in the canvas you can do many
 things with it. You could: 
 
 * Upload it straight to the server
@@ -152,12 +149,12 @@ things with it. You could:
 
 ### Stop streaming from the camera when not needed
 
-It is good practice to stop using the camera when you no longer need it. Not 
-only will it save battery and processing power, it will also give users 
-confidence in your application.
+It is good practice to stop using the camera when you no longer need it. 
+Not only will this save battery and processing power, it will also give 
+users confidence in your application.
 
-To stop access to the camera you can simply take the stream object that
-was returned from `getUserMedia`, find the video track and call `stop()` on it.
+To stop access to the camera you can simply call `stop()` on each video track 
+for the stream returned by `getUserMedia()`.
 
 <pre class="prettyprint">
 &lt;video id="player" controls autoplay>&lt;/video>
@@ -171,7 +168,7 @@ was returned from `getUserMedia`, find the video track and call `stop()` on it.
 
   var handleSuccess = function(stream) {
     // Attach the video stream to the video element and autoplay.
-    player.src = URL.createObjectURL(stream);
+    player.srcObject = stream;
     <strong>videoTracks = stream.getVideoTracks();</strong>
   };
 
@@ -180,10 +177,10 @@ was returned from `getUserMedia`, find the video track and call `stop()` on it.
     context.drawImage(player, 0, 0, snapshotCanvas.width, snapshotCanvas.height);
 
     <strong>// Stop all video streams.
-    videoTracks.forEach(function(track) { track.stop() });</strong>
+    videoTracks.forEach(function(track) {track.stop()});</strong>
   });
 
-  navigator.mediaDevices.getUserMedia({ audio: false, video: true })
+  navigator.mediaDevices.getUserMedia({audio: false, video: true})
       .then(handleSuccess);
 &lt;/script>
 </pre>
@@ -194,11 +191,13 @@ If the user has not previously granted your site access to the camera then
 the instant that you call `getUserMedia` the browser will prompt the user to
 grant your site permission to the camera. 
 
-User's hate getting prompted for access to powerful devices on their machine and
-they will frequently block the request, or they will ignore it if they don't 
-understand the context of which the prompt has been created. It is best practice
-to only ask to access the camera when first needed. Once the user has
-granted access they won't be asked again, however, if they reject access, 
-you can't get access again to ask the user for permission.
+Users hate getting prompted for access to powerful devices on their machine 
+and they will frequently block the request, or they will ignore it if they don't 
+understand the context for which the prompt has been created. It is best 
+practice to only ask to access the camera when first needed. Once the user has
+granted access they won't be asked again. However, if the user rejects access, 
+you can't get access again, unless they manually change camera permission 
+settings.
 
-Warning: Asking for access to the camera on page load will result in most of your users rejecting access to it.
+Warning: Asking for access to the camera on page load will result in most of 
+your users rejecting access to it.

--- a/src/content/en/fundamentals/native-hardware/capturing-images/index.md
+++ b/src/content/en/fundamentals/native-hardware/capturing-images/index.md
@@ -45,7 +45,7 @@ Getting access to the image file is simple.
 
       camera.addEventListener('change', function(e) {
         var file = e.target.files[0]; 
-        // Do something with the audio file.
+        // Do something with the image file.
         frame.src = URL.createObjectURL(file);
       });
     </script>
@@ -92,7 +92,7 @@ object that is passed to the `getUserMedia()` API.
         player.srcObject = stream;
       };
 
-      navigator.mediaDevices.getUserMedia({audio: false, video: true})
+      navigator.mediaDevices.getUserMedia({video: true})
           .then(handleSuccess);
     </script>
 
@@ -136,7 +136,7 @@ Done.
             snapshotCanvas.height);
       });
 
-      navigator.mediaDevices.getUserMedia({audio: false, video: true})
+      navigator.mediaDevices.getUserMedia({video: true})
           .then(handleSuccess);
     </script>
 
@@ -164,7 +164,7 @@ for the stream returned by `getUserMedia()`.
   var player = document.getElementById('player'); 
   var snapshotCanvas = document.getElementById('snapshot');
   var captureButton = document.getElementById('capture');
-  var videoTracks;
+  <strong>var videoTracks;</strong>
 
   var handleSuccess = function(stream) {
     // Attach the video stream to the video element and autoplay.
@@ -180,7 +180,7 @@ for the stream returned by `getUserMedia()`.
     videoTracks.forEach(function(track) {track.stop()});</strong>
   });
 
-  navigator.mediaDevices.getUserMedia({audio: false, video: true})
+  navigator.mediaDevices.getUserMedia({video: true})
       .then(handleSuccess);
 &lt;/script>
 </pre>

--- a/src/content/en/fundamentals/native-hardware/capturing-images/index.md
+++ b/src/content/en/fundamentals/native-hardware/capturing-images/index.md
@@ -207,3 +207,5 @@ your users rejecting access to it.
 More information about mobile and desktop browser implementation:
 * [srcObject](https://www.chromestatus.com/feature/5989005896187904)
 * [navigator.mediaDevices.getUserMedia()](https://www.chromestatus.com/features/5755699816562688)
+
+We also recommend using the [adapter.js](https://github.com/webrtc/adapter) shim to protect apps from WebRTC spec changes and prefix differences.


### PR DESCRIPTION
I've changed the examples to use `srcObject`, which is widely implemented now.

Couple of nitpicks: the `capture` attribute is boolean, and the stream object from a `getUserMediaI()` call is a `MediaStream`.

A few other suggestions below.

* Maybe add catch clauses?

* Might be worth mentioning the video option for the <input> method, i.e: 

`<input type="file" accept="video/*" capture />`

* Maybe mention that you can set the canvas dimensions from videoWidth and videoHeight — and it's probably better to set the canvas dimensions in JavaScript rather than in the HTML.

* With the examples (e.g. upload and image on a canvas to a server) I wonder if it would be worth adding how-to suggestions?

* You might want to link to samples:
  * [simpl.info/mediacapture](http://simpl.info/mediacapture/)
  * [webrtc.github.io/samples/src/content/getusermedia/gum](https://webrtc.github.io/samples/src/content/getusermedia/gum/)
  * [webrtc.github.io/samples/src/content/getusermedia/canvas](https://webrtc.github.io/samples/src/content/getusermedia/canvas/)