### PR TITLE
Eliminate false posatives on test for titles.

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -388,7 +388,7 @@ function validateMarkdown(filename, commonTags) {
         logError(filename, errMsg)
         errors++;
       }
-      matched = content.match(/^#[^#].*/gm);
+      matched = content.match(/^#\s{1}[^#].*/gm)
       if (matched) {
         numH1 += matched.length;
       }


### PR DESCRIPTION
Specifically, ^#[^#].* was catching CSS id selectors as well as legitimate markdown. We will probably need to revisit this.