### PR TITLE
Add Stack Overflow links to bluetooth and usb article resources

### DIFF
--- a/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
+++ b/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A Web API has been added to Chrome that makes it possible for websites to discover and communicate with devices over the Bluetooth 4 wireless standard using GATT.
 
-{# wf_updated_on: 2017-04-27 #}
+{# wf_updated_on: 2017-07-19 #}
 {# wf_published_on: 2015-07-21 #}
 {# wf_tags: news,iot,webbluetooth,physicalweb,origintrials #}
 {# wf_featured_image: /web/updates/images/2015-07-22-interact-with-ble-devices-on-the-web/featured.png #}
@@ -508,6 +508,7 @@ Windows 8.1+ and iOS will be supported as much as feasible by the platforms.
 
 ## Resources
 
+- Stack Overflow: [https://stackoverflow.com/questions/tagged/web-bluetooth](https://stackoverflow.com/questions/tagged/web-bluetooth)
 - Web Bluetooth Community: [https://plus.google.com/communities/108953318610326025178](https://plus.google.com/communities/108953318610326025178)
 - Chrome Feature Status: [https://www.chromestatus.com/feature/5264933985976320](https://www.chromestatus.com/feature/5264933985976320)
 - Implementation Bugs: [https://crbug.com/?q=component:Blink>Bluetooth](https://crbug.com/?q=component:Blink>Bluetooth)

--- a/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
+++ b/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: The WebUSB API makes USB safer and easier to use by bringing it to the Web.
 
-{# wf_updated_on: 2016-09-26 #}
+{# wf_updated_on: 2017-07-19 #}
 {# wf_published_on: 2016-03-30 #}
 {# wf_tags: news,webusb,iot,arduino,origintrials #}
 {# wf_featured_image: /web/updates/images/2016-03-02-access-usb-devices-on-the-web/web-usb-hero-sm.jpg #}
@@ -371,6 +371,7 @@ Android in Chrome 54.
 
 ## Resources
 
+- Stack Overflow: [https://stackoverflow.com/questions/tagged/webusb](https://stackoverflow.com/questions/tagged/webusb)
 - WebUSB API Spec: [http://wicg.github.io/webusb/](https://wicg.github.io/webusb/){: .external }
 - Chrome Feature Status: [https://www.chromestatus.com/features/5651917954875392](https://www.chromestatus.com/features/5651917954875392)
 - Spec Issues: [https://github.com/WICG/webusb/issues](https://github.com/WICG/webusb/issues)


### PR DESCRIPTION
As recommended by @scheib, this patch adds Stack Overflow links to bluetooth and usb article resources.