### PR TITLE
Fix #3578: Author photo's get squashed when the bio is long

### DIFF
--- a/src/templates/contributors/include.html
+++ b/src/templates/contributors/include.html
@@ -1,8 +1,8 @@
 <style>
 .wf-byline {display: inline-flex; margin: 16px 32px 16px 0;}
 .wf-byline .attempt-left {margin: 0 16px 0 0;}
-.wf-byline img {border-radius: 100%; width: 64px; height: 64px;}
-.wf-byline .wf-byline-desc {font-size: smaller;}
+.wf-byline img {border-radius: 100%; min-width: 64px; height: 64px;}
+.wf-byline .wf-byline-desc {font-size: smaller; word-break: break-word;}
 .wf-byline .wf-byline-social {font-size: smaller;}
 </style>
 


### PR DESCRIPTION
#3578
Addressed the issue, plus also addressed single long strings breaking the page. 
**Mutual issue**

![screenshot from 2017-05-02 23-57-10](https://cloud.githubusercontent.com/assets/24438869/25633137/c5b81c3c-2f93-11e7-86d0-bc63d0001ead.png)

**PR's commit also solves this issue**
![screenshot from 2017-05-02 23-58-53](https://cloud.githubusercontent.com/assets/24438869/25633163/decd0d18-2f93-11e7-835f-c39e3e22e848.png)

