### PR TITLE
Fix English and formatting, date article

### DIFF
--- a/src/content/en/updates/2011/11/Quota-Management-API-Fast-Facts.md
+++ b/src/content/en/updates/2011/11/Quota-Management-API-Fast-Facts.md
@@ -10,42 +10,6 @@ book_path: /web/updates/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 November 2011
 
-HTML5 introduced various offline-related features to modern browsers. While offline is convenient, its concept of quota has been left untouched for a long time. The latest version of Chrome supports the first implementation of the *Quota Management API*. The API handles quota for AppCache, IndexedDB, WebSQL and the File System API combined. Here’s a list of things you should keep in mind when working with the Quota Management API in Chrome.
-
-(The specific numbers and details noted below are not a part of HTML5 but the facts in the current Chrome implementation.  The API and Quota management in Chrome are still evolving and the details may change over the time.)
-
-* HTML5 has two notions of storage: `TEMPORARY`, and `PERSISTENT`:
-    * `TEMPORARY` storage can be used without requesting quota, but may be deleted at the browser’s discretion.
-    * `PERSISTENT` storage is never deleted without the user’s instruction, but usually requires an upfront quota request to use.
-
-* `TEMPORARY` storage is shared between all applications and websites run in the browser.
-    * `TEMPORARY` storage has a default quota of 50% of the available disk as a shared pool (e.g. 50GB => 25GB). This is no longer restricted to 1GB.<br>(To be more specific, TEMP quota is calculated according to the formula (<i>remaining disk space + TEMP storage space) * 50%</i>.  Therefore if apps are using 25GB of TEMP storage in total and the current remaining disk space is 25GB, that means the quota has already been exceeded.)
-    * Each application is limited to 20% of the available `TEMPORARY` storage pool (i.e. 20% of 50% of available disk). (Not restricted to 5Mb anymore.)
-    * When the `TEMPORARY` storage quota is exceeded, _all the data (incl. AppCache, IndexedDB, WebSQL, File System API) stored for oldest used origin gets deleted_.<br>[Note: since each app can only use up to 20% of the pool, this won’t happen very frequently unless the user has more than 5 active offline apps.]
-    * If an app tries to make a modification which will result in exceeding the `TEMPORARY` storage quota (20% of pool), an error will be thrown.
-    * Each application can query how much data is stored or how much more space is available for the app by calling the `queryUsageAndQuota()` method of the Quota API.
-
-          webkitStorageInfo.queryUsageAndQuota(
-              webkitStorageInfo.TEMPORARY,   // or PERSISTENT
-              usageCallback,
-              errorCallback);
-
-    * Requesting more quota against `TEMPORARY` storage doesn’t do anything.
-    * Requesting quota for `TEMPORARY` storage using `webkitRequestFileSystem()` doesn’t actually allocate / change quota.
-
-* For `PERSISTENT` storage, its default quota is 0 and it needs to be explicitly requested per application using the `requestQuota()` method of the Quota API.
-    * The allocated space can be used only by the File System API (for `PERSISTENT` type filesystem) and there’s no such thing like `PERSISTENT` storage on _IndexedDB_, _WebSQL DB_ or _AppCache_ (yet).
-
-          webkitStorageInfo.requestQuota(
-              webkitStorageInfo.PERSISTENT
-              newQuotaInBytes,
-              quotaCallback,
-              errorCallback);
-
-
-* Setting `unlimitedStorage` in the `manifest.json` of Chrome Web Apps has been suggested as a temporary solution for apps to work without the Quota API. There is no guarantee that Chrome will continue supporting this feature.
-
-The API is described in detail on W3C's site: [Quota Management API](https://www.w3.org/TR/quota-api/).
-
+**NOTE** this article is out of date. Please see [Persistent Storage](https://developers.google.com/web/updates/2016/06/persistent-storage) instead.
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/11/Quota-Management-API-Fast-Facts.md
+++ b/src/content/en/updates/2011/11/Quota-Management-API-Fast-Facts.md
@@ -10,20 +10,20 @@ book_path: /web/updates/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 November 2011
 
-HTML5 introduced various offline-related features to modern browsers. While offline is convenient, its concept of quota has been left untouched for a long time. The latest version of Chrome browser has the first concept and its implementation of *Quota Management API*. It handles quota for AppCache, IndexedDB, WebSQL and File System API. Here’s a list of things you should keep in mind when working with Quota Management API in the latest Chrome.
+HTML5 introduced various offline-related features to modern browsers. While offline is convenient, its concept of quota has been left untouched for a long time. The latest version of Chrome supports the first implementation of the *Quota Management API*. The API handles quota for AppCache, IndexedDB, WebSQL and the File System API combined. Here’s a list of things you should keep in mind when working with the Quota Management API in Chrome.
 
-(The specific numbers and details noted below are not a part of HTML5 but the facts in the current Chrome implementation.  The API and Quota management in Chrome is still evolving and the details may change over the time.)
+(The specific numbers and details noted below are not a part of HTML5 but the facts in the current Chrome implementation.  The API and Quota management in Chrome are still evolving and the details may change over the time.)
 
-* On HTML5 storage, there’s a notion of `TEMPORARY` storage and `PERSISTENT` storage.
+* HTML5 has two notions of storage: `TEMPORARY`, and `PERSISTENT`:
     * `TEMPORARY` storage can be used without requesting quota, but may be deleted at the browser’s discretion.
-    * `PERSISTENT` storage is never deleted without the user’s instruction, but usually requires up-front quota request to use.
+    * `PERSISTENT` storage is never deleted without the user’s instruction, but usually requires an upfront quota request to use.
 
-* For `TEMPORARY` storage, it is shared between all applications and websites run in the browser.
-    * `TEMPORARY` storage has a default quota of 50% of available disk as a shared pool. (50GB => 25GB)  (Not restricted to 1GB anymore)<br>[To be more specific, TEMP quota is calculated by (<i>remaining disk space + TEMP storage space) * 50%</i>.  Therefore if apps are using 25GB TEMP storage in total and the current remaining disk space is 25GB that’s already full.]
-    * Each application has a limitation to have 20% of the available `TEMPORARY` storage pool (i.e. 20% of 50% of available disk). (Not restricted to 5Mb anymore)
-    * When `TEMPORARY` storage quota is exceeded, _all the data (incl. AppCache, IndexedDB, WebSQL, File System API) stored for oldest used origin gets deleted_.<br>[Note: since each app can only use up to 20% of the pool, this won’t happen very frequently unless the user has more than 5 active offline apps.]
-    * If an app tries to make a modification which will result in exceeding `TEMPORARY` storage quota (20% of pool), an error will be thrown.
-    * Each application can query how much data is stored or how much more space is available for the app by calling the `queryUsageAndQuota()` method of Quota API.
+* `TEMPORARY` storage is shared between all applications and websites run in the browser.
+    * `TEMPORARY` storage has a default quota of 50% of the available disk as a shared pool (e.g. 50GB => 25GB). This is no longer restricted to 1GB.<br>(To be more specific, TEMP quota is calculated according to the formula (<i>remaining disk space + TEMP storage space) * 50%</i>.  Therefore if apps are using 25GB of TEMP storage in total and the current remaining disk space is 25GB, that means the quota has already been exceeded.)
+    * Each application is limited to 20% of the available `TEMPORARY` storage pool (i.e. 20% of 50% of available disk). (Not restricted to 5Mb anymore.)
+    * When the `TEMPORARY` storage quota is exceeded, _all the data (incl. AppCache, IndexedDB, WebSQL, File System API) stored for oldest used origin gets deleted_.<br>[Note: since each app can only use up to 20% of the pool, this won’t happen very frequently unless the user has more than 5 active offline apps.]
+    * If an app tries to make a modification which will result in exceeding the `TEMPORARY` storage quota (20% of pool), an error will be thrown.
+    * Each application can query how much data is stored or how much more space is available for the app by calling the `queryUsageAndQuota()` method of the Quota API.
 
           webkitStorageInfo.queryUsageAndQuota(
               webkitStorageInfo.TEMPORARY,   // or PERSISTENT
@@ -33,9 +33,8 @@ HTML5 introduced various offline-related features to modern browsers. While offl
     * Requesting more quota against `TEMPORARY` storage doesn’t do anything.
     * Requesting quota for `TEMPORARY` storage using `webkitRequestFileSystem()` doesn’t actually allocate / change quota.
 
-* For `PERSISTENT` storage, its default quota is 0 and it needs to be explicitly requested per application using `requestQuota()` of Quota API.
-    * The allocated space can be used only by File System API (for `PERSISTENT` type filesystem) and there’s no such thing like `PERSISTENT` storage on _IndexedDB, WebSQL DB or AppCache_ (yet).
-
+* For `PERSISTENT` storage, its default quota is 0 and it needs to be explicitly requested per application using the `requestQuota()` method of the Quota API.
+    * The allocated space can be used only by the File System API (for `PERSISTENT` type filesystem) and there’s no such thing like `PERSISTENT` storage on _IndexedDB_, _WebSQL DB_ or _AppCache_ (yet).
 
           webkitStorageInfo.requestQuota(
               webkitStorageInfo.PERSISTENT
@@ -44,9 +43,9 @@ HTML5 introduced various offline-related features to modern browsers. While offl
               errorCallback);
 
 
-* Setting `unlimitedStorage` in the `manifest.json` of Chrome Web Apps has been suggested as a temporary solution for apps to work without Quota API. There is no guarantee that Chrome will continue supporting this feature indefinitely.
+* Setting `unlimitedStorage` in the `manifest.json` of Chrome Web Apps has been suggested as a temporary solution for apps to work without the Quota API. There is no guarantee that Chrome will continue supporting this feature.
 
-* The API is described in WebIDL in this [File System API changes for Chrome 13](https://groups.google.com/a/chromium.org/group/chromium-html5/msg/5261d24266ba4366?pli=1) thread from 2011.
+The API is described in detail on W3C's site: [Quota Management API](https://www.w3.org/TR/quota-api/).
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/11/Quota-Management-API-Fast-Facts.md
+++ b/src/content/en/updates/2011/11/Quota-Management-API-Fast-Facts.md
@@ -8,46 +8,45 @@ book_path: /web/updates/_book.yaml
 # Quota Management API : Fast Facts {: .page-title }
 
 {% include "web/_shared/contributors/agektmr.html" %}
+November 2011
 
-
-There’s various offline related features introduced to modern browsers through HTML5. While offline is convenient, its concept of quota has been left untouched for a long time. The latest version of Chrome browser has the first concept and its implementation of *Quota Management API*. It handles quota for AppCache, IndexedDB, WebSQL and File System API. Here’s a list of things you should keep in mind when working with Quota Management API in the latest Chrome.
+HTML5 introduced various offline-related features to modern browsers. While offline is convenient, its concept of quota has been left untouched for a long time. The latest version of Chrome browser has the first concept and its implementation of *Quota Management API*. It handles quota for AppCache, IndexedDB, WebSQL and File System API. Here’s a list of things you should keep in mind when working with Quota Management API in the latest Chrome.
 
 (The specific numbers and details noted below are not a part of HTML5 but the facts in the current Chrome implementation.  The API and Quota management in Chrome is still evolving and the details may change over the time.)
 
 * On HTML5 storage, there’s a notion of `TEMPORARY` storage and `PERSISTENT` storage.
-    * `TEMPORARY` storage can be used without requesting quota, but may be deleted at the browser's discretion.
-    * `PERSISTENT` storage is never deleted without the user's instruction, but usually requires up-front quota request to use.
+    * `TEMPORARY` storage can be used without requesting quota, but may be deleted at the browser’s discretion.
+    * `PERSISTENT` storage is never deleted without the user’s instruction, but usually requires up-front quota request to use.
 
 * For `TEMPORARY` storage, it is shared between all applications and websites run in the browser.
-    * `TEMPORARY` storage has a default quota of 50% of available disk as a shared pool. (50GB => 25GB)  (Not restricted to 1GB anymore)<br>[To be more specific, TEMP quota is calucalated by (<i>remaining disk space + TEMP storage space) * 50%</i>.  Therefore if apps are using 25GB TEMP storage in total and the current remaining disk space is 25GB that’s already full.]
+    * `TEMPORARY` storage has a default quota of 50% of available disk as a shared pool. (50GB => 25GB)  (Not restricted to 1GB anymore)<br>[To be more specific, TEMP quota is calculated by (<i>remaining disk space + TEMP storage space) * 50%</i>.  Therefore if apps are using 25GB TEMP storage in total and the current remaining disk space is 25GB that’s already full.]
     * Each application has a limitation to have 20% of the available `TEMPORARY` storage pool (i.e. 20% of 50% of available disk). (Not restricted to 5Mb anymore)
-    * When `TEMPORARY` storage quota is exceeded, _all the data (incl. AppCache, IndexedDB, WebSQL, File System API) stored for oldest used origin gets deleted_ .<br>[Note: since each app can only use up to 20% of the pool, this won’t happen very frequently unless the user has more than 5 active offline apps.]
-    * If app tries to make a modification which will result in exceeding `TEMPORARY` storage quota (20% of pool), an error will be thrown.
-    * Each application can query how much data is stored or how much more space is available for the app by calling `queryUsageAndQuota()` method of Quota API.
+    * When `TEMPORARY` storage quota is exceeded, _all the data (incl. AppCache, IndexedDB, WebSQL, File System API) stored for oldest used origin gets deleted_.<br>[Note: since each app can only use up to 20% of the pool, this won’t happen very frequently unless the user has more than 5 active offline apps.]
+    * If an app tries to make a modification which will result in exceeding `TEMPORARY` storage quota (20% of pool), an error will be thrown.
+    * Each application can query how much data is stored or how much more space is available for the app by calling the `queryUsageAndQuota()` method of Quota API.
+
+          webkitStorageInfo.queryUsageAndQuota(
+              webkitStorageInfo.TEMPORARY,   // or PERSISTENT
+              usageCallback,
+              errorCallback);
+
     * Requesting more quota against `TEMPORARY` storage doesn’t do anything.
     * Requesting quota for `TEMPORARY` storage using `webkitRequestFileSystem()` doesn’t actually allocate / change quota.
-
-
-    webkitStorageInfo.queryUsageAndQuota(
-      webkitStorageInfo.TEMPORARY,   // or PERSISTENT
-      usageCallback,
-      errorCallback);
-    
 
 * For `PERSISTENT` storage, its default quota is 0 and it needs to be explicitly requested per application using `requestQuota()` of Quota API.
     * The allocated space can be used only by File System API (for `PERSISTENT` type filesystem) and there’s no such thing like `PERSISTENT` storage on _IndexedDB, WebSQL DB or AppCache_ (yet).
 
 
-    webkitStorageInfo.requestQuota(
-      webkitStorageInfo.PERSISTENT
-      newQuotaInBytes,
-      quotaCallback,
-      errorCallback);
-    
+          webkitStorageInfo.requestQuota(
+              webkitStorageInfo.PERSISTENT
+              newQuotaInBytes,
+              quotaCallback,
+              errorCallback);
 
-* `unlimitedStorage` on manifest.json of Chrome Web App has been brought as a temporary solution for apps to work without Quota API. So, there’s no guarantee that Chrome will support this feature forever.
 
-* The API is described in WebIDL here: [https://groups.google.com/a/chromium.org/group/chromium-html5/msg/5261d24266ba4366?pli=1](https://groups.google.com/a/chromium.org/group/chromium-html5/msg/5261d24266ba4366?pli=1)
+* Setting `unlimitedStorage` in the `manifest.json` of Chrome Web Apps has been suggested as a temporary solution for apps to work without Quota API. There is no guarantee that Chrome will continue supporting this feature indefinitely.
+
+* The API is described in WebIDL in this [File System API changes for Chrome 13](https://groups.google.com/a/chromium.org/group/chromium-html5/msg/5261d24266ba4366?pli=1) thread from 2011.
 
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
https://developers.google.com/web/updates/2011/11/Quota-Management-API-Fast-Facts

Drive-by English fixes.

Code blocks didn't show:

![image](https://cloud.githubusercontent.com/assets/33569/25363223/eaef4908-290d-11e7-9a8f-26fafa00ce67.png)

CC @agektmr 