### PR TITLE
rephrase rail guidelines

### DIFF
--- a/src/content/en/fundamentals/performance/rail.md
+++ b/src/content/en/fundamentals/performance/rail.md
@@ -9,15 +9,16 @@ description: RAIL is a user-centric performance model. Every web app has these f
 
 {% include "web/_shared/contributors/megginkearney.html" %}
 
-RAIL is a user-centric performance model. Every web app has these four distinct aspects to its life cycle, and performance fits into them in very different ways:
+RAIL is a user-centric performance model. Every web app has these four distinct aspects to its life cycle, and performance fits into them in different ways:
 
 ![RAIL performance model](images/rail.png)
 
 
 ### TL;DR {: .hide-from-toc }
-- Focus on the user; the end goal isn't to make your site perform fast on any specific device, it''s to ultimately make users happy.
+
+- Focus on the user; the end goal isn't to make your site perform fast on any specific device, it's to ultimately make users happy.
 - Respond to users immediately; acknowledge user input in under 100ms.
-- Render each frame in under 16ms and aim for consistency; users notice 'jank'.
+- When animating or scrolling, produce a frame in under 10ms.
 - Maximize main thread idle time.
 - Keep users engaged; deliver interactive content in under 1000ms.
 
@@ -36,11 +37,16 @@ Understand how users perceive performance delays:
   <tbody>
     <tr>
       <td data-th="Delay">0 - 16ms</td>
-      <td data-th="User Reaction">Given a screen that is updating 60 times per second, this window represents the time to get a single frame to the screen (Professor Math says "1000/60 ~= 16"). People are exceptionally good at tracking motion, and they dislike it when the expectation of motion isn’t met, either through variable frame rates or periodic halting.</td>
+      <td data-th="User Reaction">People are exceptionally good at tracking
+      motion, and they dislike it when animations aren't smooth. Users
+      perceive animations as smooth so long as 60 new frames are rendered
+      every second. That's 16ms per frame, including the time it takes for
+      the browser to paint the new frame to the screen, leaving an app
+      about 10ms to produce a frame.</td>
     </tr>
     <tr>
       <td data-th="Delay">0 - 100ms</td>
-      <td data-th="User Reaction">Respond to a user action within this time window and they will feel like the result was immediate. Any longer, and the connection between action and reaction is broken.</td>
+      <td data-th="User Reaction">Respond to a user action within this time window and users feel like the result is immediate. Any longer, and the connection between action and reaction is broken.</td>
     </tr>
     <tr>
       <td data-th="Delay">100 - 300ms</td>
@@ -64,8 +70,9 @@ Understand how users perceive performance delays:
 ## Response: respond in under 100ms
 
 You have 100ms to respond to user input before they notice a lag.
-This applies to any input, whether they are clicking a button,
-toggling form controls, or starting an animation.
+This applies to most inputs, such as clicking buttons, toggling form
+controls, or starting animations. This does not apply to touch drags or
+scrolls.
 
 If you don't respond, the connection between action and reaction is broken. Users will notice.
 
@@ -76,20 +83,25 @@ If possible, do work in the background.
 
 For actions that take longer than 500ms to complete, always provide feedback.
 
-Success: Respond to user's touchmoves and scrolling in under 16ms.
+## Animation: produce a frame in 10ms
 
-## Animation: render frames every 16ms
+Animations aren't just fancy UI effects. For example, scrolling and touch
+drags are types of animations.
 
-Animations aren't trivial actions that web apps can opt into.
-For example, scrolling and touchmoves are types of animation.
-Your users will really notice if the animation frame rate varies.
+Users notice when the animation frame rate varies.
 Your goal is to produce 60 frames per second, and every frame has to go through all of these steps:
 
 ![Steps to render a frame](images/render-frame.png)
 
-From a purely mathematical point of view, every frame has a budget of 16.66ms (divide 1 second by 60) but, because browsers have housekeeping to do, the reality is that there is a window of 10ms for your code during animations.
+From a purely mathematical point of view, every frame has a budget of about 
+16ms (1000ms / 60 frames per second = 16.66ms per frame). However, because
+browsers need some time to paint the new frame to the screen, **your code
+should finish executing in under 10ms**. 
 
-In high pressure points like animations, the key is to do nothing where you can, and where you can’t, do the absolute minimum. Whenever possible, make use of the 100ms response to pre-calculate expensive work so that you maximize your chances of hitting 60fps.
+In high pressure points like animations, the key is to do nothing where you
+can, and the absolute minimum where you can't. Whenever possible, make use of
+the 100ms response to pre-calculate expensive work so that you maximize your
+chances of hitting 60fps.
 
 For more information, see
 [Rendering Performance](/web/fundamentals/performance/rendering/).
