### PR TITLE
Add Media Session to HTTP 203 podcast

### DIFF
--- a/src/content/en/_shared/http-203-podcast.html
+++ b/src/content/en/_shared/http-203-podcast.html
@@ -1,0 +1,30 @@
+<a href="http://feeds.feedburner.com/Http203Podcast">
+  <span class="material-icons">rss_feed</span>
+  Subscribe
+</a>
+
+<script>
+  if ('mediaSession' in navigator) {
+
+    document.addEventListener('DOMContentLoaded', function() {
+      var audio = document.querySelector('#podcast');
+
+      audio.addEventListener('play', function() {
+        navigator.mediaSession.metadata = new MediaMetadata({
+          title: document.title,
+          artist: 'Paul Lewis & Jake Archibald',
+          album: 'HTTP 203',
+          artwork: [{ src: document.querySelector('#artwork').src }]
+        });
+      });
+
+      navigator.mediaSession.setActionHandler('seekbackward', function() {
+        audio.currentTime = Math.max(audio.currentTime - 30, 0);
+      });
+
+      navigator.mediaSession.setActionHandler('seekforward', function() {
+        audio.currentTime = Math.min(audio.currentTime + 30, audio.duration);
+      });
+    });
+  }
+</script>

--- a/src/content/en/shows/http203/podcast/http-203-cors-forced-layouts-and-raptor-kebab-shops.md
+++ b/src/content/en/shows/http203/podcast/http-203-cors-forced-layouts-and-raptor-kebab-shops.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: Why does nobody seem to include CORS headers on their files? And can Paul answer Jake's dreaded CORS pre-flight quiz?
 
