### PR TITLE
[lighthouse] make doc titles match audit titles

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -49,7 +49,7 @@ toc:
         path: /web/tools/lighthouse/audits/alt-attribute
       - title: First Meaningful Paint
         path: /web/tools/lighthouse/audits/first-meaningful-paint
-      - title: Has A &lt;meta name="viewport"&gt; Tag With width Or initial-scale
+      - title: Has A Viewport Meta Tag With width Or initial-scale
         path: /web/tools/lighthouse/audits/has-viewport-meta-tag
       - title: Manifest Contains Icons at Least 192px
         path:  /web/tools/lighthouse/audits/manifest-contains-192px-icon

--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -5,91 +5,91 @@ toc:
       path: /web/tools/lighthouse/
     - title: Audit References
       section:
+      - title: Avoids Application Cache
+        path: /web/tools/lighthouse/audits/appcache
+      - title: Avoids console.time()
+        path: /web/tools/lighthouse/audits/console-time
+      - title: Avoids Date.now()
+        path: /web/tools/lighthouse/audits/date-now
+      - title: Avoids document.write()
+        path: /web/tools/lighthouse/audits/document-write
+      - title: Avoids Mutation Events In Its Own Scripts
+        path: /web/tools/lighthouse/audits/mutation-events
+      - title: Avoids Old CSS Flexbox
+        path: /web/tools/lighthouse/audits/old-flexbox
+      - title: Avoids Requesting The Geolocation Permission On Page Load
+        path: /web/tools/lighthouse/audits/geolocation-on-load
+      - title: Avoids Requesting The Notfication Permission On Page Load
+        path: /web/tools/lighthouse/audits/notifications-on-load
+      - title: Avoids Web SQL
+        path: /web/tools/lighthouse/audits/web-sql
       - title: Background and Foreground Colors Have Sufficient Contrast Ratio
         path: /web/tools/lighthouse/audits/contrast-ratio
       - title: Cache Contains start_url From Manifest
         path: /web/tools/lighthouse/audits/cache-contains-start_url
+      - title: Contains Some Content When Its Scripts Are Not Available
+        path: /web/tools/lighthouse/audits/no-js
       - title: Content Sized Correctly for Viewport
         path: /web/tools/lighthouse/audits/content-sized-correctly-for-viewport
       - title: Critical Request Chains
         path: /web/tools/lighthouse/audits/critical-request-chains
-      - title: Element ARIA Attributes Are Allowed For This Role
+      - title: Element aria-* Attributes Are Allowed For This Role
         path: /web/tools/lighthouse/audits/aria-allowed-attributes
-      - title: Element ARIA Attributes Are Valid
+      - title: Element aria-* Attributes Are Valid And Not Mispelled Or Non-Existent
         path: /web/tools/lighthouse/audits/valid-aria-attributes
-      - title: Element ARIA Attributes Have Valid Values
+      - title: Element aria-* Attributes Have Valid Values
         path: /web/tools/lighthouse/audits/valid-aria-values
-      - title: Elements With ARIA Roles Have Required Attributes
+      - title: Elements With ARIA Roles Have The Required aria-* Attributes
         path: /web/tools/lighthouse/audits/required-aria-attributes
       - title: Estimated Input Latency
         path: /web/tools/lighthouse/audits/estimated-input-latency
       - title: Every Form Element Has A Label
         path: /web/tools/lighthouse/audits/form-labels
-      - title: Every Image Has An Alt Attribute
+      - title: Every Image Has An alt Attribute
         path: /web/tools/lighthouse/audits/alt-attribute
       - title: First Meaningful Paint
         path: /web/tools/lighthouse/audits/first-meaningful-paint
-      - title: Has a Registered Service Worker
-        path: /web/tools/lighthouse/audits/registered-service-worker
-      - title: HTML Has Viewport Meta Tag
+      - title: Has A &lt;meta name="viewport"&gt; Tag With width Or initial-scale
         path: /web/tools/lighthouse/audits/has-viewport-meta-tag
       - title: Manifest Contains Icons at Least 192px
         path:  /web/tools/lighthouse/audits/manifest-contains-192px-icon
-      - title: Manifest Contains Background Color
+      - title: Manifest Contains background_color
         path: /web/tools/lighthouse/audits/manifest-contains-background_color
-      - title: Manifest Contains Name
+      - title: Manifest Contains name
         path: /web/tools/lighthouse/audits/manifest-contains-name
-      - title: Manifest Contains Short Name
+      - title: Manifest Contains short_name
         path: /web/tools/lighthouse/audits/manifest-contains-short_name
       - title: Manifest Contains Start URL
         path: /web/tools/lighthouse/audits/manifest-contains-start_url
