### PR TITLE
Updated Broken Link for Skeleton screen blog

### DIFF
--- a/src/content/en/progressive-web-apps/checklist.md
+++ b/src/content/en/progressive-web-apps/checklist.md
@@ -226,7 +226,7 @@ on the this list and may prove helpful in easily testing sites.
       <td>        
         If using a single-page-app (client rendered), transition the user to 
         the next page immediately and show a
-        <a href="http://hannahatkin.com/blog/tag/skeleton-screens/">
+        <a href="https://www.sitepoint.com/how-to-speed-up-your-ux-with-skeleton-screens/">
         skeleton screen</a> and use any content such as title or
         thumbnail already available while content loads.
       </td>


### PR DESCRIPTION
The link to skeleton screens blog was broken and no longer available. The new resource link provided has more helpful and reliable information.

Note: I have no affiliation with the associated link. I just found it to be better than everything else I could search for.