-{# wf_updated_on: 2015-10-06 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2015-10-06 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/episode-2.mp3 #}
 {# wf_podcast_duration: 00:30:37 #}
@@ -14,7 +14,7 @@ description: Why does nobody seem to include CORS headers on their files? And ca
 
 Paul and Jake talk about CORS, Layout, and which of them has the evolutionary advantage.
 
-<img src="/web/shows/http203/podcast/images/http203-episode-2-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-2-art.jpg" class="attempt-right">
 
 In this episode:
 
@@ -26,12 +26,10 @@ In this episode:
 * Balding and Common Misconceptions
 * Movie Voices
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/episode-2.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/episode-2.mp3" controls preload="none">
 
 
 

--- a/src/content/en/shows/http203/podcast/http-203-legs-wasps-and-web-stuff.md
+++ b/src/content/en/shows/http203/podcast/http-203-legs-wasps-and-web-stuff.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: Paul's been booting frameworks, and unfortunately Jake connected his brain to Twitter
 
-{# wf_updated_on: 2017-01-17 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2017-01-17 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/episode-6.mp3 #}
 {# wf_podcast_duration: 00:45:42 #}
@@ -12,7 +12,7 @@ description: Paul's been booting frameworks, and unfortunately Jake connected hi
 
 # Legs, Wasps, and Eventually Some Web Stuff. {: .page-title }
 
-<img src="/web/shows/http203/podcast/images/http203-episode-5-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-5-art.jpg" class="attempt-right">
 
 In this episode:
 
@@ -21,12 +21,10 @@ In this episode:
 * How to fight for quality in the face of deadlines.
 * What we're planning on doing in 2017, which includes: media, presentation APIs, cancelable fetch, background fetch, & range requests.
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/episode-6.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/episode-6.mp3" controls preload="none">
 
 
 

--- a/src/content/en/shows/http203/podcast/http-203-making-burgers-and-maintainable-code.md
+++ b/src/content/en/shows/http203/podcast/http-203-making-burgers-and-maintainable-code.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: How can writing code be like making a burger? Turns out, by the power of weird segues, it can!
 
-{# wf_updated_on: 2015-09-20 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2015-09-20 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/episode-1.mp3 #}
 {# wf_podcast_duration: 00:30:13 #}
@@ -14,7 +14,7 @@ description: How can writing code be like making a burger? Turns out, by the pow
 
 How can writing code be like making a burger? Turns out, by the power of weird segues, it can!
 
-<img src="/web/shows/http203/podcast/images/http203-episode-1-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-1-art.jpg" class="attempt-right">
 
 In this episode:
 
@@ -25,9 +25,7 @@ In this episode:
 * Camels
 * Intl
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/episode-1.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/episode-1.mp3" controls preload="none">

--- a/src/content/en/shows/http203/podcast/http-203-poetry-and-delegated-event-listeners.md
+++ b/src/content/en/shows/http203/podcast/http-203-poetry-and-delegated-event-listeners.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: Jake brings his A+ poetry game, and Paul muses over the performance implications of event delegation.
 
-{# wf_updated_on: 2015-10-24 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2015-10-24 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/episode-3.mp3 #}
 {# wf_podcast_duration: 00:32:30 #}
@@ -14,7 +14,7 @@ description: Jake brings his A+ poetry game, and Paul muses over the performance
 
 Jake brings his A+ poetry game, and Paul muses over the performance implications of event delegation.
 
-<img src="/web/shows/http203/podcast/images/http203-episode-3-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-3-art.jpg" class="attempt-right">
 
 In this episode:
 
@@ -25,9 +25,7 @@ In this episode:
  * Event delegation
  * Insecure content in Chrome
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/episode-3.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/episode-3.mp3" controls preload="none">

--- a/src/content/en/shows/http203/podcast/http-203-promises-mistakes-and-door-handles.md
+++ b/src/content/en/shows/http203/podcast/http-203-promises-mistakes-and-door-handles.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: "Jake's discovered display: contents, while Paul is concerned about people microbenchmarking ES2015 features."
 
-{# wf_updated_on: 2016-02-24 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2016-02-24 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/episode-4.mp3 #}
 {# wf_podcast_duration: 00:52:25 #}
@@ -14,7 +14,7 @@ description: "Jake's discovered display: contents, while Paul is concerned about
 
 Paul and Jake talk about how to Promisify Node, the sins of CSS, and how hard it can be to find a door handle.
 
-<img src="/web/shows/http203/podcast/images/http203-episode-4-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-4-art.jpg" class="attempt-right">
 
 In this episode:
 
@@ -24,9 +24,7 @@ In this episode:
 * [Cancellable Promises](https://github.com/tc39/proposal-cancelable-promises/)
 * [CSS Mistakes](https://wiki.csswg.org/ideas/mistakes)
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/episode-4.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/episode-4.mp3" controls preload="none">

--- a/src/content/en/shows/http203/podcast/http-203-quizzing-animating-and-canceling.md
+++ b/src/content/en/shows/http203/podcast/http-203-quizzing-animating-and-canceling.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: Jake is worse at quizzes than Paul.
 
-{# wf_updated_on: 2017-03-01 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2017-03-01 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/episode-7.mp3 #}
 {# wf_podcast_duration: 00:47:39 #}
@@ -12,7 +12,7 @@ description: Jake is worse at quizzes than Paul.
 
 # Quizzing, animating, and canceling {: .page-title }
 
-<img src="/web/shows/http203/podcast/images/http203-episode-5-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-5-art.jpg" class="attempt-right">
 
 In this episode:
 
@@ -23,12 +23,10 @@ In this episode:
 * Animating height with performance.
 * [Fetch canceling](https://github.com/whatwg/fetch/issues/447#issuecomment-281731850).
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/episode-7.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/episode-7.mp3" controls preload="none">
 
 
 

--- a/src/content/en/shows/http203/podcast/http-203-springy-css-storage-and-bisecting.md
+++ b/src/content/en/shows/http203/podcast/http-203-springy-css-storage-and-bisecting.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: Paul has been playing with springy animations in the Safari Tech Preview, and Jake loves pubs that are also... windmills?
 
-{# wf_updated_on: 2016-07-03 #}
+{# wf_updated_on: 2017-03-03 #}
 {# wf_published_on: 2016-07-03 #}
 {# wf_podcast_audio: https://storage.googleapis.com/http-203-podcast/epsiode-5.mp3 #}
 {# wf_podcast_duration: 00:59:56 #}
@@ -14,7 +14,7 @@ description: Paul has been playing with springy animations in the Safari Tech Pr
 
 In this episode:
 
-<img src="/web/shows/http203/podcast/images/http203-episode-5-art.jpg" class="attempt-right">
+<img id="artwork" src="/web/shows/http203/podcast/images/http203-episode-5-art.jpg" class="attempt-right">
 
 * [HTTP/2 Push](https://www.igvita.com/2013/06/12/innovating-with-http-2.0-server-push/)
 * [Bad slides](https://twitter.com/TStrothjohann/status/744816462745862144)
@@ -29,9 +29,7 @@ Oh and this podcast is also a 59 minutes long because it's also a windmill.
 
 FYI: Jake's fault.
 
-<a href="http://feeds.feedburner.com/Http203Podcast">
-  <span class="material-icons">rss_feed</span>
-  Subscribe
-</a>
 
-<audio src="https://storage.googleapis.com/http-203-podcast/epsiode-5.mp3" controls preload="none">
+{% include "web/_shared/http-203-podcast.html" %}
+
+<audio id="podcast" src="https://storage.googleapis.com/http-203-podcast/epsiode-5.mp3" controls preload="none">


### PR DESCRIPTION
This PR adds support for the Media Session API to  HTTP 203 podcast pages.

![screenshot_20170303-125455 - edited](https://cloud.githubusercontent.com/assets/634478/23550367/c27c9cd0-0010-11e7-8f17-21de5752eac8.png)


```
git grep -l '<img' *.md | xargs sed -i 's/<img/<img id="artwork"/g'
git grep -l '<audio' *.md | xargs sed -i 's/<audio/<audio id="podcast"/g'
git grep -l '<a href="http:\/\/feeds.feedburner.com\/Http203Podcast">' *.md | xargs sed -i '/<a href="http:\/\/feeds.feedburner.com\/Http203Podcast">/d'
git grep -l '<span class="material-icons">rss_feed<\/span>' *.md | xargs sed -i '/<span class="material-icons">rss_feed<\/span>/d'
git grep -l '  Subscribe' *.md | xargs sed -i '/  Subscribe/d'
git grep -l '<\/a>' *.md | xargs sed -i '/<\/a>/d'
git grep -l '<audio' *.md | xargs sed -i 's/<audio/{% include "web\/_shared\/http-203-podcast.html" %}\n\n<audio/g'
```

FYI: @jakearchibald @paullewis 