### PR TITLE
update section title in lighthouse references

### DIFF
--- a/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
@@ -14,12 +14,12 @@ homescreen while offline.
 
 ## How to pass the audit {: #how }
 
-1. Define a `start_url` property in your `manifest.json` file. 
+1. Define a `start_url` property in your `manifest.json` file.
 2. Ensure that your service worker properly caches a resource that matches
    the value of `start_url`.
 
-To learn the basics of adding apps to homescreens, 
-see [Add Your Web App to a User's Home 
+To learn the basics of adding apps to homescreens,
+see [Add Your Web App to a User's Home
 Screen](https://codelabs.developers.google.com/codelabs/add-to-home-screen).
 This is a step-by-step, hands-on codelab in which you add "add to
 homescreen" functionality into an existing app. Use what you learn in
@@ -29,14 +29,11 @@ For more help on how to cache files with service workers for offline use,
 see the "How to pass the audit" section of the following Lighthouse doc:
 [URL responds with a 200 when offline](http-200-when-offline#how)
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 When a progressive web app is launched from the homescreen of a mobile
 device, the app opens on a specific URL. That URL is defined in the app's
-`manifest.json` file as the `start_url` property. 
+`manifest.json` file as the `start_url` property.
 
 This audit parses the value of `start_url` from `manifest.json` and then
 ensures that a matching resource is cached in the service worker's cache.

--- a/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
+++ b/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
@@ -27,9 +27,6 @@ You can ignore this audit if:
 * The content width of your page is intentionally smaller or larger than the
   viewport width.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 The audit passes if `window.innerWidth === window.outerWidth`.

--- a/src/content/en/tools/lighthouse/audits/critical-request-chains.md
+++ b/src/content/en/tools/lighthouse/audits/critical-request-chains.md
@@ -60,10 +60,7 @@ You can use this diagram to improve your CRP by:
 
 Optimizing any of these factors results in a faster page load.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse uses network priority as a proxy for identifying render-blocking
 critical resources. See [Chrome Resource Priorities and

--- a/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
+++ b/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
@@ -43,13 +43,10 @@ to ensure that all stages of [the pixel
 pipeline](/web/fundamentals/performance/rendering/#the_pixel_pipeline) are
 complete within 50ms.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 The RAIL performance model recommends that apps respond to user input within
-100ms, whereas Lighthouse's target score is 50ms. Why? 
+100ms, whereas Lighthouse's target score is 50ms. Why?
 
 The reason is that Lighthouse uses a proxy metric to measure how well your
 app responds to user input: availability of the main thread. Lighthouse

--- a/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
+++ b/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
@@ -13,7 +13,7 @@ Page load is a key aspect of how a user perceives the performance of your
 page. See [Measure Performance with the RAIL Method](/web/fundamentals/performance/rail) for more information.
 
 This audit identifies the time at which the user feels that the primary
-content of the page is visible. 
+content of the page is visible.
 
 ## How to pass the audit {: #how }
 
@@ -23,10 +23,7 @@ appears to display its primary content.
 [Optimizing the Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/)
 is particularly helpful towards achieving a faster First Meaningful Paint.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 First Meaningful Paint is essentially the paint after which the biggest
 above-the-fold layout change has happened, and web fonts have loaded. See the

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -31,10 +31,7 @@ The `width=device-width` key-value pair sets the width of the viewport to
 the width of the device. The `initial-scale=1` key-value pair sets the initial
 zoom level when visiting the page.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse checks that there's a `<meta name="viewport">` tag in the `<head>`
 of the document. It also checks that the node contains a `content` attribute

--- a/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
+++ b/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
@@ -18,10 +18,10 @@ offline.
 1. Add a service worker to your app.
 2. Use the service worker to cache files locally.
 3. When offline, use the service worker as a network proxy to return the
-   locally cached version of the file. 
+   locally cached version of the file.
 
 To learn how to add a service worker into an existing app, see [Adding a Service
-Worker and Offline Into Your Web 
+Worker and Offline Into Your Web
 App](https://codelabs.developers.google.com/codelabs/offline). Use what you
 learn in this step-by-step, hands-on codelab to learn how to add a service
 worker into your own app. This covers steps 1 and 3 above.
@@ -34,10 +34,7 @@ Workers](https://codelabs.developers.google.com/codelabs/debugging-service-worke
 Use the [Offline Cookbook](https://jakearchibald.com/2014/offline-cookbook/) to
 determine which caching strategy fits your app best. This covers step 2 above.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs or is
-returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse emulates an offline connection using the Chrome Debugging Protocol,
 and then attempts to retrieve the page using `XMLHttpRequest`.

--- a/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
+++ b/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
@@ -25,10 +25,7 @@ traffic to your site is redirected to HTTPS.
 2. Configure your server to redirect HTTP traffic to HTTPS. See your server's
    documentation to figure out the best way to do this.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse changes the page's URL to `http`, loads the page, and then waits for
 the event from the Chrome Debugger that indicates that the page is secure. If

--- a/src/content/en/tools/lighthouse/audits/https.md
+++ b/src/content/en/tools/lighthouse/audits/https.md
@@ -42,10 +42,7 @@ requests an unprotected (HTTP) resource. Check out the following doc on the
 Chrome DevTools Security panel to learn how to debug these situations:
 [Understand security issues](/web/tools/chrome-devtools/debug/security).
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse waits for an event from the Chrome Debugger Protocol indicating that
 the page is running on a secure connection. If the event is not heard within 10

--- a/src/content/en/tools/lighthouse/audits/implementation-heading.html
+++ b/src/content/en/tools/lighthouse/audits/implementation-heading.html
@@ -1,0 +1,4 @@
+<h2 id="implementation">How the audit is implemented</h2>
+
+<p><em>This section explains how this audit is implemented, so that you
+can understand how the audit's score is calculated.</em></p>

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
@@ -36,10 +36,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 This audit can only guarantee that your icon displays well on Android devices.
 Other operating systems may require a different icon size for optimal

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
@@ -29,10 +29,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Audit passes if the manifest contains a `background_color` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
@@ -32,10 +32,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse fetches the manifest and verifies that it has a `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -31,10 +31,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Audit passes if the manifest contains either `short_name` or `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
@@ -30,10 +30,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse fetches the manifest and verifies that it has a `start_url` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-theme_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-theme_color.md
@@ -28,10 +28,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Audit passes if the manifest contains a `theme_color` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-exists.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-exists.md
@@ -30,10 +30,7 @@ You can emulate and test A2HS events in Chrome DevTools. See the following
 section for more help: [Web App
 Manifest](/web/tools/chrome-devtools/debug/progressive-web-apps/#manifest).
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse fetches the manifest and verifies that it has data. The manifest that
 Lighthouse fetches is separate from the one that Chrome is using on the page, which

--- a/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
@@ -31,10 +31,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse fetches the manifest and verifies that the `display` property
 exists and that it's value is `fullscreen`, `standalone`, or `browser`.

--- a/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -33,10 +33,7 @@ Check out [Manifest Exists](manifest-exists#how)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse fetches the manifest and verifies that the `short_name` property is
 less than 12 characters. Note that since the `name` property can be used as a

--- a/src/content/en/tools/lighthouse/audits/no-js.md
+++ b/src/content/en/tools/lighthouse/audits/no-js.md
@@ -32,7 +32,7 @@ for an example of this approach.
 Another camp believes that this strict approach is unfeasible or unnecessary
 for many modern, large-scale web applications and suggests using inline
 critical path CSS in the document `<head>` for absolutely critical page styles.
-See [Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/) for more on this approach. 
+See [Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/) for more on this approach.
 
 Given these considerations, this Lighthouse audit performs a simple check to
 ensure that your page isn't blank when JavaScript is disabled. How strictly your
@@ -52,10 +52,7 @@ To see how your site looks and performs when JavaScript is disabled, use
 Chrome DevTools' [Disable
 JavaScript](/web/tools/chrome-devtools/settings#disable-js) feature.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse disables JavaScript on the page and then inspects the page's HTML. If
 the HTML is empty then the audit fails. If the HTML is not empty then the audit

--- a/src/content/en/tools/lighthouse/audits/registered-service-worker.md
+++ b/src/content/en/tools/lighthouse/audits/registered-service-worker.md
@@ -36,9 +36,6 @@ the features in your own app:
 * [Add your web app to a user's home
   screen](https://codelabs.developers.google.com/codelabs/add-to-home-screen).
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Checks if the Chrome Debugger returns a service worker version.

--- a/src/content/en/tools/lighthouse/audits/speed-index.md
+++ b/src/content/en/tools/lighthouse/audits/speed-index.md
@@ -20,12 +20,9 @@ load faster. Two good starting places are:
 * [Optimizing Content Efficiency](/web/fundamentals/performance/optimizing-content-efficiency/).
 * [Optimizing the Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/).
 
-## What the audit tests for {: #what }
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
-
-Lighthouse uses a node module called 
+Lighthouse uses a node module called
 [Speedline](https://github.com/pmdartus/speedline)
 to generate the Speed Index score.
 

--- a/src/content/en/tools/lighthouse/audits/template.md
+++ b/src/content/en/tools/lighthouse/audits/template.md
@@ -11,7 +11,4 @@ description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
 
 ## How to pass the audit {: #how }
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.md" %}

--- a/src/content/en/tools/lighthouse/audits/time-to-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/time-to-interactive.md
@@ -21,13 +21,10 @@ Check out the resources in the [How to pass the audit](speed-index#how) section
 of the Speed Index audit for more help on improving page load performance.
 The lower your Time to Interactive score, the better.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Time to Interactive is defined as the point at which layout has stabilized,
 key webfonts are visible, and the main thread is available enough to handle
-user input. 
+user input.
 
 Note that this metric is in early phases and is subject to change.

--- a/src/content/en/tools/lighthouse/audits/user-timing.md
+++ b/src/content/en/tools/lighthouse/audits/user-timing.md
@@ -30,9 +30,6 @@ Check out [User Timing API](https://www.html5rocks.com/en/tutorials/webperforman
 for an introduction on using the User Timing API to measure your app's
 JavaScript performance.
 
-## What the audit tests for {: #what }
-
-*Use this information to determine if the audit is relevant to your needs
-or is returning incorrect results.*
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse extracts User Timing data from Chrome's Trace Event Profiling Tool.


### PR DESCRIPTION
I got some feedback that the purpose of this section was confusing, so I updated the section title and note. I may need to change it again, so I'm using an include.

@petele the [includes](https://developers.google.com/web/resources/widgets#includes) references says that an include must be HTML, and that Markdown is not supported. However when I run the site locally the Markdown is working just fine. So, is that doc outdated? Can I use Markdown?