### PR TITLE
Update application name based on manifest.json

### DIFF
--- a/src/content/en/ilt/pwa/lab-auditing-with-lighthouse.md
+++ b/src/content/en/ilt/pwa/lab-auditing-with-lighthouse.md
@@ -171,13 +171,13 @@ Replace TODO 4.3 in <strong>index.html</strong> with the following:
 
 <!-- Add to homescreen for Chrome on Android -->
 <meta name="mobile-web-app-capable" content="yes">
-<meta name="application-name" content="PSK">
+<meta name="application-name" content="Blog">
 <link rel="icon" sizes="192x192" href="images/touch/icon-192x192.png">
 
 <!-- Add to homescreen for Safari on iOS -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
-<meta name="apple-mobile-web-app-title" content="Polymer Starter Kit">
+<meta name="apple-mobile-web-app-title" content="Blog">
 <link rel="apple-touch-icon" href="images/touch/icon-192x192.png">
 
 <!-- Tile for Win8 -->


### PR DESCRIPTION
Issue observed on: [https://developers.google.com/web/ilt/pwa/lab-auditing-with-lighthouse](https://developers.google.com/web/ilt/pwa/lab-auditing-with-lighthouse).

In mainfest.json the app's name is 'Blog' 
```
  "short_name": "Blog",
```
while in meta tags it is 'PSK'  and 'Polymer Starter Kit'
```
<meta name="apple-mobile-web-app-title" content="Polymer Starter Kit">
<meta name="application-name" content="PSK">
```

This pull request names them all 'Blog'. 
