### PR TITLE
Updates title tests to allow encoded html entities

### DIFF
--- a/gulp-tasks/remark-lint-tests/check-headings.js
+++ b/gulp-tasks/remark-lint-tests/check-headings.js
@@ -41,16 +41,11 @@ function wfNoMarkupInTitle(ast, file, setting) {
     if (node.depth !== 1) {
       return;
     }
-    let title = toString(node);
-    if (reHTML.test(title)) {
-      file.message('Top level headings cannot contain HTML elements', node);
-    }
-    if (reMD.test(title)) {
-      file.message('Top level headings cannot contain Markdown', node);  
-    }
-    if (reEntity.test(title)) {
-      file.message('Top level headings cannot contain encoded entities', node);  
-    }
+    node.children.forEach((child) => {
+      if (child.type !== 'text') {
+        file.message('Top level headings must only contain text.', node);
+      }
+    });
   });
 }
 
@@ -69,6 +64,3 @@ function wfTLDR(ast, file, setting) {
     }
   });
 }
-
-
-

--- a/src/tests/page-title-with-md2.md
+++ b/src/tests/page-title-with-md2.md
@@ -1,0 +1,26 @@
+project_path: /web/_project.yaml
+book_path: /web/updates/_book.yaml
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget dapibus libero. Morbi ultricies varius accumsan.
+
+{# wf_published_on: 2017-01-25 #}
+{# wf_updated_on: 2017-02-09 #}
+{# wf_featured_image: /web/updates/images/generic/new-in-chrome.png #}
+{# wf_tags: chrome55,chrome56, new-in-chrome,webvr #}
+
+# This Is **NOT** Allowed in the Page Title {: .page-title }
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget dapibus
+libero. Morbi ultricies varius accumsan. Mauris vel odio semper, ultricies
+diam eu, lobortis enim. 
+
+## This is a sub heading
+
+Phasellus quis nunc leo. Donec lacus mauris, placerat sed turpis ac, eleifend
+iaculis ipsum. Curabitur convallis felis vel lectus mattis, a accumsan magna
+consectetur. Etiam eleifend eget nisi a faucibus. 
+
+### This is a level 3 heading
+
+Sed porttitor ex eget dolor fringilla, eget rutrum odio tempus. Curabitur
+feugiat vitae ex eu tempor. Praesent fermentum leo quis tellus feugiat
+scelerisque vitae at dolor. 


### PR DESCRIPTION
Titles can now contain HTML entities. For example: `# Web Components: &lt;howto-element&gt;`

Tested on DevSite and this behaves properly for both the displayed title and the page title.

@jpmedley - fyi