### PR TITLE
update old sw-helpers link

### DIFF
--- a/src/content/en/showcase/2017/santa.md
+++ b/src/content/en/showcase/2017/santa.md
@@ -282,4 +282,4 @@ While Santa is largely a custom-built solution, many of its principles can be fo
 Project's [App Toolbox](https://www.polymer-project.org/1.0/toolbox/).
 We suggest you check it out if you're building a new PWA from scratch—or, if you're looking for a
 framework-agnostic approach, try the
-[Service Worker Helpers Library](https://github.com/GoogleChrome/sw-helpers).
+[Workbox Library](https://github.com/GoogleChrome/workbox).

--- a/src/content/en/tools/lighthouse/audits/appcache.md
+++ b/src/content/en/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ offline.
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 

--- a/src/content/es/tools/lighthouse/audits/appcache.md
+++ b/src/content/es/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ sin conexión.
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 

--- a/src/content/id/tools/lighthouse/audits/appcache.md
+++ b/src/content/id/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ secara offline.
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 

--- a/src/content/ja/tools/lighthouse/audits/appcache.md
+++ b/src/content/ja/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ Service Worker
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 

--- a/src/content/ko/tools/lighthouse/audits/appcache.md
+++ b/src/content/ko/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ AppCache 매니페스트에서 정의된 동작을 서비스 워커 기반으로
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 

--- a/src/content/pt-br/tools/lighthouse/audits/appcache.md
+++ b/src/content/pt-br/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ off-line.
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 

--- a/src/content/zh-cn/tools/lighthouse/audits/appcache.md
+++ b/src/content/zh-cn/tools/lighthouse/audits/appcache.md
@@ -28,7 +28,7 @@ description:“网站不使用应用缓存”Lighthouse 审查的参考文档。
 
 [API]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 
-[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-helpers/blob/master/packages/sw-appcache-behavior
+[sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 


### PR DESCRIPTION
closes #4831

- This change fixes broken links due to release of workbox (and subsequent repo shuffle). 
- Since this is just broken link fix, I kept `wf_updated_on` unchanged. 
- `wf_blink_components` is not added since this is update to showcase and lightouse

One update article needs content change, it is filed separately [here](https://github.com/google/WebFundamentals/issues/4842)