### PR TITLE
[devtools] fix css demos

### DIFF
--- a/src/content/en/tools/chrome-devtools/css/_background-color.html
+++ b/src/content/en/tools/chrome-devtools/css/_background-color.html
@@ -1,0 +1,26 @@
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<style>
+p {
+  display: inline-block;
+  border: 1px dashed red;
+  padding: 1em;
+}
+</style>
+<p id="target">Add A Background Color To Me!</p>
+<aside id="response" class="success" style="display:none">Success!</aside>
+<script>
+let target = document.getElementById('target'),
+    response = document.getElementById('response');
+let observer = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    response.style.display =
+        target.style.backgroundColor === 'honeydew' ? 'block' : 'none';
+    devsite.framebox.AutoSizeClient.updateSize();
+  });
+});
+let observerConfig = {
+  attributes: true
+};
+observer.observe(target, observerConfig);
+</script>
+{% endframebox %}

--- a/src/content/en/tools/chrome-devtools/css/_class.html
+++ b/src/content/en/tools/chrome-devtools/css/_class.html
@@ -1,0 +1,56 @@
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<style>
+/* red orange yellow green blue indigo violet */
+@keyframes rainbow {
+  0% {
+    background-color: violet;
+  }
+  14% {
+    background-color: red;
+  }
+  28% {
+    background-color: orange;
+  }
+  42% {
+    background-color: yellow;
+  }
+  56% {
+    background-color: green;
+  }
+  70% {
+    background-color: blue;
+  }
+  84% {
+    background-color: indigo;
+  }
+  100% {
+    background-color: violet;
+  }
+}
+.color_me {
+  animation: rainbow 10s linear infinite;
+}
+p {
+  display: inline-block;
+  border: 1px dashed red;
+  padding: 1em;
+}
+</style>
+<p id="target">Add A Class To Me!</p>
+<aside id="response" class="success" style="display:none">Success!</aside>
+<script>
+let target = document.getElementById('target'),
+    response = document.getElementById('response');
+let observer = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    response.style.display =
+        target.classList.contains('color_me') ? 'block' : 'none';
+    devsite.framebox.AutoSizeClient.updateSize();
+  });
+});
+let observerConfig = {
+  attributes: true
+};
+observer.observe(target, observerConfig);
+</script>
+{% endframebox %}

--- a/src/content/en/tools/chrome-devtools/css/_data-message.html
+++ b/src/content/en/tools/chrome-devtools/css/_data-message.html
@@ -1,0 +1,14 @@
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<form>
+  Value of <code>data-message</code>: <input id="target" type="text" size="10"/>
+</form>
+<aside id="response" class="success" style="display:none">Correct!</aside>
+<script>
+let target = document.getElementById('target'),
+    response = document.getElementById('response');
+target.addEventListener('keyup', (e) => {
+  response.style.display = target.value === 'peekaboo!' ? 'block' : 'none';
+  devsite.framebox.AutoSizeClient.updateSize();
+});
+</script>
+{% endframebox %}

--- a/src/content/en/tools/chrome-devtools/css/_margin.html
+++ b/src/content/en/tools/chrome-devtools/css/_margin.html
@@ -1,0 +1,26 @@
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<style>
+p {
+  display: inline-block;
+  border: 1px dashed red;
+  padding: 1em;
+}
+</style>
+<p id="target">Change My Margin!</p>
+<aside id="response" class="success" style="display:none">Success!</aside>
+<script>
+let target = document.getElementById('target'),
+    response = document.getElementById('response');
+let observer = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    response.style.display =
+        target.style.marginLeft === '100px' ? 'block' : 'none';
+    devsite.framebox.AutoSizeClient.updateSize();
+  });
+});
+let observerConfig = {
+  attributes: true
+};
+observer.observe(target, observerConfig);
+</script>
+{% endframebox %}

--- a/src/content/en/tools/chrome-devtools/css/_padding.html
+++ b/src/content/en/tools/chrome-devtools/css/_padding.html
@@ -1,0 +1,15 @@
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<form>
+  Value of <code>padding</code>: <input id="target" type="text" size="10"/>
+</form>
+<aside id="response" class="success" style="display:none">Correct!</aside>
+<script>
+let target = document.getElementById('target'),
+    response = document.getElementById('response');
+target.addEventListener('keyup', (e) => {
+  response.style.display =
+      target.value === '1em' ? 'block' : 'none';
+  devsite.framebox.AutoSizeClient.updateSize();
+});
+</script>
+{% endframebox %}

