### PR TITLE
[lighthouse] add inline feedback to audit docs

### DIFF
--- a/src/content/en/tools/lighthouse/audits/_feedback/_helpful.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/_helpful.html
@@ -1,0 +1,9 @@
+{% setvar category "Lighthouse" %}
+{% setvar question "Was this page helpful?" %}
+{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
+{% setvar success_button "Yes" %}
+{% setvar success_response "Thanks for the feedback." %}
+{% setvar fail_button "No" %}
+{% setvar fail_response %}Thanks for the feedback. You can help us make this page better by <a href="{{url}}" target="_blank">opening an issue</a> and telling us more.{% endsetvar %}
+<h2>Feedback</h2>
+{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/alt-attribute.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/alt-attribute.html
@@ -1,0 +1,2 @@
+{% setvar label "Alt Attribute / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/appcache.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/appcache.html
@@ -1,0 +1,2 @@
+{% setvar label "AppCache / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/aria-allowed-attributes.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/aria-allowed-attributes.html
@@ -1,0 +1,2 @@
+{% setvar label "ARIA Allowed Attributes / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/blocking-resources.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/blocking-resources.html
@@ -1,0 +1,2 @@
+{% setvar label "Blocking Resources / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/cache-contains-start_url.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/cache-contains-start_url.html
@@ -1,0 +1,2 @@
+{% setvar label "Cache Contains Start URL / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/console-time.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/console-time.html
@@ -1,0 +1,2 @@
+{% setvar label "console.time() / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/content-sized-correctly-for-viewport.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/content-sized-correctly-for-viewport.html
@@ -1,0 +1,2 @@
+{% setvar label "Content Sized Correctly For Viewport / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/contrast-ratio.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/contrast-ratio.html
@@ -1,0 +1,2 @@
+{% setvar label "Contrast Ratio / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/critical-request-chains.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/critical-request-chains.html
@@ -1,0 +1,2 @@
+{% setvar label "Critical Request Chains / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/date-now.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/date-now.html
@@ -1,0 +1,2 @@
+{% setvar label "date.now() / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/document-write.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/document-write.html
@@ -1,0 +1,2 @@
+{% setvar label "document.write() / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/estimated-input-latency.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/estimated-input-latency.html
@@ -1,0 +1,2 @@
+{% setvar label "Estimated Input Latency / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/first-meaningful-paint.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/first-meaningful-paint.html
@@ -1,0 +1,2 @@
+{% setvar label "First Meaningful Paint / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/form-labels.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/form-labels.html
@@ -1,0 +1,2 @@
+{% setvar label "Form Labels / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/geolocation-on-load.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/geolocation-on-load.html
@@ -1,0 +1,2 @@
+{% setvar label "Geolocation Permissions / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/has-viewport-meta-tag.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/has-viewport-meta-tag.html
@@ -1,0 +1,2 @@
+{% setvar label "Viewport Meta Tag / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/http-200-when-offline.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/http-200-when-offline.html
@@ -1,0 +1,2 @@
+{% setvar label "HTTP 200 When Offline / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/http-redirects-to-https.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/http-redirects-to-https.html
@@ -1,0 +1,2 @@
+{% setvar label "HTTP Redirects To HTTPS / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/http2.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/http2.html
@@ -1,0 +1,2 @@
+{% setvar label "HTTP2 / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/https.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/https.html
@@ -1,0 +1,2 @@
+{% setvar label "HTTPS / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-192px-icon.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-192px-icon.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest 192px Icon / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-background_color.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-background_color.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Background Color / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-name.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-name.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Name / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-short_name.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-short_name.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Short Name / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-start_url.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-start_url.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Start URL / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-theme_color.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-contains-theme_color.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Theme Color / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-exists.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-exists.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Exists / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-has-display-set.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-has-display-set.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Display / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/manifest-short_name-is-not-truncated.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/manifest-short_name-is-not-truncated.html
@@ -1,0 +1,2 @@
+{% setvar label "Manifest Short Name Truncation / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/mutation-events.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/mutation-events.html
@@ -1,0 +1,2 @@
+{% setvar label "Mutation Events / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/no-js.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/no-js.html
@@ -1,0 +1,2 @@
+{% setvar label "No JS / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/noopener.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/noopener.html
@@ -1,0 +1,2 @@
+{% setvar label "noopener / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/notifications-on-load.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/notifications-on-load.html
@@ -1,0 +1,2 @@
+{% setvar label "Notification Permissions / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/old-flexbox.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/old-flexbox.html
@@ -1,0 +1,2 @@
+{% setvar label "Old Flexbox / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/passive-event-listeners.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/passive-event-listeners.html
@@ -1,0 +1,2 @@
+{% setvar label "Passive Event Listeners / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/registered-service-worker.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/registered-service-worker.html
@@ -1,0 +1,2 @@
+{% setvar label "Registered Service Worker / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/required-aria-attributes.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/required-aria-attributes.html
@@ -1,0 +1,2 @@
+{% setvar label "Required ARIA Attributes / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/speed-index.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/speed-index.html
@@ -1,0 +1,2 @@
+{% setvar label "Speed Index / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/tabindex.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/tabindex.html
@@ -1,0 +1,2 @@
+{% setvar label "tabindex / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/time-to-interactive.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/time-to-interactive.html
@@ -1,0 +1,2 @@
+{% setvar label "Time To Interactive / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/user-timing.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/user-timing.html
@@ -1,0 +1,2 @@
+{% setvar label "User Timing / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/valid-aria-attributes.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/valid-aria-attributes.html
@@ -1,0 +1,2 @@
+{% setvar label "Valid ARIA Attributes / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/valid-aria-values.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/valid-aria-values.html
@@ -1,0 +1,2 @@
+{% setvar label "Valid ARIA Values / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/_feedback/web-sql.html
+++ b/src/content/en/tools/lighthouse/audits/_feedback/web-sql.html
@@ -1,0 +1,2 @@
+{% setvar label "Web SQL / Helpful" %}
+{% include "web/tools/lighthouse/audits/_feedback/_helpful.html" %}

--- a/src/content/en/tools/lighthouse/audits/alt-attribute.md
+++ b/src/content/en/tools/lighthouse/audits/alt-attribute.md
@@ -40,3 +40,6 @@ This audit is powered by the aXe Accessibility Engine. See [Images must have
 alternate text][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/image-alt
+
+
+{% include "web/tools/lighthouse/audits/_feedback/alt-attribute.html" %}

--- a/src/content/en/tools/lighthouse/audits/appcache.md
+++ b/src/content/en/tools/lighthouse/audits/appcache.md
@@ -33,3 +33,6 @@ offline.
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 The audit passes if no AppCache manifest is detected.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/appcache.html" %}

--- a/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
@@ -43,3 +43,6 @@ This audit is powered by the aXe Accessibility Engine. See [Elements must only
 use allowed ARIA attributes][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/aria-allowed-attr
+
+
+{% include "web/tools/lighthouse/audits/_feedback/aria-allowed-attributes.html" %}

--- a/src/content/en/tools/lighthouse/audits/blocking-resources.md
+++ b/src/content/en/tools/lighthouse/audits/blocking-resources.md
@@ -61,3 +61,6 @@ A `<link rel="stylesheet">` tag that:
 A `<link rel="import">` tag that:
 
 * Does not have an `async` attribute.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/blocking-resources.html" %}

--- a/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
@@ -50,3 +50,6 @@ worker redirects to another resource in the cache. Conversely, the audit can
 produce a false positive result if your cache contains a resource that
 matches `start_url`, but your service worker redirects the request to
 a non-existent resource.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/cache-contains-start_url.html" %}

--- a/src/content/en/tools/lighthouse/audits/console-time.md
+++ b/src/content/en/tools/lighthouse/audits/console-time.md
@@ -42,3 +42,6 @@ scripts that are on the same host as the page. Scripts from other hosts are
 excluded, because Lighthouse assumes that you don't have control over these
 scripts. So, there may be other scripts using `console.time()` on your page,
 but these won't show up in your Lighthouse report.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/console-time.html" %}

--- a/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
+++ b/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
@@ -30,3 +30,6 @@ You can ignore this audit if:
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 The audit passes if `window.innerWidth === window.outerWidth`.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/content-sized-correctly-for-viewport.html" %}

--- a/src/content/en/tools/lighthouse/audits/contrast-ratio.md
+++ b/src/content/en/tools/lighthouse/audits/contrast-ratio.md
@@ -55,3 +55,6 @@ must have sufficient color contrast against the background][axe] for more
 information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/color-contrast
+
+
+{% include "web/tools/lighthouse/audits/_feedback/contrast-ratio.html" %}

--- a/src/content/en/tools/lighthouse/audits/critical-request-chains.md
+++ b/src/content/en/tools/lighthouse/audits/critical-request-chains.md
@@ -69,3 +69,6 @@ for more information on how Chrome defines these priorities.
 
 Data on critical request chains, resource sizes, and time spent downloading
 resources is extracted from the Chrome Debugger Protocol.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/critical-request-chains.html" %}

--- a/src/content/en/tools/lighthouse/audits/date-now.md
+++ b/src/content/en/tools/lighthouse/audits/date-now.md
@@ -30,3 +30,6 @@ scripts that are on the same host as the page. Scripts from other hosts are
 excluded, because Lighthouse assumes that you don't have control over these
 scripts. So, there may be other scripts using `Date.now()` on your page,
 but these won't show up in your Lighthouse report.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/date-now.html" %}

--- a/src/content/en/tools/lighthouse/audits/document-write.md
+++ b/src/content/en/tools/lighthouse/audits/document-write.md
@@ -34,3 +34,6 @@ Lighthouse reports every instance of `document.write()` that it encounters.
 Note that Chrome's intervention against `document.write()` only applies to
 render-blocking, dynamically-injected scripts. Other uses of `document.write()`
 may be acceptable.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/document-write.html" %}

--- a/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
+++ b/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
@@ -58,3 +58,6 @@ that does not leave enough time for your app to complete the response.
 There is a 90% probabililty a user would encounter input latency of the
 amount that Lighthouse reports, or less. 10% of users can expect additional
 latency.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/estimated-input-latency.html" %}

--- a/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
+++ b/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
@@ -29,3 +29,6 @@ First Meaningful Paint is essentially the paint after which the biggest
 above-the-fold layout change has happened, and web fonts have loaded. See the
 spec to learn more:
 [First Meaningful Paint: A Layout-Based Aproach](https://docs.google.com/document/d/1BR94tJdZLsin5poeet0XoTW60M0SjvOJQttKT-JK8HI/view).
+
+
+{% include "web/tools/lighthouse/audits/_feedback/first-meaningful-paint.html" %}

--- a/src/content/en/tools/lighthouse/audits/form-labels.md
+++ b/src/content/en/tools/lighthouse/audits/form-labels.md
@@ -42,3 +42,6 @@ This audit is powered by the aXe Accessibility Engine. See [Form elements must
 have labels][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/label
+
+
+{% include "web/tools/lighthouse/audits/_feedback/form-labels.html" %}

--- a/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
@@ -39,3 +39,6 @@ code contains calls to `geolocation.getCurrentPosition()` or
 granted, then the user's location was requested.
 
 [help]: https://support.google.com/chrome/answer/6148059
+
+
+{% include "web/tools/lighthouse/audits/_feedback/geolocation-on-load.html" %}

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -38,3 +38,6 @@ of the document. It also checks that the node contains a `content` attribute
 and that the value of this attribute contains the text `width=`. However,
 it does not check that `width` equals `device-width`. Lighthouse also does not
 check for a `initial-scale` key-value pair.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/has-viewport-meta-tag.html" %}

--- a/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
+++ b/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
@@ -38,3 +38,6 @@ determine which caching strategy fits your app best. This covers step 2 above.
 
 Lighthouse emulates an offline connection using the Chrome Debugging Protocol,
 and then attempts to retrieve the page using `XMLHttpRequest`.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/http-200-when-offline.html" %}

--- a/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
+++ b/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
@@ -30,3 +30,6 @@ traffic to your site is redirected to HTTPS.
 Lighthouse changes the page's URL to `http`, loads the page, and then waits for
 the event from the Chrome Debugger that indicates that the page is secure. If
 Lighthouse does not receive the event within 10 seconds then the audit fails.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/http-redirects-to-https.html" %}

--- a/src/content/en/tools/lighthouse/audits/http2.md
+++ b/src/content/en/tools/lighthouse/audits/http2.md
@@ -36,3 +36,6 @@ page, and then checks the HTTP protocol version of each resource.
 
 Lighthouse excludes resources from other hosts from this audit, because it
 assumes that you have no control over how these resources are served.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/http2.html" %}

--- a/src/content/en/tools/lighthouse/audits/https.md
+++ b/src/content/en/tools/lighthouse/audits/https.md
@@ -47,3 +47,6 @@ Chrome DevTools Security panel to learn how to debug these situations:
 Lighthouse waits for an event from the Chrome Debugger Protocol indicating that
 the page is running on a secure connection. If the event is not heard within 10
 seconds, the audit fails.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/https.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
@@ -48,3 +48,6 @@ separate from the one that Chrome is using on the page, which can possibly
 cause inaccurate results. Note also that Lighthouse does not check whether
 the icon actually exists in the cache. It just makes sure that the Web App
 Manifest defines a 192-pixel icon.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-contains-192px-icon.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
@@ -35,3 +35,6 @@ Audit passes if the manifest contains a `background_color` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is
 using on the page, which can possibly cause inaccurate results. Lighthouse does
 not validate that the value is a valid CSS color.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-contains-background_color.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
@@ -37,3 +37,6 @@ implement and test "Add to Homescreen" support in your app.
 Lighthouse fetches the manifest and verifies that it has a `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is
 using on the page, which can possibly cause inaccurate results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-contains-name.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -36,3 +36,6 @@ implement and test "Add to Homescreen" support in your app.
 Audit passes if the manifest contains either `short_name` or `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is
 using on the page, which can possibly cause inaccurate results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-contains-short_name.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
@@ -35,3 +35,6 @@ implement and test "Add to Homescreen" support in your app.
 Lighthouse fetches the manifest and verifies that it has a `start_url` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is
 using on the page, which can possibly cause inaccurate results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-contains-start_url.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-theme_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-theme_color.md
@@ -34,3 +34,6 @@ Audit passes if the manifest contains a `theme_color` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is
 using on the page, which can possibly cause inaccurate results. Lighthouse does
 not validate that the value is a valid CSS color.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-contains-theme_color.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-exists.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-exists.md
@@ -35,3 +35,6 @@ Manifest](/web/tools/chrome-devtools/debug/progressive-web-apps/#manifest).
 Lighthouse fetches the manifest and verifies that it has data. The manifest that
 Lighthouse fetches is separate from the one that Chrome is using on the page, which
 can possibly cause inaccurate results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-exists.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
@@ -38,3 +38,6 @@ exists and that it's value is `fullscreen`, `standalone`, or `browser`.
 
 The manifest that Lighthouse fetches is separate from the one that Chrome
 is using on the page, which can possibly cause inaccurate results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-has-display-set.html" %}

--- a/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -42,3 +42,6 @@ So, if you don't include a `short_name` in your manifest, but your `name` is
 less than 12 characters, then the audit passes. The manifest that Lighthouse
 fetches is separate from the one that Chrome is using on the page, which can
 possibly cause inaccurate results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/manifest-short_name-is-not-truncated.html" %}

--- a/src/content/en/tools/lighthouse/audits/mutation-events.md
+++ b/src/content/en/tools/lighthouse/audits/mutation-events.md
@@ -35,3 +35,6 @@ See [`MutationObserver`][mdn] on MDN for more help.
 Lighthouse collects all of the event listeners on the page, and flags
 any listener that uses one of the types listed in [Why the audit is
 important](#why).
+
+
+{% include "web/tools/lighthouse/audits/_feedback/mutation-events.html" %}

--- a/src/content/en/tools/lighthouse/audits/no-js.md
+++ b/src/content/en/tools/lighthouse/audits/no-js.md
@@ -57,3 +57,6 @@ JavaScript](/web/tools/chrome-devtools/settings#disable-js) feature.
 Lighthouse disables JavaScript on the page and then inspects the page's HTML. If
 the HTML is empty then the audit fails. If the HTML is not empty then the audit
 passes.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/no-js.html" %}

--- a/src/content/en/tools/lighthouse/audits/noopener.md
+++ b/src/content/en/tools/lighthouse/audits/noopener.md
@@ -43,3 +43,6 @@ might want to be aware of if you're working on a large site. If your page opens
 a link to another section of your site without using `rel="noopener"`, the
 performance implications of this audit still apply. However, you won't see these
 links in your Lighthouse results.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/noopener.html" %}

--- a/src/content/en/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/notifications-on-load.md
@@ -36,3 +36,6 @@ code contains calls to `notification.requestPermission()`, and notification
 permission was not already granted, then notification permission was requested.
 
 [help]: https://support.google.com/chrome/answer/6148059
+
+
+{% include "web/tools/lighthouse/audits/_feedback/notifications-on-load.html" %}

--- a/src/content/en/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/en/tools/lighthouse/audits/old-flexbox.md
@@ -34,3 +34,6 @@ old properties map to the new ones.
 Lighthouse collects all of the stylesheets used on the page and checks if any of
 them uses `display: box`. Lighthouse does not check if the stylesheets use any
 other deprecated properties.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/old-flexbox.html" %}

--- a/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
@@ -58,3 +58,6 @@ don't have control over these scripts. Because of this, note that Lighthouse's
 audit does not represent the full scroll performance of your page. There
 may be third-party scripts that are harming your page's scroll performance,
 but these aren't listed in your Lighthouse report.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/passive-event-listeners.html" %}

--- a/src/content/en/tools/lighthouse/audits/registered-service-worker.md
+++ b/src/content/en/tools/lighthouse/audits/registered-service-worker.md
@@ -39,3 +39,6 @@ the features in your own app:
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Checks if the Chrome Debugger returns a service worker version.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/registered-service-worker.html" %}

--- a/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
@@ -38,3 +38,6 @@ This audit is powered by the aXe Accessibility Engine. See [Required ARIA
 attributes must be provided][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/aria-required-attr
+
+
+{% include "web/tools/lighthouse/audits/_feedback/required-aria-attributes.html" %}

--- a/src/content/en/tools/lighthouse/audits/speed-index.md
+++ b/src/content/en/tools/lighthouse/audits/speed-index.md
@@ -33,3 +33,6 @@ The target score is computed by a cumulative distribution function of a
 log-normal distribution. Check out the comments in the
 [source](https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/speed-index-metric.js)
 of the audit if you need to know more.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/speed-index.html" %}

--- a/src/content/en/tools/lighthouse/audits/tabindex.md
+++ b/src/content/en/tools/lighthouse/audits/tabindex.md
@@ -32,3 +32,6 @@ This audit is powered by the aXe Accessibility Engine. See [Elements should not
 have tabindex greater than zero][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/tabindex
+
+
+{% include "web/tools/lighthouse/audits/_feedback/tabindex.html" %}

--- a/src/content/en/tools/lighthouse/audits/time-to-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/time-to-interactive.md
@@ -28,3 +28,6 @@ key webfonts are visible, and the main thread is available enough to handle
 user input.
 
 Note that this metric is in early phases and is subject to change.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/time-to-interactive.html" %}

--- a/src/content/en/tools/lighthouse/audits/user-timing.md
+++ b/src/content/en/tools/lighthouse/audits/user-timing.md
@@ -33,3 +33,6 @@ JavaScript performance.
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse extracts User Timing data from Chrome's Trace Event Profiling Tool.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/user-timing.html" %}

--- a/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
@@ -40,3 +40,6 @@ This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid names][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr
+
+
+{% include "web/tools/lighthouse/audits/_feedback/valid-aria-attributes.html" %}

--- a/src/content/en/tools/lighthouse/audits/valid-aria-values.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-values.md
@@ -39,3 +39,6 @@ This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid values][axe] for more information.
 
 [axe]: https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr-value
+
+
+{% include "web/tools/lighthouse/audits/_feedback/valid-aria-values.html" %}

--- a/src/content/en/tools/lighthouse/audits/web-sql.md
+++ b/src/content/en/tools/lighthouse/audits/web-sql.md
@@ -27,3 +27,6 @@ storage options.
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse checks if the page has a Web SQL database instance.
+
+
+{% include "web/tools/lighthouse/audits/_feedback/web-sql.html" %}


### PR DESCRIPTION
Adds a feedback section to the bottom of every audit reference, asking if the user found the page helpful.

Googlers can an example at `<staging site>.com/web/tools/lighthouse/audits/alt-attribute`