### PR TITLE
DevTools: augment network timing details incl Push

### DIFF
--- a/src/content/en/tools/chrome-devtools/network-performance/reference.md
+++ b/src/content/en/tools/chrome-devtools/network-performance/reference.md
@@ -656,6 +656,7 @@ tab:
     * There are higher priority requests.
     * There are already six TCP connections open for this origin, which is
       the limit. Applies to HTTP/1.0 and HTTP/1.1 only.
+    * The browser is briefly allocating space in the disk cache
 * **Stalled**. The request could be stalled for any of the reasons described
   in **Queueing**.
 * **DNS Lookup**. The browser is resolving the request's IP address.
@@ -666,8 +667,12 @@ tab:
 * **Request to ServiceWorker**. The request is being sent to the service
   worker.
 * **Waiting (TTFB)**. The browser is waiting for the first byte of a response.
-  TTFB stands for Time To First Byte.
+  TTFB stands for Time To First Byte. This timing includes 1 round trip of latency
+  and the time the server took to prepare the response.
 * **Content Download**. The browser is receiving the response.
+* **Receiving Push**. The browser is receiving data for this response via HTTP/2
+  Server Push.
+* **Reading Push**. The browser is reading the local data previously receieved.
 
 ### View initiators and dependencies {: #initiators-dependencies }
 

--- a/src/content/en/tools/chrome-devtools/network-performance/reference.md
+++ b/src/content/en/tools/chrome-devtools/network-performance/reference.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: A comprehensive reference of Chrome DevTools Network panel features.
 
-{# wf_updated_on: 2017-04-26 #}
+{# wf_updated_on: 2017-06-21 #}
 {# wf_published_on: 2015-04-13 #}
 
 {% include "web/tools/chrome-devtools/_shared/styles.html" %}


### PR DESCRIPTION
We were missing details on what the Push timings mean. And I augmented definitions of two others.

cc @caseq 