### PR TITLE
Fix `include` implementation

### DIFF
--- a/devsiteHelper.py
+++ b/devsiteHelper.py
@@ -266,6 +266,7 @@ def getInclude(includeTag, lang='en'):
   fileName = fileName.replace('"', '')
   fileName = fileName.replace('\'', '')
   fileName = fileName.strip()
+  result = None
   if fileName == 'comment-widget.html':
     result = '<style>'
     result += '#gplus-comment-container { border: 1px solid #c5c5c5; }'
@@ -374,7 +375,7 @@ def getAnnouncementBanner(lang='en'):
 
 
 def getFooterPromo(lang='en'):
-  """Gets the promo footer. 
+  """Gets the promo footer.
 
   Args:
       lang: The language to pick from.
@@ -407,7 +408,7 @@ def getFooterPromo(lang='en'):
 
 
 def getFooterLinkBox(lang='en'):
-  """Gets the promo boxes. 
+  """Gets the promo boxes.
 
   Args:
       lang: The language to pick from.


### PR DESCRIPTION
Currently, an `{% include"xyz.html" %}` of a non-existent file crashes the development server. This patch fixes the behavior to how it was obviously intended – but wasn’t implemented correctly.