### PR TITLE
Removed a line

### DIFF
--- a/src/content/en/ilt/pwa/index.md
+++ b/src/content/en/ilt/pwa/index.md
@@ -47,8 +47,7 @@ listed at the start.
 ### Concepts
 
 Each codelab has an accompanying text that explains the concepts in the
-codelab in more detail. Links to corresponding texts are included at the
-top of each codelab.
+codelab in more detail.
 
 ### Other Resources
 


### PR DESCRIPTION
We're moving away from linking between internal docs because of the way we're publishing the docs for the ILT in separate Gitbooks. This will make doc maintenance easier.