### PR TITLE
Fixed nit in notifications sample

### DIFF
--- a/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
+++ b/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
@@ -295,14 +295,10 @@ characteristic changes on the device:
     .then(device => device.gatt.connect())
     .then(server => server.getPrimaryService('heart_rate'))
     .then(service => service.getCharacteristic('heart_rate_measurement'))
+    .then(characteristic => characteristic.startNotifications())
     .then(characteristic => {
-      return characteristic.startNotifications()
-      .then(_ => {
-        characteristic.addEventListener('characteristicvaluechanged',
-                                        handleCharacteristicValueChanged);
-      });
-    })
-    .then(_ => {
+      characteristic.addEventListener('characteristicvaluechanged',
+                                      handleCharacteristicValueChanged);
       console.log('Notifications have been started.');
     })
     .catch(error => { console.log(error); });


### PR DESCRIPTION
Since Chrome 55, `startNotifications` returns `characteristic`. This patch updates notifications sample to reflect this change.

R: @petele 