### PR TITLE
[devtools] deprecate the old forced synchronous layouts tutorial

### DIFF
--- a/src/content/en/tools/chrome-devtools/_toc.yaml
+++ b/src/content/en/tools/chrome-devtools/_toc.yaml
@@ -102,6 +102,7 @@ toc:
         path: /web/tools/chrome-devtools/rendering-tools/js-execution
       - title: Diagnose Forced Synchronous Layouts
         path: /web/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts
+        status: deprecated
     - title: Measure Network Performance
       section:
       - title: Get Started

--- a/src/content/en/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/en/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -2,13 +2,17 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Follow along with this interactive guide to learn how to use  DevTools to diagnose forced synchronous layouts.
 
-{# wf_updated_on: 2016-03-31 #}
+{# wf_updated_on: 2017-04-24 #}
 {# wf_published_on: 2015-04-13 #}
 
 # Diagnose Forced Synchronous Layouts {: .page-title }
 
 {% include "web/_shared/contributors/kaycebasques.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
+
+Warning: This page is deprecated. See [Get Started With Analyzing Runtime
+Performance](/web/tools/chrome-devtools/evaluate-performance) for an
+up-to-date tutorial on forced synchronous layouts.
 
 Learn how to use DevTools to diagnose forced synchronous 
 layouts.


### PR DESCRIPTION
As the warning mentions, it's largely redundant with the new runtime perf tutorial