### PR TITLE
[devtools] update inline feedback

### DIFF
--- a/src/content/en/_shared/feedback.html
+++ b/src/content/en/_shared/feedback.html
@@ -3,13 +3,14 @@
   usage.
 {% endcomment %}
 {% framebox width="auto" height="auto" enable_widgets="true" %}
-{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
 <style>
   .wf-feedback--hidden {
     display: none;
   }
 </style>
+{% if question %}
 <p>{{ question }}<p>
+{% endif %}
 <button type="button" class="button button-primary gc-analytics-event"
     data-category="{{ category }}" data-label="{{ label }}" data-value="1">
   {{ success_button }}
@@ -19,10 +20,7 @@
   {{ fail_button }}
 </button>
 <aside class="success wf-feedback--hidden">{{ success_response }}</aside>
-<aside class="caution wf-feedback--hidden">
-  {{ fail_response }} Please <a href="{{ url }}">open an issue on our docs
-  repo</a> and tell us more.
-</aside>
+<aside class="caution wf-feedback--hidden">{{ fail_response }}</aside>
 <script>
   function disableButtons() {
     successButton.disabled = true;

--- a/src/content/en/resources/widgets.md
+++ b/src/content/en/resources/widgets.md
@@ -197,17 +197,21 @@ Gain more feedback on your doc by asking your readers yes / no questions.
 
 ### Example
 
-See question at bottom of [Get Started Debugging JS][inline feedback example].
+See [Get Started Debugging JS][inline feedback example] for examples. Each of
+the questions at the bottom of the sections use the Inline Feedback widget.
 
-[inline feedback example]: /web/tools/chrome-devtools/javascript/#step-1
+[inline feedback example]: /web/tools/chrome-devtools/javascript/
 
 ### Usage
 
 1. Make a directory called `_feedback` near the doc that'll include the feedback.
+2. If you want to include a question before your buttons, then copy
+   `/src/content/en/tools/chrome-devtools/javascript/_feedback/7.html` into
+   your `_feedback` directory. Else, copy `.../1.html`.
 2. Copy `/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html`
    into your `_feedback` directory.
-3. Modify all of the variables to suit your question. All variables are
-   required.
+3. Modify all of the variables to suit your question. All variables except
+   `question` are required.
 4. Include `_feedback/1.html` into your doc, like this:
 
 <pre class="prettyprint">
@@ -234,5 +238,5 @@ analytics data.
 
 See Google Analytics > Behavior > Events. When the user clicks "fail",
 a value of 0 is sent for this label. When user clicks "success", a value
-of 1 is sent. So, you can determine how much users are clicking
-"success" or "fail" based on a 0 to 1 scale.
+of 1 is sent. So, a value of 1 means that users are always clicking your
+"success" button.

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html
@@ -1,8 +1,8 @@
-{% setvar question "Did you successfully reproduce the bug?" %}
 {% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / Reproduced The Bug" %}
-{% setvar success_button "Yup!" %}
+{% setvar label "JS / Get Started / (1) Reproduced The Bug" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "I reproduced the bug" %}
 {% setvar success_response "Awesome. Keep going and you'll learn how to spot this bug in DevTools." %}
-{% setvar fail_button "Something's wrong" %}
-{% setvar fail_response "Sorry to hear that." %}
+{% setvar fail_button "I can't reproduce the bug" %}
+{% setvar fail_response %}Sorry to hear that. Please <a href="{{url}}">open an issue</a> and tell us more.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/2.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/2.html
@@ -1,8 +1,8 @@
-{% setvar question "Were you able to trigger the breakpoint?" %}
 {% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / Triggered The Breakpoint" %}
-{% setvar success_button "Yes" %}
+{% setvar label "JS / Get Started / (2) Triggered The Breakpoint" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "I triggered the breakpoint" %}
 {% setvar success_response "Good job!" %}
-{% setvar fail_button "No" %}
-{% setvar fail_response "Ah, dang." %}
+{% setvar fail_button "I can't trigger the breakpoint" %}
+{% setvar fail_response %}Ah, dang. Please <a href="{{url}}">open an issue</a> and tell us what happened.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/3.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/3.html
@@ -1,8 +1,8 @@
-{% setvar question "Are you currently paused on line 19?" %}
 {% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / Paused On Correct Line" %}
-{% setvar success_button "Yes" %}
+{% setvar label "JS / Get Started / (3) Paused On Correct Line" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "I'm paused on line 19" %}
 {% setvar success_response "Great. You're right where you should be." %}
-{% setvar fail_button "No" %}
-{% setvar fail_response "Hmm, something's wrong." %}
+{% setvar fail_button "I'm paused on another line" %}
+{% setvar fail_response %}Hmm, something's wrong. Please <a href="{{url}}">open an issue</a> and tell us what line you're paused on.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/4.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/4.html
@@ -1,8 +1,8 @@
-{% setvar question "Do you see double-quotes around the value of sum?" %}
 {% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / Value Of Sum Is A String" %}
-{% setvar success_button "I See Double-Quotes" %}
+{% setvar label "JS / Get Started / (4) Value Of Sum Is A String" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "I See Double-Quotes Around The Value Of Sum" %}
 {% setvar success_response "Awesome. Then you can confirm that the value of sum appears to be a string, when it should be a number." %}
-{% setvar fail_button "No, I Don't See Double-Quotes" %}
-{% setvar fail_response "Uh oh. That's not how the demo is supposed to behave." %}
+{% setvar fail_button "I Don't See Double-Quotes" %}
+{% setvar fail_response %}Uh oh. That's not how the demo is supposed to behave. If you <a href="{{url}}">open an issue</a>, we can provide further help.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/5.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/5.html
@@ -1,8 +1,8 @@
-{% setvar question "When you ran the expression in the Console, did it evaluate to 6?" %}
 {% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / Console Evaluation Is Correct" %}
-{% setvar success_button "Yup, It Evaluated To 6" %}
+{% setvar label "JS / Get Started / (5) Console Evaluation Is Correct" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "The Expression Evaluated To 6" %}
 {% setvar success_response "You're good at this. Keep going, you're almost done!" %}
-{% setvar fail_button "No, It Evaluated To Something Else" %}
-{% setvar fail_response "Double-check that you typed everything correctly. If you're still seeing this other value, please let us know." %}
+{% setvar fail_button "It Evaluated To Something Else" %}
+{% setvar fail_response %}Double-check that you typed everything correctly. If you're still seeing this other value, please <a href="{{url}}">open an issue</a> let us know what value you're seeing.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/6.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/6.html
@@ -1,8 +1,8 @@
-{% setvar question "Is the demo working now?" %}
 {% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / Demo Is Fixed" %}
-{% setvar success_button "Yes, It's Adding Correctly Now" %}
+{% setvar label "JS / Get Started / (6) Demo Is Fixed" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "I Fixed The Demo!" %}
 {% setvar success_response "You did it!" %}
-{% setvar fail_button "No, It's Still Not Working" %}
-{% setvar fail_response "Ah, dang. So close." %}
+{% setvar fail_button "It's Still Not Working" %}
+{% setvar fail_response %}Ah, dang. So close. Please <a href="{{url}}">open an issue</a> and tell us what you're seeing.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/7.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/7.html
@@ -1,8 +1,9 @@
 {% setvar question "Was this tutorial helpful?" %}
 {% setvar category "DevTools" %}
 {% setvar label "JS / Get Started / Tutorial Is Helpful" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
 {% setvar success_button "Yes, I Learned A Lot" %}
 {% setvar success_response "We're glad we helped :)" %}
 {% setvar fail_button "No, I Was Looking For Something Else" %}
-{% setvar fail_response "Feedback like this is how we make the docs better. Please tell us more!" %}
+{% setvar fail_response %}Please <a href="{{url}}">open an issue</a> and tell us what you were hoping to learn!{% endsetvar %}
 {% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/8.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/8.html
@@ -1,8 +1,9 @@
 {% setvar question "Was this tutorial too long?" %}
 {% setvar category "DevTools" %}
 {% setvar label "JS / Get Started / Tutorial Is Too Long" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
 {% setvar success_button "No, I Think The Length Is Fine" %}
 {% setvar success_response "OK, cool!" %}
 {% setvar fail_button "Yes, Please Make It Shorter" %}
-{% setvar fail_response "If there are any sections you think we should remove, please tell us more." %}
+{% setvar fail_response %}If there are any sections you think we should remove, please <a href="{{url}}">open an issue</a> and tell us more.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}


### PR DESCRIPTION
* Removes hardcoding of `url` from the main feedback logic.
* Makes `question` optional. If omitted, then it's assumed that all of needed context will be provided in the button text. See `web/tools/chrome-devtools/javascript` on the staging site for an example.
* Makes the fail response more flexible.
* Prefixes the labels with numbers, so that I can keep track of the ordering of questions in Google Analytics
* Updates doc