### PR TITLE
[devtools] make explicit request to reader in first inline feedback question

### DIFF
--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html
@@ -2,7 +2,7 @@
 {% setvar label "JS / Get Started / (1) Reproduced The Bug" %}
 {% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
 {% setvar success_button "I reproduced the bug" %}
-{% setvar success_response "Awesome. Keep going and you'll learn how to spot this bug in DevTools." %}
+{% setvar success_response "Thanks for the feedback. Please continue to answer these questions. They help us identify problems in the tutorial." %}
 {% setvar fail_button "I can't reproduce the bug" %}
 {% setvar fail_response %}Sorry to hear that. Please <a href="{{url}}">open an issue</a> and tell us more.{% endsetvar %}
 {% include "web/_shared/feedback.html" %}


### PR DESCRIPTION
I'm running an experiment to see how this change affects engagement rates. My hunch is that readers who are successfully completing the tutorial don't really have an incentive to continue to respond to the questions. If they realize how helpful it is to us, they may be more inclined to continue to engage

note to self: mark the date when this change goes live (not when it's merged)