### PR TITLE
Fixes typos in zh-cn fundamentals/getting-started/codelabs/offline/index.md

### DIFF
--- a/src/content/zh-cn/fundamentals/getting-started/codelabs/offline/index.md
+++ b/src/content/zh-cn/fundamentals/getting-started/codelabs/offline/index.md
@@ -146,13 +146,13 @@ Horner](https://airhorner.com)。它是 Web Audio API 来播放并操作汽笛�
 
 <img src="images/image03.png" width="624" height="350" />
 
-### 高频问答
+### 常见问题
 
 **为什么要把 service worker 放在根目录？我为什么不能将它放在 `/scripts` 目录下？**
 
 为了安全，一个 service worker 只能控制与它相同目录或者相同目录下子目录中的页面。这意味着如果你将 service worker 放在 scripts 目录下，它只会作用于 `/scripts` 目录，以及 scripts 中的子目录（比如：`/scripts/test/`)。你的应用应该不会只存在于那么。
 
-## 按装应用资源
+## 安装应用资源
 
 
 

--- a/src/content/zh-cn/fundamentals/getting-started/codelabs/offline/index.md
+++ b/src/content/zh-cn/fundamentals/getting-started/codelabs/offline/index.md
@@ -146,7 +146,7 @@ Horner](https://airhorner.com)。它是 Web Audio API 来播放并操作汽笛�
 
 <img src="images/image03.png" width="624" height="350" />
 
-### 常见问题
+### 高频问答
 
 **为什么要把 service worker 放在根目录？我为什么不能将它放在 `/scripts` 目录下？**
 


### PR DESCRIPTION
更正错别字