--- a/src/content/en/tools/chrome-devtools/css/index.md
+++ b/src/content/en/tools/chrome-devtools/css/index.md
@@ -85,18 +85,7 @@ var feedback = {
 
 1. Enter the value in the text box below.
 
-     {% framebox width="auto" height="auto" enable_widgets="true" %}
-     <form>
-       Value of <code>data-message</code>: <input type="text" size="10"/>
-     </form>
-     <aside class="success" style="display:none">Correct!</aside>
-     <script>
-     document.querySelector('input').addEventListener('keyup', (e) => {
-       document.querySelector('aside').style.display =
-           e.target.value === 'peekaboo!' ? 'block' : 'none';
-     });
-     </script>
-     {% endframebox %}
+     {% include "web/tools/chrome-devtools/css/_data-message.html" %}
 
 1. The **Styles** tab on the **Elements** panel lists the CSS rules being
    applied to whatever element is currently selected in the **DOM Tree**,
@@ -107,18 +96,7 @@ var feedback = {
 1. The `aloha` class is declaring a value for `padding`. Enter that value
    in the text box below.
 
-     {% framebox width="auto" height="auto" enable_widgets="true" %}
-     <form>
-       Value of <code>padding</code>: <input type="text" size="10"/>
-     </form>
-     <aside class="success" style="display:none">Correct!</aside>
-     <script>
-     document.querySelector('input').addEventListener('keyup', (e) => {
-       document.querySelector('aside').style.display =
-           e.target.value === '1em' ? 'block' : 'none';
-     });
-     </script>
-     {% endframebox %}
+     {% include "web/tools/chrome-devtools/css/_padding.html" %}
 
 <figure>
   <img src="imgs/inspect.png"
@@ -150,34 +128,7 @@ before doing this one.
 1. Right-click the `Add A Background Color To Me!` text below and select
    **Inspect**.
 
-     {% framebox width="auto" height="auto" enable_widgets="true" %}
-     <style>
-     p {
-       display: inline-block;
-       border: 1px dashed red;
-       padding: 1em;
-     }
-     </style>
-     <p>Add A Background Color To Me!</p>
-     <aside class="success" style="display:none">Success!</aside>
-     <script>
-     var observer = new MutationObserver((mutations) => {
-       mutations.forEach((mutation) => {
-         if (mutation.target.style.backgroundColor === 'honeydew') {
-           document.querySelector('aside').style.display = 'block';
-         }
-       });
-     });
-     var observerConfig = {
-       attributes: true,
-       childList: false,
-       characterData: false,
-       attributeOldValue: true
-     };
-     var targetNode = document.querySelector('p');
-     observer.observe(targetNode, observerConfig);
-     </script>
-     {% endframebox %}
+     {% include "web/tools/chrome-devtools/css/_background-color.html" %}
 
 1. Click `element.style` near the top of the **Styles** tab.
 1. Type `background-color` and press <kbd>Enter</kbd>.
@@ -204,64 +155,7 @@ before doing this one.
 
 1. Right-click the `Add A Class To Me!` element below and select **Inspect**.
 
-     {% framebox width="auto" height="auto" enable_widgets="true" %}
-     <style>
-     /* red orange yellow green blue indigo violet */
-     @keyframes rainbow {
-       0% {
-         background-color: violet;
-       }
-       14% {
-         background-color: red;
-       }
-       28% {
-         background-color: orange;
-       }
-       42% {
-         background-color: yellow;
-       }
-       56% {
-         background-color: green;
-       }
-       70% {
-         background-color: blue;
-       }
-       84% {
-         background-color: indigo;
-       }
-       100% {
-         background-color: violet;
-       }
-     }
-     .color_me {
-       animation: rainbow 10s linear infinite;
-     }
-     p {
-       display: inline-block;
-       border: 1px dashed red;
-       padding: 1em;
-     }
-     </style>
-     <p>Add A Class To Me!</p>
-     <aside class="success" style="display:none">Success!</aside>
-     <script>
-     var observer = new MutationObserver((mutations) => {
-       var p = document.querySelector('p');
-       mutations.forEach((mutation) => {
-         document.querySelector('aside').style.display =
-             p.classList.contains('color_me') ? 'block' : 'none';
-       });
-     });
-     var observerConfig = {
-       attributes: true,
-       childList: false,
-       characterData: false,
-       attributeOldValue: true
-     };
-     var targetNode = document.querySelector('p');
-     observer.observe(targetNode, observerConfig);
-     </script>
-     {% endframebox %}
+     {% include "web/tools/chrome-devtools/css/_class.html" %}
 
 1. Click **.cls**. DevTools reveals a text box where you can add classes
    to the selected element.
@@ -328,33 +222,7 @@ before doing this one.
 
 1. Right-click the `Change My Margin!` element below and select **Inspect**.
 
-     {% framebox width="auto" height="auto" enable_widgets="true" %}
-     <style>
-     p {
-       display: inline-block;
-       border: 1px dashed red;
-       padding: 1em;
-     }
-     </style>
-     <p>Change My Margin!</p>
-     <aside class="success" style="display:none">Success!</aside>
-     <script>
-     var observer = new MutationObserver((mutations) => {
-       mutations.forEach((mutation) => {
-         document.querySelector('aside').style.display = 
-           mutation.target.style.marginLeft === '100px' ? 'block' : 'none';
-       });
-     });
-     var observerConfig = {
-       attributes: true,
-       childList: false,
-       characterData: false,
-       attributeOldValue: true
-     };
-     var targetNode = document.querySelector('p');
-     observer.observe(targetNode, observerConfig);
-     </script>
-     {% endframebox %}
+     {% include "web/tools/chrome-devtools/css/_margin.html" %}
 
 1. In the **Box Model** diagram in the **Styles** tab, hover over
    **padding**. The element's margin is highlighted in the viewport.


### PR DESCRIPTION
`framebox` demos that include arrow functions need to be moved to external files... the DevSite Markdown parser converts the greater-than characters to HTML encodings...

Also fixes logic bugs that I encountered when testing out the changes on the real staging server