### PR TITLE
[devtools] add "coming soon" placeholder for release notes

### DIFF
--- a/src/content/en/tools/chrome-devtools/coming-soon.md
+++ b/src/content/en/tools/chrome-devtools/coming-soon.md
@@ -1,0 +1,11 @@
+project_path: /web/_project.yaml
+book_path: /web/tools/_book.yaml
+description: A placeholder page for release notes that aren't ready yet.
+
+{# wf_updated_on: 2017-04-10 #}
+{# wf_published_on: 2017-04-10 #}
+
+# What's New In DevTools (Coming Soon) {: .page-title }
+
+Hey there, the "What's New" release notes that you're trying to access aren't
+ready yet. Check back in a week and they should be available!

--- a/src/content/en/updates/_redirects.yaml
+++ b/src/content/en/updates/_redirects.yaml
@@ -2,6 +2,9 @@
 
 redirects:
 
+- from: /web/updates/2017/04/devtools-release-notes
+  to: /web/tools/chrome-devtools/coming-soon
+
 - from: /web/updates/2011/06/HTML5-Libraries---Late-June
   to: /web/updates/2011/06/HTML5-Libraries-Late-June
 


### PR DESCRIPTION
The "What's New" panel in DevTools is going to reference a doc on /web/updates before that doc exists. This ensures that the people who try to navigate to that doc don't hit a 404.

It's a clunky solution I know, but the amount of people it'll affect is very low, so it's not worth doing any more work than this