### PR TITLE
fix framebox emulator

### DIFF
--- a/devsiteHelper.py
+++ b/devsiteHelper.py
@@ -237,7 +237,7 @@ def renderDevSiteContent(content, lang='en'):
     replaceWith = '<iframe class="framebox inherit-locale'
     if fbClass:
      replaceWith += ' ' + fbClass.group(1)
-    replaceWith += + '" '
+    replaceWith += '" '
     replaceWith += 'style="width: 100%;'
     if fbHeight:
       replaceWith += 'height:' + fbHeight.group(1) + ';'


### PR DESCRIPTION
Repro:

1. Add this to a page:

       {% framebox width="auto" height="auto" enable_widgets="true" %}
         <p>this is my framebox</p>
       {% endframebox %}

2. Run `start-appengine.sh`
3. Access the page