### PR TITLE
Less abrupt link to the shim

### DIFF
--- a/src/content/en/fundamentals/discovery-and-monetization/payment-request/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/discovery-and-monetization/payment-request/deep-dive-into-payment-request.md
@@ -46,7 +46,7 @@ it's stable enough to implement, it may continue to change. We'll <a
 href="/web/updates/2017/01/payment-request-updates">keep this page updated</a>
 to always reflect the current status of the API. Meanwhile, to protect yourself
 from API changes that may be backwards incompatible, we're offering <a
-href="https://storage.googleapis.com/prshim/v1/payment-shim.js">a shim</a> that
+href="#paymentrequest_shim">a shim</a> that
 can be embedded on your site. The shim will paper over any API differences for
 two major Chrome versions.
 


### PR DESCRIPTION
BTW, is there a reason the markup in this paragraph is HTML rather than Markdown? Maybe `Dogfood:` doesn't support Markdown?