### PR TITLE
Updated some glossary terms

### DIFF
--- a/src/data/glossary.yaml
+++ b/src/data/glossary.yaml
@@ -18,28 +18,28 @@
 #   - title: Your First PWA Code Lab (REQUIRED)
 #     link: /web/fundamentals/something (REQUIRED)
 
-- term: Accelerated Mobile pages
+- term: Accelerated Mobile Pages
   description: "Accelerated Mobile Pages are web pages that load very quickly. AMP pages are built with three core components: AMP HTML, AMP JS, and the AMP Cache. AMP HTML is HTML with some restrictions for reliable performance. AMP JS is a library that ensures the fast rendering of AMP HTML pages. The AMP Cache is a proxy-based content delivery network used to serve cached AMP HTML pages."
   acronym: AMP
   see:
     title: The AMP Project
     link: https://www.ampproject.org/learn/overview/
 
-- term: Add to Home Screen
-  description: "A method where Progressive Web App developers can implement web app install banners to help users quickly and easily (with one touch) add web apps to their Android mobile device’s home screen, making it easy to launch and return to an app."
+- term: add to home screen
+  description: "Add to home screen is a method where Progressive Web App developers can implement web app install banners to help users quickly and easily (with one touch) add web apps to their Android mobile device’s home screen, making it easy to launch and return to an app."
   acronym: A2HS
   see:
     title: Web App Install Banners
     link: /web/fundamentals/app-install-banners/
 
-- term: Application Shell
-  description: "An application shell (or app shell) architecture is one way to build a Progressive Web App that reliably and instantly loads on your users' screens, similar to what you see in native applications. The app 'shell' is the minimal HTML, CSS and JavaScript required to power the user interface and when cached offline can ensure instant, reliably good performance to users on repeat visits."
+- term: application shell
+  description: "An application shell (or app shell) architecture is one way to build a Progressive Web App that reliably and instantly loads on your users' screens, similar to what you see in native applications. The app shell is the minimal HTML, CSS and JavaScript required to power the user interface and when cached offline can ensure instant, reliably good performance to users on repeat visits."
   see:
     title: The App Shell Model
     link: /web/fundamentals/architecture/app-shell
 
-- term: Content Delivery Network
-  description: "A network of geographically distributed servers that cooperate to satisfy requests for content. CDNs optimize content delivery by distributing copies of files (such as videos, images, HTML, CSS and JavaScript) to multiple servers. This reduces latency by placing the content closer to the requestor. For example, if a user in India requests a web page from a Brazilian website, the request could be rerouted to deliver assets served from a local CDN server in Mumbai."
+- term: content delivery network
+  description: "A CDN is a network of geographically distributed servers that cooperate to satisfy requests for content. CDNs optimize content delivery by distributing copies of files (such as videos, images, HTML, CSS and JavaScript) to multiple servers. This reduces latency by placing the content closer to the requestor. For example, if a user in India requests a web page from a Brazilian website, the request could be rerouted to deliver assets served from a local CDN server in Mumbai."
   acronym: CDN
   see:
     title: Content deliver network on Wikipedia
@@ -93,7 +93,7 @@
     title: HTTPS on Wikipedia
     link: https://en.wikipedia.org/wiki/HTTPS
 
-- term: Lifecycle Callback
+- term: lifecycle callback
   description: "Every Custom Element has a set of built-in lifecycle callbacks, or \"reactions\" that are called when the element is added/removed from the page, or has an attribute mutated."
   see:
     title: Custom elements - lifecycles
@@ -111,7 +111,7 @@
     title: Detect DOM changes with Mutation Observers
     link: /web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers
 
-- term: Progressive Web App
+- term: progressive web app
   acronym: PWA
   description: "Progressive Web Apps are user experiences that have the reach of the web, and are fast, integrated, reliable and engaging."
   see:
@@ -119,12 +119,12 @@
     link: /web/progressive-web-apps/
 
 - term: Promise
