### PR TITLE
Changes Google+ IDs to strings

### DIFF
--- a/src/data/_contributors.yaml
+++ b/src/data/_contributors.yaml
@@ -5,12 +5,12 @@
 ##
 
 # EXAMPLE
-# givenfamily:  # REQUIRED - place JPG image file with same name in /images/contributors
+# givenfamily:  # REQUIRED - place a 512x512 px JPG image file with same name in /images/contributors
 #   name:
 #     given: First # Required
 #     family: Last # Required
 #   homepage: https://developers.google.com/web/ # Optional
-#   google: +PeteLePage                          # Optional - id or +Name
+#   google: "123456789012345678901"              # Optional - id (must be quoted) or +Name
 #   twitter: petele                              # Recommended - handle only (no @)
 #   github: petele                               # Recommended - handle only
 #   lanyrd: petele                               # Optional - handle only

--- a/src/data/_contributors.yaml
+++ b/src/data/_contributors.yaml
@@ -51,7 +51,7 @@ jakearchibald:
   role:
     - author
   homepage: http://jakearchibald.com/
-  google: 116237864387312784020
+  google: "116237864387312784020"
   twitter: jaffathecake
   email: jakearchibald@google.com
   lanyrd: jaffathecake
@@ -148,7 +148,7 @@ aliceboxhall:
   country: USA
   role:
     - author
-  google: 111975973972817482025
+  google: "111975973972817482025"
   twitter: sundress
   email: aboxhall@google.com
 
@@ -195,7 +195,7 @@ samchen:
   role:
     - translator
   homepage: 'http://www.zfanw.com/blog/'
-  google: 104787680206754797134
+  google: "104787680206754797134"
   twitter: chenxsan
   email: chenxsan@google.com
   description:
@@ -276,7 +276,7 @@ alexdanilo:
   country: AU
   role:
     - author
-  google: 113205278198625312096
+  google: "113205278198625312096"
   twitter: alexanderdanilo
   email: adanilo@google.com
 
@@ -307,7 +307,7 @@ robdodson:
   role:
     - author
   homepage: 'https://robdodson.me'
-  google: 118271135596408598424
+  google: "118271135596408598424"
   twitter: rob_dodson
   email: robdodson@google.com
 
@@ -409,7 +409,7 @@ simongong:
   role:
     - translator
   homepage: 'http://allmyverse.com'
-  google: 113525015220376733647
+  google: "113525015220376733647"
   email: simon.gong64@gmail.com
   description:
     en: Simon is a Full Stack Developer
@@ -443,7 +443,7 @@ eligrey:
     - author
     - engineer
   homepage: 'https://eligrey.com'
-  google: 111217788892362755679
+  google: "111217788892362755679"
   twitter: sephr
   email: me@eligrey.com
   description:
@@ -500,7 +500,7 @@ ilmariheikkinen:
     family: Heikkinen
   country: UK
   homepage: 'http://fhtr.org'
-  google: 105862726631119909094
+  google: "105862726631119909094"
   twitter: ilmarihei
   role:
     - author
@@ -531,7 +531,7 @@ captainpangyo:
   role:
     - translator
   homepage: 'https://joshuajangblog.wordpress.com/'
-  google: 112235341337838764023
+  google: "112235341337838764023"
   email: jangkeehyo@gmail.com
   description:
     en: Josh is a Singing Computer Scientist
@@ -544,7 +544,7 @@ kazukikanamori:
   role:
     - translator
   twitter: yogurito
-  google: 113987163927119714999
+  google: "113987163927119714999"
   email: kazuki.kanamori@gmail.com
   description:
     en: Digital Marketing Engineer
@@ -559,7 +559,7 @@ megginkearney:
   country: US
   role:
     - author
-  google: 110573989653316535297
+  google: "110573989653316535297"
   email: mkearney@google.com
   description:
     en: Meggin is a Tech Writer
@@ -604,7 +604,7 @@ swengineer:
   role:
     - translator
   homepage: 'http://fetobe.co.kr'
-  google: 112816149994035233646
+  google: "112816149994035233646"
   email: kim.sw.engineer@gmail.com
   description:
     en: Sungwon is a front-end Developer
@@ -770,7 +770,7 @@ heathermahan:
   role:
     - author
   homepage: 'https://github.com/heatheramahan'
-  google: 108335678119817391642
+  google: "108335678119817391642"
   twitter: heatheramahan
   email: heatheramahan@gmail.com
   description:
@@ -787,7 +787,7 @@ mikemahemoff:
   role:
     - author
   homepage: 'https://github.com/mahemoff'
-  google: 106413090159067280619
+  google: "106413090159067280619"
   twitter: mahemoff
   email: mahemoff@google.com
   lanyrd: mahemoff
@@ -803,7 +803,7 @@ renatomangini:
   role:
     - author
   homepage: 'http://renatomangini.com/'
-  google: 102180419759627664875
+  google: "102180419759627664875"
   twitter: renatomangini
   email: mangini@google.com
 
@@ -852,7 +852,7 @@ addyosmani:
   country: UK
   role:
     - author
-  google: 115133653231679625609
+  google: "115133653231679625609"
   twitter: addyosmani
   email: addyo@google.com
 
@@ -890,7 +890,7 @@ jeffposnick:
   role:
     - author
   homepage: 'https://twitter.com/jeffposnick'
-  google: 117780118136555864520
+  google: "117780118136555864520"
   twitter: jeffposnick
   email: jeffy@google.com
   description:
@@ -950,7 +950,7 @@ glenshires:
   country: USA
   role:
     - author
-  google: 110477083701772758618
+  google: "110477083701772758618"
   email: gshires@google.com
 
 abdshomad:
@@ -1022,7 +1022,7 @@ borissmus:
     unit: Developer Relations
   country: USA
   homepage: 'http://smus.com'
-  google: 115694705577863745195
+  google: "115694705577863745195"
   twitter: borismus
   role:
     - author
@@ -1098,7 +1098,7 @@ fouadvaladbeigi:
   country: UK
   role:
     - author
-  google: 115771375659957547634
+  google: "115771375659957547634"
   email: fouad.valadbeigi@unit9.com
 
 johyphenel:
@@ -1140,7 +1140,7 @@ mikewest:
   role:
     - author
   homepage: 'https://mikewest.org/'
-  google: 104437754419996754779
+  google: "104437754419996754779"
   twitter: mikewest
   email: mkwst@google.com
 
@@ -1154,7 +1154,7 @@ chriswilson:
   country: USA
   role:
     - author
-  google: 106422711035746240826
+  google: "106422711035746240826"
   twitter: cwilso
   email: cwilso@google.com
 
@@ -1163,7 +1163,7 @@ tomwiltzius:
     given: Tom
     family: Wiltzius
   country: USA
-  google: 103238735625031210015
+  google: "103238735625031210015"
   role:
     - author
 
@@ -1191,5 +1191,5 @@ maciejzasada:
   country: UK
   role:
     - author
-  google: 104812516714503133849
+  google: "104812516714503133849"
   email: maciej@unit9.com


### PR DESCRIPTION
Changes Google+ IDs to strings from numbers. As numbers, when read by js-yaml, there was an integer overflow and it was dropping/changing the values.