### PR TITLE
Add markups to support RTL languages (fixes #4539)

### DIFF
--- a/devsitePage.py
+++ b/devsitePage.py
@@ -115,7 +115,15 @@ def getPage(requestPath, lang):
         toc = re.sub(r'<li>', '<li class="devsite-nav-item">', toc)
 
       # Replaces <pre> tags with prettyprint enabled tags
-      content = re.sub(r'^<pre>(?m)', r'<pre class="prettyprint">', content)
+      # and sets dir attibute to auto to look fine in RTL languages
+      content = re.sub(r'^<pre>(?m)', r'<pre class="prettyprint" dir="auto">', content)
+      content = re.sub(r'^<pre class="prettyprint">(?m)',
+                       r'<pre class="prettyprint" dir="auto">', content)
+      
+      # Surrounds code tags with bdi tags to look properly in RTL languages
+      # without it, function() will appear like ()function in Arabic text!
+      content = re.sub(r'<code>(?m)', r'<bdi><code>', content)
+      content = re.sub(r'</code>(?m)', r'</code></bdi>', content)
 
       # Get the page title from the markup.
       titleRO = re.search(r'<h1 class="page-title".*?>(.*?)<\/h1>', content)

--- a/gae/article.tpl
+++ b/gae/article.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
-  <head>
+  <head dir="auto">
     <meta charset="utf-8" />
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,400,400italic,500,500italic,700,700italic|Roboto+Mono:400,500,700|Material+Icons">
     <link rel="stylesheet" href="/wf-local/styles/devsite-google-blue.css">
@@ -95,8 +95,8 @@
             {% endautoescape %}
           </nav>
           <nav class="devsite-page-nav devsite-nav">
-            <ul class="devsite-page-nav-list">
-              <li class="devsite-nav-item devsite-nav-item-heading">
+            <ul class="devsite-page-nav-list" dir="auto">
+              <li class="devsite-nav-item devsite-nav-item-heading" dir="auto">
                 <a href="#top_of_page" class="devsite-nav-title">
                   <span>Contents</span>
                 </a>
@@ -123,7 +123,7 @@
                   <span class="devsite-rating-stats"></span>
                 </div>
               </div>
-              <div class="devsite-article-body clearfix">
+              <div class="devsite-article-body clearfix" dir="auto">
                 {% autoescape off %}{{ content }}{% endautoescape %}
               </div>
               <div class="devsite-content-footer nocontent">

--- a/src/content/en/_shared/udacity/ud811.html
+++ b/src/content/en/_shared/udacity/ud811.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Intro to Progressive Web Apps</h2>
   <a href="https://udacity.com/ud811">
     <img src="/web/shows/udacity/img/ud811.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud860.html
+++ b/src/content/en/_shared/udacity/ud860.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Browser Rendering Optimizations</h2>
   <a href="https://udacity.com/ud860">
     <img src="/web/shows/udacity/img/ud860.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud882.html
+++ b/src/content/en/_shared/udacity/ud882.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Responsive Images</h2>
   <a href="https://udacity.com/ud882">
     <img src="/web/shows/udacity/img/ud882.png" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud884.html
+++ b/src/content/en/_shared/udacity/ud884.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Critical Rendering Path</h2>
   <a href="https://udacity.com/ud884">
     <img src="/web/shows/udacity/img/ud884.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud890.html
+++ b/src/content/en/_shared/udacity/ud890.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Building High Conversion Web Forms</h2>
   <a href="https://udacity.com/ud890">
     <img src="/web/shows/udacity/img/ud890.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud891.html
+++ b/src/content/en/_shared/udacity/ud891.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Web Accessibility</h2>
   <a href="https://udacity.com/ud891">
     <img src="/web/shows/udacity/img/ud891.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud892.html
+++ b/src/content/en/_shared/udacity/ud892.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Web Tooling and Automation</h2>
   <a href="https://udacity.com/ud892">
     <img src="/web/shows/udacity/img/ud892.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud893.html
+++ b/src/content/en/_shared/udacity/ud893.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Responsive Web Design</h2>
   <a href="https://udacity.com/ud893">
     <img src="/web/shows/udacity/img/ud893.jpg" class="attempt-right" itemprop="image">

--- a/src/content/en/_shared/udacity/ud899.html
+++ b/src/content/en/_shared/udacity/ud899.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/Course">
+<div itemscope itemtype="http://schema.org/Course" dir="ltr">
   <h2 itemprop="name">Offline Web Applications</h2>
   <a href="https://udacity.com/ud899">
     <img src="/web/shows/udacity/img/ud899.png" class="attempt-right" itemprop="image">

--- a/src/templates/contributors/include.html
+++ b/src/templates/contributors/include.html
@@ -1,12 +1,12 @@
 <style>
-.wf-byline {display: inline-flex; margin: 16px 32px 16px 0;}
+.wf-byline {display: flex; margin: 16px 32px 16px 0;}
 .wf-byline .attempt-left {margin: 0 16px 0 0;}
 .wf-byline img {border-radius: 100%; width: 64px; height: 64px;}
 .wf-byline .wf-byline-desc {font-size: smaller;}
 .wf-byline .wf-byline-social {font-size: smaller;}
 </style>
 
-<section class="wf-byline" itemscope itemtype="http://schema.org/Person">
+<section class="wf-byline" itemscope itemtype="http://schema.org/Person" dir="ltr">
   <div class="attempt-left">
     <figure>
       <img itemprop="image" src="/web/images/contributors/{{photo}}.jpg" alt="{{name.given}} {{name.family}}">


### PR DESCRIPTION
Related issue: #4539 

This solution is based on W3C articles:

1. [Creating HTML Pages in Arabic, Hebrew and Other Right-to-left Scripts (tutorial)](https://www.w3.org/International/tutorials/bidi-xhtml)
2. [Structural markup and right-to-left text in HTML](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics)

There're other articles from W3C to read about this, but I'm tired & busy to read them now and wanted to share what I have with you. Maybe someone could see this fix as an appropriate fix and add to it. Or, it could be inapplicable for the project and I should stop!

Known issues:
1. no margins in the right toc.
2. In RTL languages (tested with Arabic), lines with English text only flow from RTL! (Could be fixed by wrapping it with `<bdi>` or `<span>`, didn't test but should work. Or add `dir=auto` to every paragraph!
3. English-only headings are from RTL in RTL languages. Either it should be translated or wrapped with `<bdi>` / span

I just test Arabic and English text which look fine to me. Maybe other languages need extra treatments...

Suggested reviewers:
@PaulKinlan, @samdutton, @petele, @ianbarber (because you were involved with localisation & RTL issues)