### PR TITLE
[devtools] add more inline feedback to JS debugging tutorial

### DIFF
--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/3.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/3.html
@@ -1,0 +1,8 @@
+{% setvar question "Are you currently paused on line 19?" %}
+{% setvar category "DevTools" %}
+{% setvar label "JS / Get Started / Paused On Correct Line" %}
+{% setvar success_button "Yes" %}
+{% setvar success_response "Great. You're right where you should be." %}
+{% setvar fail_button "No" %}
+{% setvar fail_response "Hmm, something's wrong." %}
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/4.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/4.html
@@ -1,0 +1,8 @@
+{% setvar question "Do you see double-quotes around the value of sum?" %}
+{% setvar category "DevTools" %}
+{% setvar label "JS / Get Started / Value Of Sum Is A String" %}
+{% setvar success_button "I See Double-Quotes" %}
+{% setvar success_response "Awesome. Then you can confirm that the value of sum appears to be a string, when it should be a number." %}
+{% setvar fail_button "No, I Don't See Double-Quotes" %}
+{% setvar fail_response "Uh oh. That's not how the demo is supposed to behave." %}
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/5.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/5.html
@@ -1,0 +1,8 @@
+{% setvar question "When you ran the expression in the Console, did it evaluate to 6?" %}
+{% setvar category "DevTools" %}
+{% setvar label "JS / Get Started / Console Evaluation Is Correct" %}
+{% setvar success_button "Yup, It Evaluated To 6" %}
+{% setvar success_response "You're good at this. Keep going, you're almost done!" %}
+{% setvar fail_button "No, It Evaluated To Something Else" %}
+{% setvar fail_response "Double-check that you typed everything correctly. If you're still seeing this other value, please let us know." %}
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/6.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/6.html
@@ -1,0 +1,8 @@
+{% setvar question "Is the demo working now?" %}
+{% setvar category "DevTools" %}
+{% setvar label "JS / Get Started / Demo Is Fixed" %}
+{% setvar success_button "Yes, It's Adding Correctly Now" %}
+{% setvar success_response "You did it!" %}
+{% setvar fail_button "No, It's Still Not Working" %}
+{% setvar fail_response "Ah, dang. So close." %}
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/7.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/7.html
@@ -1,0 +1,8 @@
+{% setvar question "Was this tutorial helpful?" %}
+{% setvar category "DevTools" %}
+{% setvar label "JS / Get Started / Tutorial Is Helpful" %}
+{% setvar success_button "Yes, I Learned A Lot" %}
+{% setvar success_response "We're glad we helped :)" %}
+{% setvar fail_button "No, I Was Looking For Something Else" %}
+{% setvar fail_response "Feedback like this is how we make the docs better. Please tell us more!" %}
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/8.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/8.html
@@ -1,0 +1,8 @@
+{% setvar question "Was this tutorial too long?" %}
+{% setvar category "DevTools" %}
+{% setvar label "JS / Get Started / Tutorial Is Too Long" %}
+{% setvar success_button "No, I Think The Length Is Fine" %}
+{% setvar success_response "OK, cool!" %}
+{% setvar fail_button "Yes, Please Make It Shorter" %}
+{% setvar fail_response "If there are any sections you think we should remove, please tell us more." %}
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/index.md
+++ b/src/content/en/tools/chrome-devtools/javascript/index.md
@@ -130,6 +130,8 @@ That's the basic idea of stepping through code. If you look at the code in
 you can use another type of breakpoint to pause the code closer to the
 location of the bug.
 
+{% include "web/tools/chrome-devtools/javascript/_feedback/3.html" %}
+
 [into]: /web/tools/chrome-devtools/images/step-into.png
 [over]: /web/tools/chrome-devtools/images/step-over.png
 
@@ -155,6 +157,8 @@ line-of-code breakpoint. Try it now:
 
 The value of `sum` looks suspicious. It looks like it's being evaluated as
 a string, when it should be a number. This may be the cause of the bug.
+
+{% include "web/tools/chrome-devtools/javascript/_feedback/4.html" %}
 
 ## Step 5: Check variable values
 
@@ -211,6 +215,8 @@ fixes for the bug you just discovered. Try it now:
        </figcaption>
      </figure>
 
+{% include "web/tools/chrome-devtools/javascript/_feedback/5.html" %}
+
 [add]: /web/tools/chrome-devtools/javascript/imgs/add-expression.png
 
 ## Step 6: Apply a fix
@@ -241,6 +247,8 @@ Keep in mind that this workflow only applies a fix to the code that is
 running in your browser. It won't fix the code for all users that run your
 page. To do that, you need to fix the code that's running on the servers
 that serve your page.
+
+{% include "web/tools/chrome-devtools/javascript/_feedback/6.html" %}
 
 [deactivate]: /web/tools/chrome-devtools/images/deactivate-breakpoints-button.png
 
@@ -274,36 +282,6 @@ tutorial. Check out the link below to learn more about them.
 
 Help us make this tutorial better by answering the questions below.
 
-{% framebox width="auto" height="auto" %}
+{% include "web/tools/chrome-devtools/javascript/_feedback/7.html" %}
 
-<p>Did you complete the tutorial successfully?</p>
-
-<button class="gc-analytics-event"
-        data-category="DevTools / JS / Get Started"
-        data-label="Completed / Yes">Yes</button>
-
-<button class="gc-analytics-event"
-        data-category="DevTools / JS / Get Started"
-        data-label="Completed / No">No</button>
-
-<p>Did this tutorial contain the information you were looking for?</p>
-
-<button class="gc-analytics-event"
-        data-category="DevTools / JS / Get Started"
-        data-label="Relevant / Yes">Yes</button>
-
-<button class="gc-analytics-event"
-        data-category="DevTools / JS / Get Started"
-        data-label="Relevant / No">No</button>
-
-<p>Was the tutorial too long?</p>
-
-<button class="gc-analytics-event"
-        data-category="DevTools / JS / Get Started"
-        data-label="Too Long / Yes">Yes</button>
-
-<button class="gc-analytics-event"
-        data-category="DevTools / JS / Get Started"
-        data-label="Too Long / No">No</button>
-
-{% endframebox %}
+{% include "web/tools/chrome-devtools/javascript/_feedback/8.html" %}


### PR DESCRIPTION
Building off of #4042, this adds more inline feedback to the Debug JS tutorial.

Note: these widgets don't work from the local development server (`startappengine.sh`). This is a limitation of the server. The widgets aren't broken.

