### PR TITLE
adding another itunes tag, required for new podcast submissions, basi…

### DIFF
--- a/src/templates/shows/podcast.xml
+++ b/src/templates/shows/podcast.xml
@@ -23,6 +23,7 @@
       {{{ description }}}
     </itunes:summary>
     <itunes:image href="{{ image }}" />
+    <itunes:explicit>no</itunes:explicit>
     <enclosure url="{{ podcast.audioUrl }}" length="{{podcast.fileSize}}" type="audio/mpeg"/>
     <guid isPermaLink="true">{{ ../host }}{{ url }}</guid>
     <pubDate>{{ podcast.pubDate }}</pubDate>


### PR DESCRIPTION
There is an itunes tag called <itunes:explicit> that is required for new podcast submissions. I have added <itunes:explicit>no</itunes:explicit> into the template file by default. 