@@ -101,15 +113,14 @@ Use idle time to complete deferred work. For example, keep pre-load data to a mi
 Deferred work should be grouped into blocks of about 50ms. Should a user begin interacting, then the highest priority is to respond to that. 
 
 To allow for <100ms response,
-the app must yield control back to main thread every <100ms,
+the app must yield control back to main thread every <50ms,
 such that it can execute its pixel pipeline, react to user input, and so on.
 
 Working in 50ms blocks allows the task to finish while still ensuring instant response.
 
 ## Load: deliver content under 1000ms
 
-Load your site in under 1 second.
-If you don't, your user's attention wanders,
+Load your site in under 1 second. If you don't, user attention wanders,
 and their perception of dealing with the task is broken.
 
 Focus on
@@ -118,9 +129,9 @@ to unblock rendering.
 
 You don't have to load everything in under 1 second to produce the perception of a complete load. Enable progressive rendering and do some work in the background. Defer non-essential loads to periods of idle time (see this [Website Performance Optimization Udacity course](https://www.udacity.com/course/website-performance-optimization--ud884) for more information).
 
-## Summary of key rail metrics
+## Summary of key RAIL metrics
 
-To evaluate your site against RAIL metrics, use the Chrome DevTools [Timeline tool](/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool) to record user actions. Then check the recording times in the Timeline against these key rail metrics:
+To evaluate your site against RAIL metrics, use the Chrome DevTools [Timeline tool](/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool) to record user actions. Then check the recording times in the Timeline against these key RAIL metrics:
 
 <table>
   <thead>
@@ -132,22 +143,17 @@ To evaluate your site against RAIL metrics, use the Chrome DevTools [Timeline to
     <tr>
       <td data-th="RAIL Step"><strong>Response</strong></td>
       <td data-th="Key Metric">Input latency (from tap to paint) < 100ms.</td>
-      <td data-th="User Test">User taps on an icon or button (for example, opening the nav menu, tapping Compose).</td>
-    </tr>
-    <tr>
-      <td data-th="RAIL Step"><strong>Response</strong></td>
-      <td data-th="Key Metric">Input latency (from tap to paint) < 16ms.</td>
-      <td data-th="User Test">User drags their finger and the app's response is bound to the finger position (for example, pull to refresh, swiping a carousel).</td>
+      <td data-th="User Test">User taps a button (for example, opening navigation).</td>
     </tr>
     <tr>
       <td data-th="RAIL Step"><strong>Animation</strong></td>
-      <td data-th="Key Metric">Input latency (from tap to paint) < 100ms for initial response.</td>
-      <td data-th="User Test">User initiates page scroll or animation begins.</td>
-    </tr>
-    <tr>
-      <td data-th="RAIL Step"><strong>Animation</strong></td>
-      <td data-th="Key Metric">Each frame's work (JS to paint) completes < 16ms.</td>
-      <td data-th="User Test">User scrolls the page or sees an animation.</td>
+      <td data-th="Key Metric">Each frame's work (from JS to paint) completes < 16ms.</td>
+      <td data-th="User Test">User scrolls the page, drags a finger (to open
+        a menu, for example), or sees an animation. When dragging, the app's
+        response is bound to the finger position, such as pulling to refresh,
+        or swiping a carousel. This metric applies only to the continuous
+        phase of drags, not the start.
+      </td>
     </tr>
     <tr>
       <td data-th="RAIL Step"><strong>Idle</strong></td>
@@ -158,11 +164,6 @@ To evaluate your site against RAIL metrics, use the Chrome DevTools [Timeline to
       <td data-th="RAIL Step"><strong>Load</strong></td>
       <td data-th="Key Metric">Page considered ready to use in 1000ms.</td>
       <td data-th="User Test">User loads the page and sees the critical path content.</td>
-    </tr>
-    <tr>
-      <td data-th="RAIL Step"><strong>Load</strong></td>
-      <td data-th="Key Metric">Satisfy the Response goals during the full page load process.</td>
-      <td data-th="User Test">User loads the page and starts interacting (for example, scrolls or opens navigation).</td>
     </tr>
   </tbody>
 </table> 


### PR DESCRIPTION
This started in an email thread with @tdresser. The RAIL doc was confusingly referring to a budget of 16ms for animations. This PR rephrases the stuff to make it clear that animation code should finish in 10ms, so that the browser has time to paint the new frame to the screen within the 16ms budget. 

PR also includes some minor copyedit updates

@tdresser please review