### PR TITLE
make inline feedback widget more flexible

### DIFF
--- a/src/content/en/_shared/multichoice.html
+++ b/src/content/en/_shared/multichoice.html
@@ -1,0 +1,40 @@
+<script>
+function disableButtons() {
+  var buttons = document.querySelectorAll('button');
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].disabled = true;
+  }
+}
+function makeButtonAndResponse(choice, responseContainer) {
+  var b = document.createElement('button'),
+      response = document.createElement('aside'),
+      classes = 'button gc-analytics-event' + (choice.button.primary ? ' button-primary' : '');
+  response.className = 'note';
+  response.style.display = 'none';
+  response.innerHTML = choice.response;
+  b.textContent = choice.button.text;
+  b.type = 'button';
+  b.className = classes;
+  b.dataset.value = choice.analytics.hasOwnProperty('value') ?
+      choice.analytics.value : 1;
+  b.dataset.label = choice.analytics.label;
+  b.dataset.category = feedback.category;
+  b.addEventListener('click', function(e) {
+    response.style.display = 'block';
+    disableButtons();
+  });
+  document.body.appendChild(b);
+  responseContainer.appendChild(response);
+}
+var responseContainer = document.createElement('div');
+if (feedback.hasOwnProperty('question')) {
+  var question = document.createElement('p');
+  question.textContent = feedback.question;
+  document.body.appendChild(question);
+}
+for (var i = 0; i < feedback.choices.length; i++) {
+  var choice = feedback.choices[i];
+  makeButtonAndResponse(choice, responseContainer);
+}
+document.body.appendChild(responseContainer);
+</script>

--- a/src/content/en/tools/chrome-devtools/evaluate-performance/index.md
+++ b/src/content/en/tools/chrome-devtools/evaluate-performance/index.md
@@ -23,6 +23,50 @@ Caution: This tutorial is based on Chrome 59. If you use another version of
 Chrome, the UI and features of DevTools may be different. Check `chrome://help`
 to see what version of Chrome you're running.
 
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<script>
+var response1 = "That's OK! This tutorial covers how the Performance panel works in depth. You " +
+    "should have no problem following along.";
+var response2 = "The Performance panel is pretty complicated. You may still learn some new stuff!";
+var feedback = {
+  "category": "DevTools",
+  "question": "Let's get started! How much do you use the Performance panel?",
+  "choices": [
+    {
+      "button": {
+        "text": "Never used it"
+      },
+      "response": response1,
+      "analytics": {
+        "label": "Runtime Tutorial / Experience / None",
+        "value": 0 // optional, defaults to 1 if omitted
+      }
+    },
+    {
+      "button": {
+        "text": "Sometimes"
+      },
+      "response": response1,
+      "analytics": {
+        "label": "Runtime Tutorial / Experience / Some",
+        "value": 0.5
+      }
+    },
+    {
+      "button": {
+        "text": "All the time"
+      },
+      "response": response2,
+      "analytics": {
+        "label": "Runtime Tutorial / Experience / A Lot"
+      }
+    }
+  ]
+};
+</script>
+{% include "web/_shared/multichoice.html" %}
+{% endframebox %}
+
 ## Get started {: #get-started }
 
 In this tutorial, you open DevTools on a live page and use the Performance

--- a/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html
+++ b/src/content/en/tools/chrome-devtools/javascript/_feedback/1.html
@@ -1,8 +1,0 @@
-{% setvar category "DevTools" %}
-{% setvar label "JS / Get Started / (1) Reproduced The Bug" %}
-{% setvar url %}https://github.com/google/webfundamentals/issues/new?title=[{{ category }} / {{ label }}] {% endsetvar %}
-{% setvar success_button "I reproduced the bug" %}
-{% setvar success_response "Thanks for the feedback. Please continue to answer these questions. They help us identify problems in the tutorial." %}
-{% setvar fail_button "I can't reproduce the bug" %}
-{% setvar fail_response %}Sorry to hear that. Please <a href="{{url}}">open an issue</a> and tell us more.{% endsetvar %}
-{% include "web/_shared/feedback.html" %}

--- a/src/content/en/tools/chrome-devtools/javascript/index.md
+++ b/src/content/en/tools/chrome-devtools/javascript/index.md
@@ -46,7 +46,40 @@ to fix in this tutorial.
 Whoops. That result is wrong. The result should be `6`. This is the bug that
 you're going to fix.
 
-{% include "web/tools/chrome-devtools/javascript/_feedback/1.html" %}
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<script>
+var label = 'JS / Get Started / (1) Reproduced The Bug';
+var url = 'https://github.com/google/webfundamentals/issues/new?title=[' +
+      label + ']';
+var feedback = {
+  "category": "DevTools",
+  "choices": [
+    {
+      "button": {
+        "text": "I reproduced the bug",
+        "primary": true
+      },
+      "response": "You're off to a good start!",
+      "analytics": {
+        "label": label
+      }
+    },
+    {
+      "button": {
+        "text": "I can't reproduce the bug"
+      },
+      "response": 'Sorry to hear that. Please <a href="' + url +
+          '" target="_blank">open an issue</a> and tell us what happened.',
+      "analytics": {
+        "label": label,
+        "value": 0
+      }
+    }
+  ]
+};
+</script>
+{% include "web/_shared/multichoice.html" %}
+{% endframebox %}
 
 ## Step 2: Pause the code with a breakpoint
 


### PR DESCRIPTION
Hey @petele check it out:

* by storing the question / response data in JSON and populating the framebox with a little JS, we can support questions with any number of choices. see [evaluate-performance/index.md](https://github.com/google/WebFundamentals/compare/master...kaycebasques:wf-multichoicefeedback?expand=1#diff-dd6e42295cd623684916dbe974b717b7) for an example of a question with three choices (v1 of the widget is hard-coded to only support two choices)
* this refactor can also replace the v1 widget. it handles all of v1's features 100%. see [javascript/index.md](https://github.com/google/WebFundamentals/compare/master...kaycebasques:wf-multichoicefeedback?expand=1#diff-f755648971e7f7ec554c20e5ff5454cd) for example
* I like that I can include the JSON directly in the page. In v1 there's too much indirection and it's tedious to author
* I like the flexibility of a JS solution

In general I'm very happy with this new workflow. Let me know if you're cool with it