-      - title: Manifest Contains Theme Color
+      - title: Manifest Contains theme_color
         path: /web/tools/lighthouse/audits/manifest-contains-theme_color
       - title: Manifest Exists
         path: /web/tools/lighthouse/audits/manifest-exists
-      - title: Manifest's Display Property Is Set
+      - title: Manifest's display Property Is Set
         path: /web/tools/lighthouse/audits/manifest-has-display-set
-      - title: Manifest's Short Name Won't Be Truncated
+      - title: Manifest's short_Name Won't Be Truncated When Displayed On Homescreen
         path: /web/tools/lighthouse/audits/manifest-short_name-is-not-truncated
-      - title: No Element Has A Tabindex Attribute Greater Than Zero
+      - title: No Element Has A tabindex Attribute Greater Than 0
         path: /web/tools/lighthouse/audits/tabindex
-      - title: Page Contains Some Content When Its Scripts Are Not Available
-        path: /web/tools/lighthouse/audits/no-js
-      - title: Page Does Not Automatically Request Geolocation On Page Load
-        path: /web/tools/lighthouse/audits/geolocation-on-load
-      - title: Page Does Not Automatically Request Notfication Permissions On Page Load
-        path: /web/tools/lighthouse/audits/notifications-on-load
-      - title: Site Does Not Use Application Cache
-        path: /web/tools/lighthouse/audits/appcache
-      - title: Site Does Not Use console.time()
-        path: /web/tools/lighthouse/audits/console-time
-      - title: Site Does Not Use Resources That Delay First Paint
-        path: /web/tools/lighthouse/audits/blocking-resources
-      - title: Site Does Not Use Date.now()
-        path: /web/tools/lighthouse/audits/date-now
-      - title: Site Does Not Use document.write()
-        path: /web/tools/lighthouse/audits/document-write
-      - title: Site Does Not Use Mutation Events
-        path: /web/tools/lighthouse/audits/mutation-events
-      - title: Site Does Not Use The Old CSS Flexbox
-        path: /web/tools/lighthouse/audits/old-flexbox
-      - title: Site Does Not Use Web SQL
-        path: /web/tools/lighthouse/audits/web-sql
-      - title: Site Is On HTTPS
-        path: /web/tools/lighthouse/audits/https
-      - title: Site Opens External Anchors Using rel="noopener"
+      - title: Opens External Anchors Using rel="noopener"
         path: /web/tools/lighthouse/audits/noopener
-      - title: Site Redirects HTTP Traffic to HTTPS
-        path: /web/tools/lighthouse/audits/http-redirects-to-https
-      - title: Site Uses HTTP/2
-        path: /web/tools/lighthouse/audits/http2
-      - title: Site Uses Passive Event Listeners
-        path: /web/tools/lighthouse/audits/passive-event-listeners
-      - title: Speed Index
+      - title: Perceptual Speed Index
         path: /web/tools/lighthouse/audits/speed-index
+      - title: Redirects HTTP Traffic To HTTPS
+        path: /web/tools/lighthouse/audits/http-redirects-to-https
+      - title: Registers A Service Worker
+        path: /web/tools/lighthouse/audits/registered-service-worker
+      - title: Render-Blocking Resources
+        path: /web/tools/lighthouse/audits/blocking-resources
+      - title: Responds With A 200 When Offline
+        path: /web/tools/lighthouse/audits/http-200-when-offline
       - title: Time to Interactive
         path: /web/tools/lighthouse/audits/time-to-interactive
-      - title: URL Responds with a 200 When Offline
-        path: /web/tools/lighthouse/audits/http-200-when-offline
       - title: User Timing Marks and Measures
         path: /web/tools/lighthouse/audits/user-timing
+      - title: Uses HTTP/2 For Its Own Resources
+        path: /web/tools/lighthouse/audits/http2
+      - title: Uses HTTPS
+        path: /web/tools/lighthouse/audits/https
+      - title: Uses Passive Event Listeners To Improve Scrolling Performance
+        path: /web/tools/lighthouse/audits/passive-event-listeners

--- a/src/content/en/tools/lighthouse/audits/alt-attribute.md
+++ b/src/content/en/tools/lighthouse/audits/alt-attribute.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Every Image Element Has An Alt Attribute" Lighthouse audit.
+description: Reference documentation for the "Every Image Element Has An alt Attribute" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-23 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2017-01-23 #}
 
