### PR TITLE
navigator.share late changes and clarifications from Chrome team

### DIFF
--- a/src/content/en/updates/2016/10/navigator-share.md
+++ b/src/content/en/updates/2016/10/navigator-share.md
@@ -13,9 +13,7 @@ description: Sharing is caring. Chrome is running an Origin Trial to enable nati
 {% include "web/_shared/contributors/paulkinlan.html" %}
 
 Good news, everybody! [Matt Giuca](https://twitter.com/mgiuca)
-on the Chrome team has been working on a
-[simple API](https://github.com/WICG/web-share/blob/master/docs/interface.md)
-called
+on the Chrome team has been working on a simple API called
 [Web Share](https://github.com/WICG/web-share/blob/master/docs/explainer.md)
 that allows websites to invoke the native sharing capabilities of the host platform.
 
@@ -34,9 +32,9 @@ where the data is shared.
 In Chrome 55 (Beta as of October 2016), we've enabled an 
 [Origin Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
 that lets you integrate the Web Share API into your
-site. The origin trial means this API is not generally available to all sites;
+site. The "Origin Trial" means this API is only available to sites in an opt-in basis;
 instead you need to register to get access during the trial phase. Over this
-time, the API will likely change and break in unexpected ways, which is why we
+time, the API may undergo breaking changes, which is why we
 are looking for as much feedback as possible.
 
 The Web Share API is a
@@ -57,15 +55,16 @@ The Web Share API is a
 </div>
 
 Once invoked it will bring up the native picker (see video) and allow you to
-share the data with the app chosen by the user.
+share the data with the app chosen by the user. You need to supply at least one of 
+'text' or 'url' but may supply both if you like.
 
 <div class="clearfix"></div>
 
 This API has a few constraints:
 
 * You need to host your site in a [secure context](https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features)
-  (typically https).
-*  You only need to supply one of text or url, not both.
+  (typically HTTPS).
+* You only need to supply one of text or url, not both.
 * You can only invoke the API as a result of a user gesture. (For example, you can't call
   `navigator.share()` in an onload handler.)
 * The property values that you pass into the API must all be strings.
@@ -75,37 +74,36 @@ This API has a few constraints:
 The process is pretty simple:
 
 1. Get the [Chrome Beta Channel on Android](https://play.google.com/store/apps/details?id=com.chrome.beta)
-   (as of October 2016).
-2. [Sign up](https://docs.google.com/forms/d/e/1FAIpQLSfO0_ptFl8r8G0UFhT0xhV17eabG-erUWBDiKSRDTqEZ_9ULQ/viewform)
-   for the Origin Trial.
-3. [Integrate](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md#how-do-i-enable-an-experimental-feature-on-my-origin)
-   the Origin Trial tokens into your site (as long as it is on https).
+   (required as of October 2016, but won't be necessary once Chrome 55 reaches stable).
+2. [Sign up](https://goo.gl/GR5YLI) for the Origin Trial.
+3. [Insert](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md#how-do-i-enable-an-experimental-feature-on-my-origin)
+   the Origin Trial tokens into your site.
 4. Call `navigator.share()` in response to a user gesture.
-5. Share!
+5. That's it, done. Share to your hearts content!
 
 ### Be progressive
 
 The API is not available on all platforms, so you will have to gracefully handle
-the scenarios where you don't have the ability to call. I try to progressively
+the scenarios where you don't have the ability to call it. I try to progressively
 enhance as much as possible, and the process that I follow on my
 [blog](https://paul.kinlan.me/) is to:
 
 1. Use your preferred sharing service via a simple `<a>` ([intent: URL with
    Twitter fallback is an example I use](https://paul.kinlan.me/sharing-natively-on-android-from-the-web/)).
 2. Check the availability of the API `(navigator.share !== undefined)`.
-3. Wait for the content to be available and then find the sharing element.
-4. Intercept and prevent the default behavior of the click.
-5. Call `navigator.share()`.
+3. Wait for the element to be available intercept and prevent the default
+   behavior of the click.
+4. Call `navigator.share()`.
 
 ### Share the correct URL
 
 You should also think about the URL that you want to share. In many cases the
 user will be on a mobile device and your site might have an "m." url, or a url
 that is custom to user's context. You can use the fact that there might be
-a canonical URL on your page to provide a better experience to the user.  For
+a canonical URL on your page to provide a better experience to the user. For
 example, you might do:
 
-    var url = document.location;
+    var url = document.location.href;
     var canonicalElement = document.querySelector('link[rel=canonical]');
     if(canonicalElement !== undefined) {
         url = canonicalElement.href;
@@ -121,7 +119,6 @@ save you a click, here are the important links:
 * [Intent to implement](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/1BOhy5av8MQ/8LqNvS5TAQAJ)
 * [Sample](https://github.com/mgiuca/web-share/blob/master/demos/share.html)
 * [Share explainer](https://github.com/WICG/web-share/blob/master/docs/explainer.md)
-* [Web Share in WICG](https://github.com/WICG/web-share)
 * [Discussion on Discourse](https://discourse.wicg.io/t/web-share-api-for-sharing-content-to-arbitrary-destination/1561/3)
 
 Future work will also level the playing field for web apps, by allowing them to


### PR DESCRIPTION
There were some last minute changes that came in from the Chrome team (not to the API), but
rather some clarifications and a shorter URL for the orgin trail.