### PR TITLE
headless chrome: use execFile()

### DIFF
--- a/src/content/en/updates/2017/04/headless-chrome.md
+++ b/src/content/en/updates/2017/04/headless-chrome.md
@@ -133,12 +133,12 @@ want to spawn Chrome _from_ your application.
 One way is to use `child_process`:
 
 ```javascript
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 
 function launchHeadlessChrome(url, callback) {
   // Assuming MacOSx.
   const CHROME = '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome';
-  exec(`${CHROME} --headless --disable-gpu --remote-debugging-port=9222 ${url}`, callback);
+  execFile(CHROME, ['--headless', '--disable-gpu', '--remote-debugging-port=9222', url], callback);
 }
 
 launchHeadlessChrome('https://www.chromestatus.com', (err, stdout, stderr) => {

--- a/src/content/ja/updates/2017/04/headless-chrome.md
+++ b/src/content/ja/updates/2017/04/headless-chrome.md
@@ -104,12 +104,12 @@ Chrome を `--remote-debugging-port=9222` フラグつきで実行すると、[D
 それを実現するひとつの方法が `child_process` です。
 
 ```javascript
-const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 
 function launchHeadlessChrome(url, callback) {
   // macOS を想定
   const CHROME = '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome';
-  exec(`${CHROME} --headless --disable-gpu --remote-debugging-port=9222 ${url}`, callback);
+  execFile(CHROME, ['--headless', '--disable-gpu', '--remote-debugging-port=9222', url], callback);
 }
 
 launchHeadlessChrome('https://www.chromestatus.com', (err, stdout, stderr) => {


### PR DESCRIPTION
`exec()` spawns a shell, which means that unsanitised user input must not be passed. The example suggests doing exactly that. Presumably people will use Lighthouse, but nevertheless I don't think such a potentially dangerous approach should be shown as an example.

This commit changes the example to use `execFile()`. This does not spawn a shell, avoiding the security risks of `exec()`.