-# Every Image Element Has An Alt Attribute  {: .page-title }
+# Every Image Element Has An alt Attribute  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/appcache.md
+++ b/src/content/en/tools/lighthouse/audits/appcache.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use Application Cache" Lighthouse audit.
+description: Reference documentation for the "Avoids Application Cache" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-04 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2017-01-04 #}
 
-# Site Does Not Use Application Cache  {: .page-title }
+# Avoids Application Cache  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Element ARIA Attributes Are Allowed For This Role" Lighthouse audit.
+description: Reference documentation for the "Element aria-* Attributes Are Allowed For This Role" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-13 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2017-01-13 #}
 
-# Element ARIA Attributes Are Allowed For This Role  {: .page-title }
+# Element aria-* Attributes Are Allowed For This Role  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/blocking-resources.md
+++ b/src/content/en/tools/lighthouse/audits/blocking-resources.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use Link Tags That Delay First Paint" and "Site Does Not Use Script Tags In Head That Delay First Paint" Lighthouse audits.
+description: Reference documentation for the "Render-blocking stylesheets" and "Render-blocking scripts" Lighthouse audits.
 
-{# wf_updated_on: 2016-12-01 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-01 #}
 
-# Site Does Not Use Resources That Delay First Paint  {: .page-title }
+# Render-Blocking Resources {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/console-time.md
+++ b/src/content/en/tools/lighthouse/audits/console-time.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use console.time() In Its Own Scripts" Lighthouse audit.
+description: Reference documentation for the "Avoids console.time() In Its Own Scripts" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-01 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-01 #}
 
-# Site Does Not Use console.time() In Its Own Scripts  {: .page-title }
+# Avoids console.time() In Its Own Scripts  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/date-now.md
+++ b/src/content/en/tools/lighthouse/audits/date-now.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use Date.now() In Its Own Scripts" Lighthouse audit.
+description: Reference documentation for the "Avoids Date.now() In Its Own Scripts" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-01 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-01 #}
 
-# Site Does Not Use Date.now() In Its Own Scripts  {: .page-title }
+# Avoids Date.now() In Its Own Scripts  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/document-write.md
+++ b/src/content/en/tools/lighthouse/audits/document-write.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use document.write()" Lighthouse audit.
+description: Reference documentation for the "Avoids document.write()" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-01 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-01 #}
 
-# Site Does Not Use document.write() {: .page-title }
+# Avoids document.write() {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Page Does Not Automatically Request Geolocation On Page Load" Lighthouse audit.
+description: Reference documentation for the "Avoids Requesting The Geolocation Permission On Page Load" Lighthouse audit.
 
-{# wf_updated_on: 2016-11-30 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-11-30 #}
 
-# Page Does Not Automatically Request Geolocation On Page Load  {: .page-title }
+# Avoids Requesting The Geolocation Permission On Page Load  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -5,7 +5,7 @@ description: Reference documentation for the "Has A &lt;meta name="viewport"&gt;
 {# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-10-04 #}
 
-# Has A &lt;meta name="viewport"&gt; Tag With width Or initial-scale {: .page-title }
+# Has A Viewport Meta Tag With width Or initial-scale {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "HTML Has a Viewport Meta Tag" Lighthouse audit.
+description: Reference documentation for the "Has A <meta name="viewport"> Tag With width Or initial-scale" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-10-04 #}
 
-# HTML Has a Viewport Meta Tag {: .page-title }
+# Has A <meta name="viewport"> Tag With width Or initial-scale {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Has A <meta name="viewport"> Tag With width Or initial-scale" Lighthouse audit.
+description: Reference documentation for the "Has A &lt;meta name="viewport"&gt; Tag With width Or initial-scale" Lighthouse audit.
 
 {# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-10-04 #}
 
-# Has A <meta name="viewport"> Tag With width Or initial-scale {: .page-title }
+# Has A &lt;meta name="viewport"&gt; Tag With width Or initial-scale {: .page-title }
 
 ## Why the audit is important {: #why }
 
@@ -14,8 +14,8 @@ screen widths, and then scale the pages to fit the mobile screens. Setting
 the viewport enables you to control the width and scaling of the viewport.
 Check out the following links to learn more:
 
-* [Configure the Viewport](/speed/docs/insights/ConfigureViewport).
-* [Set the Viewport](/web/fundamentals/design-and-ui/responsive/#set-the-viewport).
+* [Configure the Viewport](/speed/docs/insights/ConfigureViewport)
+* [Set the Viewport](/web/fundamentals/design-and-ui/responsive/#set-the-viewport)
 
 ## How to pass the audit {: #how }
 

--- a/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
+++ b/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "URL responds with a 200 when offline" Lighthouse audit.
+description: Reference documentation for the "Responds With A 200 When Offline" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-15 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-15 #}
 
-# URL Responds With a 200 When Offline {: .page-title }
+# Responds With A 200 When Offline {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
+++ b/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site redirects HTTP traffic to HTTPS" Lighthouse audit.
+description: Reference documentation for the "Redirects HTTP Traffic To HTTPS" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-20 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-20 #}
 
-# Site Redirects HTTP Traffic to HTTPS  {: .page-title }
+# Redirects HTTP Traffic To HTTPS  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/http2.md
+++ b/src/content/en/tools/lighthouse/audits/http2.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Uses HTTP/2 For Its Own Resources" Lighthouse audit.
+description: Reference documentation for the "Uses HTTP/2 For Its Own Resources" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-05 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-05 #}
 
-# Site Uses HTTP/2 For Its Own Resources  {: .page-title }
+# Uses HTTP/2 For Its Own Resources  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/https.md
+++ b/src/content/en/tools/lighthouse/audits/https.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site is on HTTPS" Lighthouse audit.
+description: Reference documentation for the "Uses HTTPS" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-19 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-19 #}
 
-# Site is on HTTPS  {: .page-title }
+# Uses HTTPS  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
@@ -2,10 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains background_color" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-21 #}
 
-# Manifest Contains Background Color  {: .page-title }
+# Manifest Contains background_color  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
@@ -2,10 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains name" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-21 #}
 
-# Manifest Contains Name  {: .page-title }
+# Manifest Contains name  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -2,10 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains short_name" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-21 #}
 
-# Manifest Contains Short Name  {: .page-title }
+# Manifest Contains short_name  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-theme_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-theme_color.md
@@ -2,10 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains theme_color" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-21 #}
 
-# Manifest Contains Theme Color  {: .page-title }
+# Manifest Contains theme_color  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
@@ -2,10 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest's display Property Is Set" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-21 #}
 
-# Manifest's Display Property Is Set  {: .page-title }
+# Manifest's display Property Is Set  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -2,10 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest's short_name won't be truncated when displayed on homescreen" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-21 #}
 
-# Manifest's Short Name Won't Be Truncated When Displayed on Homescreen {: .page-title }
+# Manifest's short_name Won't Be Truncated When Displayed on Homescreen {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/mutation-events.md
+++ b/src/content/en/tools/lighthouse/audits/mutation-events.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use Mutation Events In Its Own Scripts" Lighthouse audit.
+description: Reference documentation for the "Avoids Mutation Events In Its Own Scripts" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-10-04 #}
 
-# Site Does Not Use Mutation Events In Its Own Scripts  {: .page-title }
+# Avoids Mutation Events In Its Own Scripts  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/no-js.md
+++ b/src/content/en/tools/lighthouse/audits/no-js.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Page contains some content when its scripts are not available" Lighthouse audit.
+description: Reference documentation for the "Contains Some Content When JavaScript Is Not Available" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-20 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-09-20 #}
 
-# Page Contains Some Content When Its Scripts Are Not Available  {: .page-title }
+# Contains Some Content When JavaScript Is Not Available  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/noopener.md
+++ b/src/content/en/tools/lighthouse/audits/noopener.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Opens External Anchors Using rel="noopender"" Lighthouse audit.
+description: Reference documentation for the "Opens External Anchors Using rel="noopender"" Lighthouse audit.
 
-{# wf_updated_on: 2016-11-30 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-11-30 #}
 
-# Site Opens External Anchors Using rel="noopener"  {: .page-title }
+# Opens External Anchors Using rel="noopener"  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/notifications-on-load.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Page Does Not Automatically Request Notification Permissions On Page Load" Lighthouse audit.
+description: Reference documentation for the "Avoids Requesting The Notification Permission On Page Load" Lighthouse audit.
 
 {# wf_updated_on: 2016-12-05 #}
 {# wf_published_on: 2016-12-05 #}
 
-# Page Does Not Automatically Request Notification Permissions On Page Load  {: .page-title }
+# Avoids Requesting The Notification Permission On Page Load  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/notifications-on-load.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Requesting The Notification Permission On Page Load" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-05 #}
+{# wf_updated_on: 2017-04-19 #}
 {# wf_published_on: 2016-12-05 #}
 
 # Avoids Requesting The Notification Permission On Page Load  {: .page-title }

--- a/src/content/en/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/en/tools/lighthouse/audits/old-flexbox.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use The Old CSS Flexbox" Lighthouse audit.
+description: Reference documentation for the "Avoids Old CSS Flexbox" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-05 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-05 #}
 
-# Site Does Not Use The Old CSS Flexbox  {: .page-title }
+# Avoids Old CSS Flexbox  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Uses Passive Event Listeners to Improve Scrolling Performance" Lighthouse audit.
+description: Reference documentation for the "Uses Passive Event Listeners to Improve Scrolling Performance" Lighthouse audit.
 
-{# wf_updated_on: 2016-11-30 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-11-30 #}
 
-# Site Uses Passive Event Listeners to Improve Scrolling Performance  {: .page-title }
+# Uses Passive Event Listeners to Improve Scrolling Performance  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/registered-service-worker.md
+++ b/src/content/en/tools/lighthouse/audits/registered-service-worker.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Has a registered service worker" Lighthouse audit.
+description: Reference documentation for the "Registers A Service Worker" Lighthouse audit.
 
-{# wf_updated_on: 2016-07-25 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-07-25 #}
 
-# Has a Registered Service Worker {: .page-title }
+# Registers A Service Worker {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Elements With ARIA Roles Have The Required aria-* Attributes" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-17 #}
+{# wf_updated_on: 2017-04-19 #}
 {# wf_published_on: 2017-01-17 #}
 
 # Elements With ARIA Roles Have The Required aria-* Attributes  {: .page-title }

--- a/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Elements With ARIA Roles Have Required Attributes" Lighthouse audit.
+description: Reference documentation for the "Elements With ARIA Roles Have The Required aria-* Attributes" Lighthouse audit.
 
 {# wf_updated_on: 2017-01-17 #}
 {# wf_published_on: 2017-01-17 #}
 
-# Elements With ARIA Roles Have Required Attributes  {: .page-title }
+# Elements With ARIA Roles Have The Required aria-* Attributes  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/speed-index.md
+++ b/src/content/en/tools/lighthouse/audits/speed-index.md
@@ -1,16 +1,17 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Speed Index" Lighthouse audit.
+description: Reference documentation for the "Perceptual Speed Index" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-10-04 #}
 
-# Speed Index  {: .page-title }
+# Perceptual Speed Index  {: .page-title }
 
 ## Why the audit is important {: #why }
 
-Speed Index is a page load performance metric that shows you how quickly
-the contents of a page are visibly populated. The lower the score, the better.
+Perceptual Speed Index is a page load performance metric that shows you how
+quickly the contents of a page are visibly populated. The lower the score,
+the better.
 
 ## How to pass the audit {: #how }
 

--- a/src/content/en/tools/lighthouse/audits/tabindex.md
+++ b/src/content/en/tools/lighthouse/audits/tabindex.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "No Element Has a Tabindex Attribute Greater Than Zero" Lighthouse audit.
+description: Reference documentation for the "No Element Has a tabindex Attribute Greater Than 0" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-23 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2017-01-23 #}
 
-# No Element Has a Tabindex Attribute Greater Than Zero  {: .page-title }
+# No Element Has a tabindex Attribute Greater Than 0  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Element ARIA Attributes Are Valid" Lighthouse audit.
+description: Reference documentation for the "Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-18 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2017-01-18 #}
 
-# Element ARIA Attributes Are Valid  {: .page-title }
+# Element ARIA Attributes Are Valid And Not Mispelled Or Non-Existent  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/valid-aria-values.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-values.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Element ARIA Attributes Have Valid Values" Lighthouse audit.
+description: Reference documentation for the "Element aria-* Attributes Have Valid Values" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-18 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2017-01-18 #}
 
-# Element ARIA Attributes Have Valid Values  {: .page-title }
+# Element aria-* Attributes Have Valid Values  {: .page-title }
 
 ## Why the audit is important {: #why }
 

--- a/src/content/en/tools/lighthouse/audits/web-sql.md
+++ b/src/content/en/tools/lighthouse/audits/web-sql.md
@@ -1,11 +1,11 @@
 project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Site Does Not Use Web SQL" Lighthouse audit.
+description: Reference documentation for the "Avoids Web SQL" Lighthouse audit.
 
-{# wf_updated_on: 2016-12-05 #}
+{# wf_updated_on: 2017-04-18 #}
 {# wf_published_on: 2016-12-05 #}
 
-# Site Does Not Use Web SQL  {: .page-title }
+# Avoids Web SQL  {: .page-title }
 
 ## Why the audit is important {: #why }
 


### PR DESCRIPTION
Just minor updates so that the reference doc titles match the audit titles pretty much verbatim