-  description: "An object that is used as a placeholder for the eventual results of a deferred (and possibly asynchronous) computation. JavaScript promises are an addition to ECMAscript 6 that provide a cleaner, more intuitive way to deal with the completion (or failure) of asynchronous tasks."
+  description: "A JavaScript promise is an object that is used as a placeholder for the eventual results of a deferred (and possibly asynchronous) computation. JavaScript promises are an addition to ECMAscript 6 that provide a cleaner, more intuitive way to deal with the completion (or failure) of asynchronous tasks."
   see:
     title: JavaScript Promises
     link: /web/fundamentals/primers/promises
 
-- term: Push Notifications
+- term: push notifications
   description: "Web push notifications make it easy to re-engage with users by showing relevant, timely, and contextual notifications, even when the browser is closed."
   see:
     title: Web Push Notifications
@@ -150,14 +150,14 @@
     title: Measure Performance with the RAIL Model
     link: /web/fundamentals/performance/rail
 
-- term: Responsive Design
+- term: responsive design
   description: "Responsive web design is an approach to web design aimed at making web pages visually appealing and performant on any form factor. In addition, it is important to understand that responsive web design tasks include offering the same content to a variety of devices for a single website."
   see:
     title: Responsive Web Design Basics
     link: /web/fundamentals/design-and-ux/responsive/
 
 - term: Service Worker
-  description: "Service workers essentially act as proxy servers that sit between web applications, and the browser and network (when available). They are intended to (amongst other things) enable the creation of effective offline experiences, intercepting network requests and taking appropriate action based on whether the network is available and updated assets reside on the server. They also allow access to push notifications and background sync APIs."
+  description: "Service workers essentially act as proxy servers that sit between web applications, and the browser and network (when available). They are intended to (amongst other things) enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available and updated assets reside on the server. They also allow access to push notifications and background sync APIs."
   see:
     title: Introduction to Service Workers
     link: /web/fundamentals/primers/service-workers/
@@ -171,15 +171,15 @@
     title: "Shadow DOM v1: Self-Contained Web Components"
     link: /web/fundamentals/architecture/building-components/shadowdom
 
-- term: Single Page App
+- term: single page app
   acronym: SPA
-  description: "User-friendly apps that perform more like desktop apps. Typically, SPA content is rendered dynamically using JavaScript, rather than opening a new page. As a result, single-page applications typically load only data (e.g. in JSON or XML format) rather than pre-rendered HTML. This decreases the data transferred on the wire."
+  description: "An SPA is user-friendly app that performs more like a desktop app. Typically, SPA content is rendered dynamically using JavaScript, rather than opening a new page. As a result, single-page applications typically load only data (e.g. in JSON or XML format) rather than pre-rendered HTML. This decreases the data transferred on the wire."
   links:
   - title: Single-page application on Wikipedia
     link: https://en.wikipedia.org/wiki/Single-page_application
 
-- term: Splash Screen
-  description: "A graphic that is shown to users while an application is loading in the background, giving immediate feedback to the user while the application is launching."
+- term: splash screen
+  description: "A splash screen is a graphic that is shown to users while an application is loading in the background, giving immediate feedback to the user while the application is launching."
 
 - term: Time To First Byte
   acronym: TTFB
@@ -190,8 +190,8 @@
 - term: Time To Interactive
   acronym: TTI
 
-- term: Web App Manifest
-  description: "A JSON-formatted file named manifest.json that is a centralized place to put metadata that controls how the web application appears to the user and how it can be launched. (Do not confuse this with a manifest file used by AppCache.) Some browsers, such as Chrome, use the web app manifest to enable 'add to homescreen'."
+- term: web app manifest
+  description: "A web app manifest is a JSON-formatted file named manifest.json that is a centralized place to put metadata that controls how the web application appears to the user and how it can be launched. (Do not confuse this with a manifest file used by AppCache.) Some browsers, such as Chrome, use the web app manifest to enable 'add to homescreen'."
   see:
     title: The Web App Manifest
     link: /web/fundamentals/web-app-manifest/
@@ -199,7 +199,7 @@
   - title: Web App Manifest spec
     link: https://w3c.github.io/manifest/
 
-- term: Web Components
+- term: web components
   description: "Web components are a set of web platform APIs that allow you to create new custom, reusable, encapsulated HTML tags to use in web pages and web apps. Custom components and widgets build on the Web Component standards, will work across modern browsers, and can be used with any JavaScript library or framework that works with HTML."
   see:
     title: Building Web Components

