### PR TITLE
Redirect Android Pay integration guide

### DIFF
--- a/src/content/en/fundamentals/getting-started/_redirects.yaml
+++ b/src/content/en/fundamentals/getting-started/_redirects.yaml
@@ -5,3 +5,5 @@ redirects:
   to: /web/fundamentals/getting-started/#codelabs
 - from: /web/fundamentals/getting-started/primers/payment-request/
   to: /web/fundamentals/discovery-and-monetization/payment-request/
+- from: /web/fundamentals/getting-started/primers/payment-request/android-pay
+  to: /web/fundamentals/discovery-and-monetization/payment-request/android-pay


### PR DESCRIPTION
Forgot to add a redirect to Android Pay article thanks to @afitz0 for letting me know.