### PR TITLE
Fix escaping bug

### DIFF
--- a/src/content/en/updates/2017/02/navigation-preload.md
+++ b/src/content/en/updates/2017/02/navigation-preload.md
@@ -49,7 +49,7 @@ responding using the network…
     height: 38px;
     display: flex;
   }
-  .group > div {
+  .group div {
     display: flex;
     align-items: center;
     font: normal 1.2rem/1 sans-serif;
@@ -94,7 +94,7 @@ way to perform navigation requests in parallel:
     height: 38px;
     display: flex;
   }
-  .group > div {
+  .group div {
     display: flex;
     align-items: center;
     font: normal 1.2rem/1 sans-serif;


### PR DESCRIPTION
This works differently on live to how it works in the dev server. On live the `>` is escaped to `&gt;` breaking the layout.