### PR TITLE
Clarify promise usage in service worker example

### DIFF
--- a/src/content/en/fundamentals/getting-started/primers/service-workers.md
+++ b/src/content/en/fundamentals/getting-started/primers/service-workers.md
@@ -129,7 +129,7 @@ service worker JavaScript file lives.
         navigator.serviceWorker.register('/sw.js').then(function(registration) {
           // Registration was successful
           console.log('ServiceWorker registration successful with scope: ', registration.scope);
-        }).catch(function(err) {
+        }, function(err) {
           // registration failed :(
           console.log('ServiceWorker registration failed: ', err);
         });


### PR DESCRIPTION
This change makes the use of promises in the code example clear, and safe when people copy-paste.

A lot of readers will be unclear about the important differences between `registration.then(mapSuccess, mapError)` and `registration.then(mapSuccess).catch(mapError)`, namely that in the second example `mapError` handles both registration errors *and* errors from the `mapSuccess` handler.

This change makes the comment `// registration failed :(` true regardless of changes made to the currently safe `mapSuccess` function. The error handler will now indeed run if-and-only-if the registration itself fails.