--- a/src/data/glossary.yaml
+++ b/src/data/glossary.yaml
@@ -45,7 +45,7 @@
     title: Content deliver network on Wikipedia
     link: https://en.wikipedia.org/wiki/Content_delivery_network
 
-- term: Custom Element
+- term: custom element
   description: "A Custom Element is a developer defined HTML tag. These elements are the foundation of Web Components and can be used to create any sort of UI."
   see:
     title: "Custom Elements v1: Reusable Web Components"
@@ -58,8 +58,8 @@
     title: Progressive Web Apps
     link: /web/progressive-web-apps/
 
-- term: Fetch API
-  description: "The Fetch API is a promise-based JavaScript interface for requesting resources and reading responses. It provides a global fetch() method that gives an easy, logical way to fetch resources asynchronously across the network. Fetch is a successor to the older XMLHttpRequest."
+- term: fetch API
+  description: "The fetch API is a promise-based JavaScript interface for requesting resources and reading responses. It provides a global fetch() method that gives an easy, logical way to fetch resources asynchronously across the network. Fetch is a successor to the older XMLHttpRequest."
   see:
     title: Working the with Fetch API
     link: /web/ilt/pwa/working-with-the-fetch-api
@@ -80,7 +80,7 @@
     title: FLIP your animations
     link: https://aerotwist.com/blog/flip-your-animations/
 
-- term: Flexbox
+- term: flexbox
   description: "The Flexible Box Layout Module (Flexbox) is an API that provides tools to make web content responsive. Flexbox provides an efficient way to lay out, align, and distribute space among items in a container, even when their size is unknown and/or dynamic. The API allows the rapid creation of complex, flexible layouts, and features that have historically proved difficult with CSS."
   see:
     title: Flexbox on MDN
@@ -105,20 +105,20 @@
     title: Lighthouse
     link: /web/tools/lighthouse/
 
-- term: Mutation Observer
+- term: mutation observer
   description: "Mutation Observers are a web platform API to detect and react to change to the DOM tree. If an element is observed by a MutationObserver, events like appending a new element or removing and existing one will trigger a function to execute."
   see:
     title: Detect DOM changes with Mutation Observers
     link: /web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers
 
-- term: progressive web app
+- term: Progressive Web App
   acronym: PWA
   description: "Progressive Web Apps are user experiences that have the reach of the web, and are fast, integrated, reliable and engaging."
   see:
     title: Progressive Web Apps
     link: /web/progressive-web-apps/
 
-- term: Promise
+- term: promise
   description: "A JavaScript promise is an object that is used as a placeholder for the eventual results of a deferred (and possibly asynchronous) computation. JavaScript promises are an addition to ECMAscript 6 that provide a cleaner, more intuitive way to deal with the completion (or failure) of asynchronous tasks."
   see:
     title: JavaScript Promises
@@ -165,7 +165,7 @@
   - title: Service Worker API
     link: https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
 
-- term: Shadow DOM
+- term: shadow DOM
   description: "Shadow DOM introduces scoped CSS and DOM to the web platform. It lets developers write encapsulated UI components which can be used in any application."
   see:
     title: "Shadow DOM v1: Self-Contained Web Components"
@@ -173,7 +173,7 @@
 
 - term: single page app
   acronym: SPA
-  description: "An SPA is user-friendly app that performs more like a desktop app. Typically, SPA content is rendered dynamically using JavaScript, rather than opening a new page. As a result, single-page applications typically load only data (e.g. in JSON or XML format) rather than pre-rendered HTML. This decreases the data transferred on the wire."
+  description: "A single page app is user-friendly app that performs more like a desktop app. Typically, SPA content is rendered dynamically using JavaScript, rather than opening a new page. As a result, single-page applications typically load only data (e.g. in JSON or XML format) rather than pre-rendered HTML. This decreases the data transferred on the wire."
   links:
   - title: Single-page application on Wikipedia
     link: https://en.wikipedia.org/wiki/Single-page_application


### PR DESCRIPTION
- Removed unnecessary quotes in the app shell definition 
- Made descriptions consistently repeat the term being defined in the first sentence of the definition
- Fixed grammar in the service worker definition
- Removed init caps from some terms (e.g., changed "Add to Home Screen" to "add to home screen")