### PR TITLE
Fix tags for new articles.

### DIFF
--- a/src/content/en/updates/2016/12/performant-parallaxing.md
+++ b/src/content/en/updates/2016/12/performant-parallaxing.md
@@ -4,7 +4,7 @@ description: With a little mathematical wriggling, it's possible to have paralla
 
 {# wf_updated_on: 2016-12-02 #}
 {# wf_published_on: 2016-12-02 #}
-{# wf_tags: performance,parallax,sticky,3d,style #}
+{# wf_tags: performance,parallax,css,3d,style #}
 {# wf_featured_image: /web/updates/images/2016/12/performant-parallaxing/featured-image.jpg #}
 {# wf_featured_snippet: When used judiciously paralaxing can add of depth and subtlety to a web app. #}
 

--- a/src/content/en/updates/2016/12/position-sticky.md
+++ b/src/content/en/updates/2016/12/position-sticky.md
@@ -4,7 +4,7 @@ description: position:sticky. It's back!
 
 {# wf_updated_on: 2016-12-07 #}
 {# wf_published_on: 2016-12-07 #}
-{# wf_tags: performance,sticky,style #}
+{# wf_tags: performance,css,style #}
 {# wf_featured_image: /web/updates/images/generic/visibility.png #} #}
 {# wf_featured_snippet: After a long time absent from Chrome, position:sticky is back. #}
 

--- a/src/data/commonTags.json
+++ b/src/data/commonTags.json
@@ -1,4 +1,5 @@
 [
+  "3d",
   "absolute-positioned",
   "accessibility",
   "addtohomescreen",
@@ -144,6 +145,7 @@
   "pagespeed",
   "pagevisibility",
   "paint",
+  "parallax",
   "payload",
   "payment",
   "performance",


### PR DESCRIPTION
@petele 

These were also causing test failures when I tried to publish. I judged that 'sticky' was too specific because we don't have other CSS rules and selectors in the approved list. 'Parallax' and '3d' seemed better candidates.