### PR TITLE
Add a warning about where to include the FP/FCP tracking code

### DIFF
--- a/src/content/en/updates/2017/06/user-centric-performance-metrics.md
+++ b/src/content/en/updates/2017/06/user-centric-performance-metrics.md
@@ -617,8 +617,8 @@ window.__trackAbandons = () => {
   // Send the data to Google Analytics via the Measurement Protocol.
   navigator.sendBeacon && navigator.sendBeacon(ANALYTICS_URL, [
     'v=1', 't=event', 'ec=Load', 'ea=abandon', 'ni=1',
-    'dl=' + location.href,
-    'dt=' + document.title,
+    'dl=' + encodeURIComponent(location.href),
+    'dt=' + encodeURIComponent(document.title),
     'tid=' + TRACKING_ID,
     'cid=' + CLIENT_ID,
     'ev=' + Math.round(performance.now()),

--- a/src/content/en/updates/2017/06/user-centric-performance-metrics.md
+++ b/src/content/en/updates/2017/06/user-centric-performance-metrics.md
@@ -368,7 +368,7 @@ follows:
 <aside>
   <p><strong>Important:</strong> you must ensure your <code>PerformanceObserver
   </code> is registered in the <code>&lt;head&gt;</code> of your document
-  before any stylesheets, so it runs before FP/FCP happen.<p>
+  before any stylesheets, so it runs before FP/FCP happens.<p>
   <p>This will no longer be necessary once Level 2 of the <a
   href="https://w3c.github.io/performance-timeline/">Performance Observer spec
   </a> is implemented, as it introduces a <a


### PR DESCRIPTION
This PR updates the section on tracking FP/FCP to include details about how the `PerformanceObserver` (currently) needs to be created prior to the performance event you want to track.