### PR TITLE
Wrong link in "Getting-started" page

### DIFF
--- a/src/content/en/fundamentals/getting-started/index.md
+++ b/src/content/en/fundamentals/getting-started/index.md
@@ -49,7 +49,7 @@ or adding a new feature to an existing application.  Find more codelabs on
   </p>
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     Adding Push Notifications
   </a>
   <p>

--- a/src/content/es/fundamentals/getting-started/index.md
+++ b/src/content/es/fundamentals/getting-started/index.md
@@ -49,7 +49,7 @@ o de agregado de una nueva función a una app existente.  Encuentra más codelab
   </p>
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     Agregado de notificaciones push
   </a>
   <p>

--- a/src/content/id/fundamentals/getting-started/index.md
+++ b/src/content/id/fundamentals/getting-started/index.md
@@ -49,7 +49,7 @@ atau menambahkan fitur baru ke aplikasi yang ada.  Temukan codelab selengkapnya 
  </p>
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     Menambahkan Pemberitahuan Push
  </a>
   <p>

--- a/src/content/ja/fundamentals/getting-started/index.md
+++ b/src/content/ja/fundamentals/getting-started/index.md
@@ -47,7 +47,7 @@ book_path: /web/fundamentals/_book.yaml
 
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     プッシュ通知の追加
   </a>
   <p>

--- a/src/content/ko/fundamentals/getting-started/index.md
+++ b/src/content/ko/fundamentals/getting-started/index.md
@@ -49,7 +49,7 @@ book_path: /web/fundamentals/_book.yaml
   </p>
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     푸시 알림 추가
   </a>
   <p>

--- a/src/content/pt-br/fundamentals/getting-started/index.md
+++ b/src/content/pt-br/fundamentals/getting-started/index.md
@@ -49,7 +49,7 @@ como uma experiência de tela inteira de alto nível.
   </p>
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     Adicionar Notificações Push
   </a>
   <p>

--- a/src/content/zh-cn/fundamentals/getting-started/index.md
+++ b/src/content/zh-cn/fundamentals/getting-started/index.md
@@ -49,7 +49,7 @@ book_path: /web/fundamentals/_book.yaml
 
 </div>
 <div class="attempt-right">
-  <a href="codelabs/debugging-service-workers/">
+  <a href="codelabs/push-notifications/">
     添加推送通知
   </a>
   <p>


### PR DESCRIPTION
Fixed erroneous link from "debugging-service-workers/" to "push-notifications/" in i10n "Getting-started > Welcome" page.