### PR TITLE
restore warning on deleted file

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -322,10 +322,9 @@ function getFiles() {
     });
   } else {
     gutil.log(' ', 'Searching for changed files');
-    // --diff-filter set to ignore deleted files as this will cause error on `testFile()`
-    let cmd = 'git --no-pager diff --name-only --diff-filter=ACMRTUXB ';
+    let cmd = 'git --no-pager diff --name-only ';
     if (IS_TRAVIS) {
-      cmd += 'FETCH_HEAD $(git merge-base FETCH_HEAD master)';
+      cmd += '$(git merge-base FETCH_HEAD master) FETCH_HEAD';
     } else {
       cmd += '$(git merge-base master HEAD)';
     }


### PR DESCRIPTION
Rolls back change in #4800 that throws a warning when a file has been deleted. There was an unintended side effect with that change that caused new files not to be recognized. Also reversed the comparison so that new files are seen as new files, and removed files are seen as deleted.

Keeping the warning that a file has been deleted is a helpful reminder to check to see if any redirects need to be setup.

cc @mustafa-x 