### PR TITLE
Reflect Payment Request API updates in M56

### DIFF
--- a/src/content/en/fundamentals/discovery-and-monetization/_toc.yaml
+++ b/src/content/en/fundamentals/discovery-and-monetization/_toc.yaml
@@ -11,7 +11,7 @@ toc:
       path: https://www.google.com/adsense
     - title: Handling Payments
       section:
-      - title: Integration Guide
+      - title: Payment Request API - an Integration Guide
         path: /web/fundamentals/discovery-and-monetization/payment-request/
       - title: Integrating Android Pay into Payment Request
         path: /web/fundamentals/discovery-and-monetization/payment-request/android-pay

--- a/src/content/en/fundamentals/discovery-and-monetization/payment-request/android-pay.md
+++ b/src/content/en/fundamentals/discovery-and-monetization/payment-request/android-pay.md
@@ -82,9 +82,8 @@ figure {
 
 * Make sure you have the Android Pay app installed on your device. You need to be in one of the supported countries to install it. Check on [android.com/pay](https://www.android.com/pay/){: .external } to see if your country is supported.
 * For testing, you need to [add a credit card](https://support.google.com/androidpay/answer/6289372) to Android Pay on your device.
-* Sign up for a merchant ID from Android Pay
-    * Add your company, site origin, and a company email using [this form.](https://goo.gl/forms/SiKd7GAESCPNg9H83)
-    * Google will provide a merchant ID within 1 business day.
+* Sign up for Android Pay
+    * Add your company, site origin, and a company email etc using [this form.](https://androidpay.developers.google.com/signup)
 * Ensure that [your payment gateway / processor supports Android Pay tokens](/android-pay/#processors).
 * Acquire a key-pair used to encrypt the response from Android Pay if you are using [the network token approach](#integration-using-network-token).
     * Google recommends that you work with your payment processor to obtain a public key. This simplifies the process as your processor will be able to handle decryption of the Android Pay Payload. Find more information at your payment processor documentation.
@@ -137,13 +136,13 @@ In requesting a gateway token, Android Pay makes a call to your processor on you
         }
       }
     ];
-    
+
 
 In order to use Android Pay with the gateway token approach, add a JSON object that contains the following parameters per the above example.
 
 * `supportedMethods: [ 'https://android.com/pay' ]`: Indicate this is a payment method using Android Pay.
 * `data`: These are Android Pay specific values which are not yet standardized.
-    * `merchantId`: [Android Pay Merchant ID](https://goo.gl/forms/SiKd7GAESCPNg9H83) you have obtained from Google.
+    * `merchantId`: The Android Pay Merchant ID you have obtained by [signing up to Android Pay](https://androidpay.developers.google.com/signup).
     * `environment:'TEST'`: Add this if you are testing with Android Pay. The generated gateway token will be invalid.
     * `allowedCardNetworks`: Provide an array of credit card networks that constitute a valid Android Pay response. It accepts "AMEX", "DISCOVER", "MASTERCARD" and "VISA".
     * `paymentMethodTokenizationParameters`:
@@ -181,14 +180,14 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
 
     function onBuyClicked() {
       const ANDROID_PAY = 'https://android.com/pay';
-    
+
       if (!window.PaymentRequest) {
         // PaymentRequest API is not available. Forwarding to
         // legacy form based experience.
         location.href = '/checkout';
         return;
       }
-    
+
       var supportedInstruments = [
         {
           supportedMethods: [
@@ -213,7 +212,7 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
           }
         }
       ];
-    
+
       var details = {
         displayItems: [{
           label: 'Original donation amount',
@@ -227,16 +226,17 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
           amount: { currency: 'USD', value : '55.00' }
         }
       };
-    
+
       var options = {
         requestShipping: true,
         requestPayerEmail: true,
-        requestPayerPhone: true
+        requestPayerPhone: true,
+        requestPayerName: true
       };
-    
+
       // Initialization
       var request = new PaymentRequest(supportedInstruments, details, options);
-    
+
       // When user selects a shipping address
       request.addEventListener('shippingaddresschange', e => {
         e.updateWith(((details, addr) => {
@@ -271,11 +271,11 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
             details.displayItems.push(shippingOption);
           }
           details.shippingOptions = [shippingOption];
-    
+
           return Promise.resolve(details);
         })(details, request.shippingAddress));
       });
-    
+
       // When user selects a shipping option
       request.addEventListener('shippingoptionchange', e => {
         e.updateWith(((details) => {
@@ -283,26 +283,17 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
           return Promise.resolve(details);
         })(details));
       });
-    
+
       // Show UI then continue with user payment info
       request.show().then(result => {
-        // Manually clone the resulting object
-        var data = {};
-        data.methodName = result.methodName;
-        data.details    = result.details;
-        data.payerEmail = result.payerEmail;
-        data.payerPhone = result.payerPhone;
-        data.address    = toDict(result.shippingAddress);
-        data.shipping   = result.shippingOption;
-    
-        // POST the object to the server
+        // POST the result to the server
         return fetch('/pay', {
           method: 'POST',
           credentials: 'include',
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: result.toJSON()
         }).then(res => {
           // Only if successful
           if (res.status === 200) {
@@ -319,9 +310,9 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
           }
         }).then(() => {
           console.log('Thank you!',
-              result.shippingAddress,
+              result.shippingAddress.toJSON(),
               result.methodName,
-              result.details);
+              result.details.toJSON());
         }).catch(() => {
           return result.complete('fail');
         });
@@ -329,29 +320,9 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
         console.error('Uh oh, something bad happened: ' + err.message);
       });
     }
-    
-    // convert `addr` into a dictionary
-    var toDict = function(addr) {
-      var dict = {};
-      if (addr) {
-        dict.country           = addr.country;
-        dict.region            = addr.region;
-        dict.city              = addr.city;
-        dict.dependentLocality = addr.dependentLocality;
-        dict.addressLine       = addr.addressLine;
-        dict.postalCode        = addr.postalCode;
-        dict.sortingCode       = addr.sortingCode;
-        dict.languageCode      = addr.languageCode;
-        dict.organization      = addr.organization;
-        dict.recipient         = addr.recipient;
-        dict.careOf            = addr.careOf;
-        dict.phone             = addr.phone;
-      }
-      return dict;
-    };
-    
+
     document.querySelector('#start').addEventListener('click', onBuyClicked);
-    
+
 
 ### Integration using Network Token
 Requesting a network token requires two pieces of information to be included in the PaymentRequest.
@@ -383,13 +354,13 @@ Requesting a network token requires two pieces of information to be included in 
         }
       }
     ];
-    
+
 
 In order to use Android Pay with the network token approach, add a JSON object that contains the following parameters per the above example.
 
 * `supportedMethods: [ 'https://android.com/pay' ]`: Indicate this is a payment method using Android Pay.
 * `data`:
-    * `merchantId`: [Android Pay Merchant ID](https://goo.gl/forms/SiKd7GAESCPNg9H83) you have obtained from Google.
+    * `merchantId`: The Android Pay Merchant ID you have obtained by [signing up to Android Pay](https://androidpay.developers.google.com/signup).
     * `environment:'TEST'`: Add this if you are testing with Android Pay. The generated token will be invalid.  For production environment, remove this line.
     * `allowedCardNetworks`: Provide an array of credit card networks that constitute a valid Android Pay response.
     * `paymentMethodTokenizationParameters`:
@@ -405,14 +376,14 @@ After you add the Android Pay object, Chrome can request a chargeable network to
       details,              // required information about transaction
       options               // optional parameter for things like shipping, etc.
     );
-    
+
     payment.show().then(function(response) {
       // Process response
       response.complete("success");
     }).catch(function(err) {
       console.error("Uh oh, something bad happened", err.message);
     });
-    
+
 
 The encrypted response from PaymentRequest will contain the shipping and contact information as in the examples outlined in the [PaymentRequest integration guide](.), but now includes an additional response from Android Pay containing
 

--- a/src/content/en/fundamentals/discovery-and-monetization/payment-request/android-pay.md
+++ b/src/content/en/fundamentals/discovery-and-monetization/payment-request/android-pay.md
@@ -83,7 +83,7 @@ figure {
 * Make sure you have the Android Pay app installed on your device. You need to be in one of the supported countries to install it. Check on [android.com/pay](https://www.android.com/pay/){: .external } to see if your country is supported.
 * For testing, you need to [add a credit card](https://support.google.com/androidpay/answer/6289372) to Android Pay on your device.
 * Sign up for Android Pay
-    * Add your company, site origin, and a company email etc using [this form.](https://androidpay.developers.google.com/signup)
+    * Add your company, site origin, and a company email etc. using [this form.](https://androidpay.developers.google.com/signup)
 * Ensure that [your payment gateway / processor supports Android Pay tokens](/android-pay/#processors).
 * Acquire a key-pair used to encrypt the response from Android Pay if you are using [the network token approach](#integration-using-network-token).
     * Google recommends that you work with your payment processor to obtain a public key. This simplifies the process as your processor will be able to handle decryption of the Android Pay Payload. Find more information at your payment processor documentation.
@@ -142,7 +142,7 @@ In order to use Android Pay with the gateway token approach, add a JSON object t
 
 * `supportedMethods: [ 'https://android.com/pay' ]`: Indicate this is a payment method using Android Pay.
 * `data`: These are Android Pay specific values which are not yet standardized.
-    * `merchantId`: The Android Pay Merchant ID you have obtained by [signing up to Android Pay](https://androidpay.developers.google.com/signup).
+    * `merchantId`: The Android Pay Merchant ID you obtained by [signing up to Android Pay](https://androidpay.developers.google.com/signup).
     * `environment:'TEST'`: Add this if you are testing with Android Pay. The generated gateway token will be invalid.
     * `allowedCardNetworks`: Provide an array of credit card networks that constitute a valid Android Pay response. It accepts "AMEX", "DISCOVER", "MASTERCARD" and "VISA".
     * `paymentMethodTokenizationParameters`:
@@ -293,7 +293,7 @@ How you handle a submitted gateway token depends on the payment gateway. Please 
           headers: {
             'Content-Type': 'application/json'
           },
-          body: result.toJSON()
+          body: JSON.stringify(result.toJSON())
         }).then(res => {
           // Only if successful
           if (res.status === 200) {
@@ -360,7 +360,7 @@ In order to use Android Pay with the network token approach, add a JSON object t
 
 * `supportedMethods: [ 'https://android.com/pay' ]`: Indicate this is a payment method using Android Pay.
 * `data`:
-    * `merchantId`: The Android Pay Merchant ID you have obtained by [signing up to Android Pay](https://androidpay.developers.google.com/signup).
+    * `merchantId`: The Android Pay Merchant ID you obtained by [signing up to Android Pay](https://androidpay.developers.google.com/signup).
     * `environment:'TEST'`: Add this if you are testing with Android Pay. The generated token will be invalid.  For production environment, remove this line.
     * `allowedCardNetworks`: Provide an array of credit card networks that constitute a valid Android Pay response.
     * `paymentMethodTokenizationParameters`:

--- a/src/content/en/fundamentals/discovery-and-monetization/payment-request/android-pay.md
+++ b/src/content/en/fundamentals/discovery-and-monetization/payment-request/android-pay.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Android Pay enables simple and secure purchases online and eliminates the need for users to remember and manually enter their payment information. Integrate Android Pay to reach millions of Android users, drive higher conversion, and give users a true one-touch checkout experience.
 
-{# wf_updated_on: 2016-09-20 #}
+{# wf_updated_on: 2016-12-06 #}
 {# wf_published_on: 2016-09-07 #}
 
 # Integrating Android Pay into Payment Request {: .page-title }

--- a/src/content/en/fundamentals/discovery-and-monetization/payment-request/index.md
+++ b/src/content/en/fundamentals/discovery-and-monetization/payment-request/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Payment Request API is for fast, easy payments on the web.
 
 {# wf_published_on: 2016-07-25 #}
-{# wf_updated_on: 2016-08-18 #}
+{# wf_updated_on: 2016-12-06 #}
 
 # Payment Request API: an Integration Guide {: .page-title }
 

--- a/src/content/en/fundamentals/discovery-and-monetization/payment-request/index.md
+++ b/src/content/en/fundamentals/discovery-and-monetization/payment-request/index.md
@@ -178,7 +178,7 @@ Repeated or calculated values used in the `details` can be specified either as s
   </figure>
 </div>
 
-Activate the `PaymentRequest` interface by calling its [`show`](https://www.w3.org/TR/payment-request/#show) method. This method invokes a native UI that allows the user to examine the details of the purchase, add or change information, and finally, pay. A [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) (indicated by its `then` method and callback function) that resolves will be returned when the user accepts or rejects the payment request.
+Activate the `PaymentRequest` interface by calling its [`show()`](https://www.w3.org/TR/payment-request/#show) method. This method invokes a native UI that allows the user to examine the details of the purchase, add or change information, and finally, pay. A [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) (indicated by its `then()` method and callback function) that resolves will be returned when the user accepts or rejects the payment request.
 
 <div style="clear:both;"></div>
 
@@ -193,11 +193,11 @@ Activate the `PaymentRequest` interface by calling its [`show`](https://www.w3.o
 *PaymentRequest show method*
 
 ### Abort a Payment Request {: #abort-paymentrequest }
-You can intentionally abort a `PaymentRequest` by calling its [`abort`](https://www.w3.org/TR/payment-request/#abort) method. This is particulary useful when the shopping session is timed out or the goods is sold out in between a user's transaction.
+You can intentionally abort a `PaymentRequest` by calling its [`abort()`](https://www.w3.org/TR/payment-request/#abort) method. This is particulary useful when the shopping session is timed out or an item in the cart sells out during the transaction.
 
-Use this method if the app needs to cancel the payment request after the `show` method has been called but before the promise has been resolved&mdash;for example, if an item is no longer available, or the user fails to confirm the purchase within an allotted amount of time.
+Use this method if the app needs to cancel the payment request after the `show()` method has been called but before the promise has been resolved &mdash; For example, if an item is no longer available, or the user fails to confirm the purchase within an allotted amount of time.
 
-If you abort a request, you'll need to create a new instance of `PaymentRequest` before you can call `show` again.
+If you abort a request, you'll need to create a new instance of `PaymentRequest` before you can call `show()` again.
 
 
     var paymentTimeout = window.setTimeout(function() {
@@ -213,7 +213,7 @@ If you abort a request, you'll need to create a new instance of `PaymentRequest`
 *PaymentRequest abort method*
 
 ### Process the PaymentResponse {: # process-paymentresponse}
-Upon a user approval for a payment request, the [`show`](https://www.w3.org/TR/payment-request/#show) method's promise resolves, resulting in a `PaymentResponse` object.
+Upon a user approval for a payment request, the [`show()`](https://www.w3.org/TR/payment-request/#show) method's promise resolves, resulting in a `PaymentResponse` object.
 
 <table class="properties responsive">
 <tr>
@@ -259,7 +259,7 @@ For credit card payments, the response is standardized. For non-credit card paym
 `cardSecurityCode`
 `billingAddress`
 
-After payment information is received, the app should submit the payment information to your payment processor for processing. The UI will show a spinner while the request takes place. When a response has come back, the app should call `complete` to close the UI.
+After payment information is received, the app should submit the payment information to your payment processor for processing. The UI will show a spinner while the request takes place. When a response has come back, the app should call `complete()` to close the UI.
 
 
     payment.show().then(paymentResponse => {
@@ -299,7 +299,7 @@ After payment information is received, the app should submit the payment informa
   </figure>
 </div>
 
-The [`complete`](https://www.w3.org/TR/payment-request/#complete) method tells the user agent that the user interaction is over and allows the app to notify the user of the result and to address the disposition of any remaining UI elements.
+The [`complete()`](https://www.w3.org/TR/payment-request/#complete) method tells the user agent that the user interaction is over and allows the app to notify the user of the result and to address the disposition of any remaining UI elements.
 
 <div style="clear:both;"></div>
 
@@ -325,7 +325,7 @@ The [`complete`](https://www.w3.org/TR/payment-request/#complete) method tells t
 
 If you are a merchant selling physical goods, you may want to collect the user's shipping address using the Payment Request API. This is accomplished by adding `requestShipping: true` to the `options` parameter. With this parameter set, "Shipping" will be added to the UI, and users can select from a list of stored addresses or add a new shipping address.
 
-You can alternatively use "Delivery" or "Pickup" instead of "Shipping" in the UI by specifying `shippingType`. This is solely display purpose.
+You can alternatively use "Delivery" or "Pickup" instead of "Shipping" in the UI by specifying `shippingType`. This is solely for display purposes.
 
 <div style="clear:both;"></div>
 
@@ -400,7 +400,7 @@ Note: Resolving <code>shippingaddresschange</code> event and leaving <code>detai
   </figure>
 </div>
 
-Upon user approval for a payment request, the [`show`](https://www.w3.org/TR/payment-request/#show) method's promise resolves. The app may use the `.shippingAddress` property of the [`PaymentResponse`](https://www.w3.org/TR/payment-request/#paymentresponse-interface) object to inform the payment processor of the shipping address, along with other properties.
+Upon user approval for a payment request, the [`show()`](https://www.w3.org/TR/payment-request/#show) method's promise resolves. The app may use the `.shippingAddress` property of the [`PaymentResponse`](https://www.w3.org/TR/payment-request/#paymentresponse-interface) object to inform the payment processor of the shipping address, along with other properties.
 
 <div style="clear:both;"></div>
 
@@ -489,7 +489,7 @@ Changing shipping options may have different prices. In order to add the shippin
   </figure>
 </div>
 
-Upon user approval for a payment request, the [`show`](https://www.w3.org/TR/payment-request/#show) method's promise resolves. The app may use the `.shippingOption` property of the [`PaymentResponse`](https://www.w3.org/TR/payment-request/#paymentresponse-interface) object to inform the payment processor of the shipping option, along with other properties.
+Upon user approval for a payment request, the [`show()`](https://www.w3.org/TR/payment-request/#show) method's promise resolves. The app may use the `.shippingOption` property of the [`PaymentResponse`](https://www.w3.org/TR/payment-request/#paymentresponse-interface) object to inform the payment processor of the shipping option, along with other properties.
 
 <div style="clear:both;"></div>
 
@@ -529,7 +529,7 @@ You can also collect a user's email address, phone number or name by configuring
   </figure>
 </div>
 
-Upon user approval for a payment request, the [`show`](https://www.w3.org/TR/payment-request/#show) method's promise resolves. The app may use the `.payerPhone`, `.payerEmail` and/or `.payerName` properties of the [`PaymentResponse`](https://www.w3.org/TR/payment-request/#paymentresponse-interface) object to inform the payment processor of the user choice, along with other properties.
+Upon user approval for a payment request, the [`show()`](https://www.w3.org/TR/payment-request/#show) method's promise resolves. The app may use the `.payerPhone`, `.payerEmail` and/or `.payerName` properties of the [`PaymentResponse`](https://www.w3.org/TR/payment-request/#paymentresponse-interface) object to inform the payment processor of the user choice, along with other properties.
 
 <div style="clear:both;"></div>
 
@@ -666,7 +666,7 @@ As Payment Request API is an emerging feature, many browsers don't yet support i
           headers: {
             'Content-Type': 'application/json'
           },
-          body: result.toJSON()
+          body: JSON.stringify(result.toJSON())
         }).then(res => {
           // Only if successful
           if (res.status === 200) {

--- a/src/content/en/updates/2016/07/payment-request.md
+++ b/src/content/en/updates/2016/07/payment-request.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Payment Request is a new API for the open web that makes checkout flows easier, faster and consistent.
 
-{# wf_updated_on: 2016-07-30 #}
+{# wf_updated_on: 2016-12-06 #}
 {# wf_published_on: 2016-07-30 #}
 {# wf_tags: javascript,payment #}
 {# wf_featured_image: /web/updates/images/2016/07/payment-request/0.png #}
@@ -43,7 +43,7 @@ Let's peek at how Payment Request API works in some code. Here's a minimal examp
         location.href = '/checkout';
         return;
       }
-    
+
       // Supported payment methods
       var supportedInstruments = [{
         supportedMethods: [
@@ -51,7 +51,7 @@ Let's peek at how Payment Request API works in some code. Here's a minimal examp
           'diners', 'jcb', 'unionpay'
         ]
       }];
-    
+
       // Checkout details
       var details = {
         displayItems: [{
@@ -66,18 +66,14 @@ Let's peek at how Payment Request API works in some code. Here's a minimal examp
           amount: { currency: 'USD', value : '55.00' }
         }
       };
-    
+
       // 1. Create a `PaymentRequest` instance
       var request = new PaymentRequest(supportedInstruments, details);
-    
+
       // 2. Show the native UI with `.show()`
       request.show()
       // 3. Process the payment
       .then(result => {
-        var data = {};
-        data.methodName = result.methodName;
-        data.details    = result.details;
-    
         // POST the payment information to the server
         return fetch('/pay', {
           method: 'POST',
@@ -85,7 +81,7 @@ Let's peek at how Payment Request API works in some code. Here's a minimal examp
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: result.toJSON()
         }).then(response => {
           // Examine server response
           if (response.status === 200) {
@@ -100,9 +96,9 @@ Let's peek at how Payment Request API works in some code. Here's a minimal examp
         });
       });
     }
-    
+
     document.querySelector('#start').addEventListener('click', onBuyClicked);
-    
+
 
 ![](/web/updates/images/2016/07/payment-request/1.png)
 
@@ -112,7 +108,7 @@ When a  user taps on "Checkout", start a payment procedure by instantiating `Pay
 
 
     var request = new PaymentRequest(supportedInstruments, details);
-    
+
 
 ### 2. Show the native UI with .show()
 
@@ -123,7 +119,7 @@ Show the native payment UI with `show()`. Within this UI, a user can determine a
       .then(payment => {
         // pressed "Pay"
       });
-    
+
 
  <img src="/web/updates/images/2016/07/payment-request/2.png" style="max-width:340px">
  <img src="/web/updates/images/2016/07/payment-request/3.png" style="max-width:340px">
@@ -135,10 +131,6 @@ Upon user tapping on "PAY" button, a promise will be resolved and payment inform
 
       request.show()
       .then(result => {
-        var data = {};
-        data.methodName = result.methodName;
-        data.details    = result.details;
-    
         // POST the payment information to the server
         return fetch('/pay', {
           method: 'POST',
@@ -146,7 +138,7 @@ Upon user tapping on "PAY" button, a promise will be resolved and payment inform
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: result.toJSON()
         }).then(response => {
           // Examine server response
           if (response.status === 200) {
@@ -160,7 +152,7 @@ Upon user tapping on "PAY" button, a promise will be resolved and payment inform
           return result.complete('fail');
         });
       });
-    
+
 
  <img src="/web/updates/images/2016/07/payment-request/4.png" style="max-width:340px">
  <img src="/web/updates/images/2016/07/payment-request/5.png" style="max-width:340px">
@@ -177,7 +169,7 @@ If you are selling physical goods, you'll probably need to collect the user's sh
 
 ### Adding more payment solutions
 
-Credit card is not the only supported payment solution for Payment Request. There are a number of other payment services and solutions in the wild and the Payment Request API is designed to support as many of those as possible. Google is working to bring Android Pay to Chrome. Other third party solutions will be supported in the near future as well. Stay tuned for updates.
+Credit card is not the only supported payment solution for Payment Request. There are a number of other payment services and solutions in the wild and the Payment Request API is designed to support as many of those as possible. Google is working to bring [Android Pay to Chrome](/web/fundamentals/discovery-and-monetization/payment-request/android-pay). Other third party solutions will be supported in the near future as well. Stay tuned for updates.
 
 ## FAQ
 
@@ -187,8 +179,8 @@ Use Chrome for Android with version 53 or later. Requires secure origin - HTTPS,
 
 ### Is it possible to query the available payment methods?
 
-Currently not supported, but we're investigating ways of exposing this API in a privacy-sensitive way.  
-Payment Request API is designed to support the broadest possible array of payment methods. Each payment method is identified by a [payment method identifier](https://w3c.github.io/browser-payment-api/specs/architecture.html#dfn-payment-method-identifier).  
+Currently not supported, but we're investigating ways of exposing this API in a privacy-sensitive way.
+Payment Request API is designed to support the broadest possible array of payment methods. Each payment method is identified by a [payment method identifier](https://w3c.github.io/browser-payment-api/specs/architecture.html#dfn-payment-method-identifier).
 Payment Method Identifiers will support distributed extensibility, meaning that there does not need to be a central machine-readable registry to discover or register [payment methods](https://w3c.github.io/browser-payment-api/specs/architecture.html#dfn-payment-method).
 
 ### Do you plan on offering a coupon code?

--- a/src/content/en/updates/2016/07/payment-request.md
+++ b/src/content/en/updates/2016/07/payment-request.md
@@ -81,7 +81,7 @@ Let's peek at how Payment Request API works in some code. Here's a minimal examp
           headers: {
             'Content-Type': 'application/json'
           },
-          body: result.toJSON()
+          body: JSON.stringify(result.toJSON())
         }).then(response => {
           // Examine server response
           if (response.status === 200) {
@@ -138,7 +138,7 @@ Upon user tapping on "PAY" button, a promise will be resolved and payment inform
           headers: {
             'Content-Type': 'application/json'
           },
-          body: result.toJSON()
+          body: JSON.stringify(result.toJSON())
         }).then(response => {
           // Examine server response
           if (response.status === 200) {

--- a/src/content/ja/updates/2016/07/payment-request.md
+++ b/src/content/ja/updates/2016/07/payment-request.md
@@ -87,7 +87,7 @@ Payment Request API がどのように動作するのか、コードを追いな
           headers: {
             'Content-Type': 'application/json'
           },
-          body: result.toJSON()
+          body: JSON.stringify(result.toJSON())
         }).then(response => {
           // Examine server response
           if (response.status === 200) {
@@ -143,7 +143,7 @@ Payment Request API がどのように動作するのか、コードを追いな
           headers: {
             'Content-Type': 'application/json'
           },
-          body: result.toJSON()
+          body: JSON.stringify(result.toJSON())
         }).then(response => {
           // Examine server response
           if (response.status === 200) {

--- a/src/content/ja/updates/2016/07/payment-request.md
+++ b/src/content/ja/updates/2016/07/payment-request.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Payment Request は決済フローを簡単・高速で一貫性のあるものにする、オープン Web 向けの新しい API です。
 
-{# wf_updated_on: 2016-07-30 #}
+{# wf_updated_on: 2016-12-06 #}
 {# wf_published_on: 2016-07-30 #}
 
 # Payment Request API で簡単・高速な決済を実現する {: .page-title }
@@ -46,7 +46,7 @@ Payment Request API がどのように動作するのか、コードを追いな
         location.href = '/checkout';
         return;
       }
-    
+
       // Supported payment methods
       var supportedInstruments = [{
         supportedMethods: [
@@ -54,7 +54,7 @@ Payment Request API がどのように動作するのか、コードを追いな
           'diners', 'jcb', 'unionpay'
         ]
       }];
-    
+
       // Checkout details
       var details = {
         displayItems: [{
@@ -69,21 +69,17 @@ Payment Request API がどのように動作するのか、コードを追いな
           amount: { currency: 'USD', value : '55.00' }
         }
       };
-    
+
       // 1. Create a `PaymentRequest` instance
       // 1. `PaymentRequest` インスタンスを生成する
       var request = new PaymentRequest(supportedInstruments, details);
-    
+
       // 2. Show the native UI with `.show()`
       // 2. `.show()` を呼び出して、ネイティブ UI を表示する
       request.show()
       // 3. Process the payment
       // 3. 決済処理をおこなう
       .then(result => {
-        var data = {};
-        data.methodName = result.methodName;
-        data.details    = result.details;
-    
         // POST the payment information to the server
         return fetch('/pay', {
           method: 'POST',
@@ -91,7 +87,7 @@ Payment Request API がどのように動作するのか、コードを追いな
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: result.toJSON()
         }).then(response => {
           // Examine server response
           if (response.status === 200) {
@@ -106,9 +102,9 @@ Payment Request API がどのように動作するのか、コードを追いな
         });
       });
     }
-    
+
     document.querySelector('#start').addEventListener('click', onBuyClicked);
-    
+
 
 ![](/web/updates/images/2016/07/payment-request/1.png)
 
@@ -117,7 +113,7 @@ Payment Request API がどのように動作するのか、コードを追いな
 
 
     var request = new PaymentRequest(supportedInstruments, details);
-    
+
 
 ### 2. .show() を呼び出して、ネイティブ UI を表示する
 `show()` でネイティブの決済 UI を表示します。
@@ -128,7 +124,7 @@ Payment Request API がどのように動作するのか、コードを追いな
       .then(payment => {
         // pressed "Pay"
       });
-    
+
 
  <img src="/web/updates/images/2016/07/payment-request/2.png" style="max-width:340px">
  <img src="/web/updates/images/2016/07/payment-request/3.png" style="max-width:340px">
@@ -140,10 +136,6 @@ Payment Request API がどのように動作するのか、コードを追いな
 
       request.show()
       .then(result => {
-        var data = {};
-        data.methodName = result.methodName;
-        data.details    = result.details;
-    
         // POST the payment information to the server
         return fetch('/pay', {
           method: 'POST',
@@ -151,7 +143,7 @@ Payment Request API がどのように動作するのか、コードを追いな
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(data)
+          body: result.toJSON()
         }).then(response => {
           // Examine server response
           if (response.status === 200) {
@@ -165,7 +157,7 @@ Payment Request API がどのように動作するのか、コードを追いな
           return result.complete('fail');
         });
       });
-    
+
 
  <img src="/web/updates/images/2016/07/payment-request/4.png" style="max-width:340px">
  <img src="/web/updates/images/2016/07/payment-request/5.png" style="max-width:340px">
@@ -185,7 +177,7 @@ Payment Request API はもちろんこのようなケースをサポートして
 ### 決済ソリューションの追加
 Payment Request API がサポートする支払い手段はクレジットカードだけではありません。
 世の中には他にも多くの決済サービスやソリューションがあり、 Payment Request API はこれらのできる限り多くをサポートできるように設計されています。
-Google では、 Chrome で Android Pay を利用できるようにしようとしています。
+Google では、 [Chrome で Android Pay](/web/fundamentals/discovery-and-monetization/payment-request/android-pay) を利用できるようにしようとしています。
 他のサードパーティソリューションも近い将来サポートされる予定ですので、アップデートをお待ち下さい。
 
 ## FAQ
@@ -224,5 +216,5 @@ Payment Request API についてさらに知るために、いくつかのドキ
 * [Simple demos and sample code](https://googlechrome.github.io/samples/paymentrequest/)
 
 
-Translated By: 
+Translated By:
 {% include "web/_shared/contributors/kazukikanamori.html" %}


### PR DESCRIPTION
Changes are described in [this doc](https://docs.google.com/document/d/1I8ha1ySrPWhx80EB4CVPmThkD4ILFM017AfOA5gEFg4/edit#).

In addition to above,
- Changed the link to Android Pay sign-up page
- Fixed the wording around `abort()` as per described in #3153

cc: @jpmedley @zkoch @asieke @rsolomakhin