### PR TITLE
Fix web fundamentals design and UI input touch demos

### DIFF
--- a/src/content/en/fundamentals/design-and-ui/input/touch/_code/touch-demo-1.html
+++ b/src/content/en/fundamentals/design-and-ui/input/touch/_code/touch-demo-1.html
@@ -388,7 +388,7 @@
           // Add Touch Listener
           swipeFrontElement.addEventListener('touchstart', this.handleGestureStart, true);
           swipeFrontElement.addEventListener('touchmove', this.handleGestureMove, true);
-          swipeFrontElement.addEventListener('touchup', this.handleGestureEnd, true);
+          swipeFrontElement.addEventListener('touchend', this.handleGestureEnd, true);
           swipeFrontElement.addEventListener('touchcancel', this.handleGestureEnd, true);
 
           // Add Mouse Listener

--- a/src/content/en/fundamentals/design-and-ui/input/touch/_code/touch-demo-2.html
+++ b/src/content/en/fundamentals/design-and-ui/input/touch/_code/touch-demo-2.html
@@ -190,7 +190,7 @@
       this.handleGestureMove = function(evt) {
         evt.preventDefault();
 
-        if(evt.targetTouches && evt.targetTouches.length > 0) {
+        if(evt.targetTouches && evt.targetTouches.length > 1) {
           return;
         }
 

--- a/src/content/en/fundamentals/design-and-ui/input/touch/_code/touch-demo-2.html
+++ b/src/content/en/fundamentals/design-and-ui/input/touch/_code/touch-demo-2.html
@@ -155,8 +155,11 @@
         initialYPos = point.y;
         /* // [END stash-start] */
 
-        if (!window.PointerEvent) {
-          // Add Mouse Listeners to document
+        // Add the move and end listeners
+        if (window.PointerEvent) {
+          evt.target.setPointerCapture(evt.pointerId);
+        } else {
+          // Add Mouse Listeners
           document.addEventListener('mousemove', this.handleGestureMove, true);
           document.addEventListener('mouseup', this.handleGestureEnd, true);
         }
@@ -169,8 +172,11 @@
           return;
         }
 
-        if (!window.PointerEvent) {
-          // Remove Mouse Listeners from document
+        // Remove Event Listeners
+        if (window.PointerEvent) {
+          evt.target.releasePointerCapture(evt.pointerId);
+        } else {
+          // Remove Mouse Listeners
           document.removeEventListener('mousemove', this.handleGestureMove, true);
           document.removeEventListener('mouseup', this.handleGestureEnd, true);
         }

--- a/src/content/en/fundamentals/design-and-ui/input/touch/_code/user-select-example.html
+++ b/src/content/en/fundamentals/design-and-ui/input/touch/_code/user-select-example.html
@@ -87,7 +87,7 @@
   </head>
 
   <body>
-    <button class="btn" tabindex="1">None Selectable Text</button>
+    <button class="btn" tabindex="1">Non-Selectable Text</button>
 
     <button class="btn user-selectable" tabindex="2">+44 (0) 123456789</button>
 


### PR DESCRIPTION
Fixes https://googlesamples.github.io/web-fundamentals/fundamentals/design-and-ui/input/touch/touch-demo-1.html and https://googlesamples.github.io/web-fundamentals/fundamentals/design-and-ui/input/touch/touch-demo-2.html (linked quite prominently from https://developers.google.com/web/fundamentals/design-and-ui/input/touch/) which are currently completely borked on touch-events browsers.

Further fixes a small typo "None selectable" > "Non-Selectable" (though I don't think that demo's actually linked to from anywhere)