### PR TITLE
Add link to Media Session article

### DIFF
--- a/src/content/en/updates/2015/07/media-notifications.md
+++ b/src/content/en/updates/2015/07/media-notifications.md
@@ -47,7 +47,7 @@ Note that:
 
 With the [Media Session API](/web/updates/2017/02/media-session), you can
 customize media notifications by providing metadata for the media your web app
-is playing. It also allows you to handle media related events such as seeking
-or track changing which may come from notifications or media keys.
+is playing. This API also allows you to handle media related events such as
+seeking or track changing which may come from notifications or media keys.
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2015/07/media-notifications.md
+++ b/src/content/en/updates/2015/07/media-notifications.md
@@ -2,15 +2,13 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: When audio or video is playing on a web page, a notification showing the page title and a play/pause button is displayed in the notification tray and on the lock screen. The notification can be used to pause/resume play or return to the page playing the media.
 
-{# wf_updated_on: 2015-07-20 #}
+{# wf_updated_on: 2017-07-09 #}
 {# wf_published_on: 2015-07-20 #}
-{# wf_tags: news,audio,video,android,notifications #}
+{# wf_tags: news,audio,video,android,media,notifications #}
 
 # Media playback notifications for Chrome on Android {: .page-title }
 
 {% include "web/_shared/contributors/samdutton.html" %}
-
-
 
 Chrome 45 Beta introduces a handy new feature for controlling audio and video playback.
 
@@ -18,17 +16,20 @@ When an audio or video element is playing on a web page, a notification showing 
 
 Great for controlling music apps and for many other audio and video use cases.
 
-Here's an animated GIF of a notification displayed over a web page:
-
-<p style="text-align: center;">
-  <img src="/web/updates/images/2015-07-21-media-notifications/notification-over-web-page.gif" alt="Notification displayed over a web page">
-</p>
-
-This animation shows a notification over the Android lock screen:
-
-<p style="text-align: center;">
-  <img src="/web/updates/images/2015-07-21-media-notifications/notification-over-lock-screen.gif" alt="Notification displayed over the Android lock screen">
-</p>
+<div class="clearfix"></div>
+<div class="attempt-left">
+  <figure>
+    <img src="/web/updates/images/2015-07-21-media-notifications/notification-over-web-page.gif" alt="Notification displayed over a web page">
+    <figcaption>Notification displayed over a web page</figcaption>
+  </figure>
+</div>
+<div class="attempt-right">
+  <figure>
+    <img src="/web/updates/images/2015-07-21-media-notifications/notification-over-lock-screen.gif" alt="Notification displayed over the Android lock screen">
+    <figcaption>Notification displayed over the Android lock screen</figcaption>
+  </figure>
+</div>
+<div class="clearfix"></div>
 
 The screencast below shows the process of displaying a notification and controlling video playback on a web page:
 
@@ -41,17 +42,12 @@ The screencast below shows the process of displaying a notification and controll
 
 Note that:
 
-* The lock screen notification is currently only shown in Android L and later. Support for J and K devices is in progress.
 * Notifications are only shown for media over five seconds in length.
 * There is no notification for audio from the Web Audio API unless it is played back via an audio element.
 
-We are currently working on implementing the <a href="https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/dLWDxYgxzQ8" title="MediaSession Intent to Implement">MediaSession API</a>. Although this looks like a simple addition to Chrome, it will be the basis for implementation of future media control APIs. MediaSession will enable control over media in a web page, such as the ability to move between tracks or display extra metadata about the currently playing track. You could imagine that this API might be integrated with platforms such as Android Wear, or even enable remote controls on Bluetooth devices to extend the reach of web experiences.
-
-We welcome your feedback on the MediaSession API. You can follow the <a href="https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/dLWDxYgxzQ8" title="Intent to Implement thread on Google Groups">Intent to Implement discussion</a>, comment on the <a href="https://mediasession.spec.whatwg.org/" title="WHATWG Media Session spec">WHATWG standard</a>, or track our <a href="https://crbug.com/497735" title="Implementation bug on crbug.com">implementation bug</a>.
-
-
-
-
-
+With the [Media Session API](/web/updates/2017/02/media-session), you can
+customize media notifications by providing metadata for the media your web app
+is playing. It also allows you to handle media related events such as seeking
+or track changing which may come from notifications or media keys.
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
@samdutton Now that the Media Session article is up, I thought we should link it from your existing article at https://developers.google.com/web/updates/2015/07/media-notifications

WDYT?

FYI @mounirlamouri