### PR TITLE
Make `wf_blink_components` tag name mono space

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -516,7 +516,7 @@ function testMarkdown(filename, contents, options) {
         }
       })
     } else {
-      msg = `No wf_blink_components field found in metadata. Add if appropriate.`;
+      msg = 'No `wf_blink_components` field found in metadata. Add if appropriate.';
       logWarning(filename, '', msg);
     }
 


### PR DESCRIPTION
Tiny fix to make log message nicer like other tag. 

![update_old_sw-helpers_link_by_kosamari_ _pull_request__4843_ _google_webfundamentals](https://user-images.githubusercontent.com/4581495/28231307-d6225b10-68b8-11e7-81be-a527855b61ee.png)
