### PR TITLE
Requires code samples to use 4 spaces

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -432,6 +432,15 @@ function validateMarkdown(filename, commonTags) {
         });
       }
 
+      // Search for ``` wrapped code blocks
+      matched = content.match(/```/g);
+      if (matched) {
+        errMsg = 'Found sample code block(s) wrapped in ```.';
+        errMsg += ' Required style is indented by 4 spaces.';
+        logError(filename, errMsg);
+        errors++;
+      }
+
       // Verify all TL;DRs are H3 and include hide-from-toc   
       matched = content.match(/^#+ TL;DR.*\n/gm);
       if (matched) {

--- a/src/content/en/fundamentals/accessibility/accessible-styles.md
+++ b/src/content/en/fundamentals/accessibility/accessible-styles.md
@@ -185,13 +185,9 @@ Going over all of responsive design is outside the scope of this guide, but
 here are a few important takeaways that will benefit your responsive experience
 and give your users better access to your content.
 
- - First, make sure you always use the proper `viewport` meta tag.
-
-   ```
-   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-   ```
-   
-   Setting `width=device-width`
+ - First, make sure you always use the proper `viewport` meta tag.<br>
+   `<meta name="viewport" content="width=device-width, initial-scale=1.0">`
+   <br>Setting `width=device-width`
    will match the screen's width in device-independent pixels, and setting
    `initial-scale=1` establishes a 1:1 relationship between CSS pixels and
    device-independent pixels. Doing this instructs the browser to fit your

--- a/src/content/en/fundamentals/accessibility/semantics-aria/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/index.md
@@ -93,33 +93,35 @@ panel. Often, ARIA lets us create widget-type elements that wouldn't be possible
 with plain HTML.
 
  - For example, ARIA can add extra label and description text that is only
-   exposed to assistive technology APIs.
+   exposed to assistive technology APIs.<br>
 
-```
-<button aria-label="screen reader only label"></button>
-```
-    
+<div class="clearfix"></div>
+      
+    <button aria-label="screen reader only label"></button>
+
 
  - ARIA can express semantic relationships between elements that extend the
    standard parent/child connection, such as a custom scrollbar that controls a
    specific region.
 
-```
-<div role="scrollbar" aria-controls="main"></div>
-<div id="main">
-. . .
-</div>
-```
+<div class="clearfix"></div>
+
+    <div role="scrollbar" aria-controls="main"></div>
+    <div id="main">
+    . . .
+    </div>
+
     
 
  - And ARIA can make parts of the page "live", so they immediately inform
    assistive technology when they change.
 
-```
-<div aria-live="true">
-  <span>GOOG: $400</span>
-</div>
-```
+<div class="clearfix"></div>
+
+    <div aria-live="true">
+      <span>GOOG: $400</span>
+    </div>
+
     
 One of the core aspects of the ARIA system is its collection of *roles*. A role
 in accessibility terms amounts to a shorthand indicator for a particular UI

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
@@ -143,11 +143,12 @@ touchscreen users. To associate a label with an element, either
 
  - Place the input element inside a label element
 
-```
-<label>
-    <input type="checkbox">Receive promotional offers?</input>
-</label>
-```
+<div class="clearfix"></div>
+
+    <label>
+      <input type="checkbox">Receive promotional offers?</input>
+    </label>
+
 
 {% framebox height="60px" %}
 <div style="margin: 10px;">
@@ -162,10 +163,11 @@ or
 
  - Use the label's `for` attribute and refer to the element's `id`
 
-```
-<input id="promo" type="checkbox"></input>
-<label for="promo">Receive promotional offers?</label>
-```
+<div class="clearfix"></div>
+
+    <input id="promo" type="checkbox"></input>
+    <label for="promo">Receive promotional offers?</label>
+
 
 {% framebox height="60px" %}
 <div style="margin: 10px;">
@@ -181,7 +183,7 @@ promotional offers?".
 
 ![on-screen text output from VoiceOver showing the spoken label for a checkbox](imgs/promo-offers.png)
 
->Tip: You can actually use the screen reader to find improperly-associated
+Success: You can actually use the screen reader to find improperly-associated
 labels by tabbing through the page and verifying the spoken roles, states, and
 names.
 

--- a/src/content/en/resources/style-guide.md
+++ b/src/content/en/resources/style-guide.md
@@ -105,6 +105,11 @@ automatically converted into HTML entities. This makes it very easy to include
 example HTML source code using Markdown -- just paste it and indent it, and
 Markdown will handle the hassle of encoding the ampersands and angle brackets.
 
+Warning: Wrapping code blocks in &grave;&grave;&grave; is not supported on
+DevSite. DevSite will not automatically style these blocks and our integration
+tests will fail.
+
+
 ### Highlighting
 
 Use `<strong>` to call attention to content within a `<pre>` block. Doing so

--- a/src/content/en/tools/lighthouse/audits/critical-request-chains.md
+++ b/src/content/en/tools/lighthouse/audits/critical-request-chains.md
@@ -27,7 +27,7 @@ the page load performance of your app.
 In the Chrome Extension version of Lighthouse, your report generates a diagram
 like the following:
 
-```
+<pre>
 Initial navigation
 |---lighthouse/ (developers.google.com)
     |---/css (fonts.googleapis.com) - 1058.34ms, 72.80KB
@@ -37,7 +37,7 @@ Initial navigation
     |---2.2.0/jquery.min.js (ajax.googleapis.com) - 2699.55ms, 99.92KB
     |---contributors/kaycebasques.jpg (developers.google.com) - 2841.54ms, 84.74KB
     |---MC30SXJEli4/photo.jpg (lh3.googleusercontent.com) - 3200.39ms, 73.59KB
-```
+</pre>
 
 This diagram represents the page's critical request chains. The path from
 `lighthouse/` to `/css` is one chain. The path from `lighthouse/` to

--- a/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
+++ b/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
@@ -346,9 +346,9 @@ default. To allow Chrome to open a USB device, you will need to add a new [udev 
 Create a file at `/etc/udev/rules.d/50-yourdevicename.rules` with the following
 content:
 
-```
-SUBSYSTEM=="usb", ATTR{idVendor}=="[yourdevicevendor]", MODE="0664", GROUP="plugdev"
-```
+
+    SUBSYSTEM=="usb", ATTR{idVendor}=="[yourdevicevendor]", MODE="0664", GROUP="plugdev"
+
 
 where `[yourdevicevendor]` is `2341` if your device is an Arduino for instance.
 `ATTR{idProduct}` can also be added for a more specific rule. Make sure your


### PR DESCRIPTION
DevSite does not support the ``` markdown syntax. This PR adds:

* a test to search for ``` codeblocks
* fixes existing code blocks that are wrapped in ```
* adds a warning to the style guide that they are not supported