### PR TITLE
Update link to new styleguide in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ the CLA.
 ## Writing Code ##
 
 If your contribution contains code, please make sure that it follows 
-[the style guide](https://google.github.io/styleguide/javascriptguide.xml).
+[the style guide](https://google.github.io/styleguide/jsguide.html).
 Otherwise, we will have to ask you to make changes, and that's no fun for anyone.
 
 ## Formatting HTML ##


### PR DESCRIPTION
The [old link](https://google.github.io/styleguide/javascriptguide.xml) suggests that one should now use the [new version](https://google.github.io/styleguide/jsguide.html)

CLA signed under Jarrod Mosen.