### PR TITLE
Comment on PR (not commit) and clean up

### DIFF
--- a/tools/travis/addCommitComment.js
+++ b/tools/travis/addCommitComment.js
@@ -67,7 +67,7 @@ function generateCommitMessage(gitData, testResults) {
  * @return {Promise} The result of the GitHub API push
  */
 function addPRComment(github, gitInfo, body) {
-  return github.repos.createComment({
+  return github.issues.createComment({
     owner: gitInfo.repoOwner,
     repo: gitInfo.repoName,
     number: gitInfo.prNum,
@@ -87,7 +87,7 @@ function deletePreviousPRComments(github, gitInfo) {
     number: gitInfo.prNum,
   })
   .then((issueCommentsData) => {
-    const issueComments = issueCommentsData.data;
+    const issueComments = issueCommentsData.data || [];
     const botIssues = issueComments.filter((issueComment) => {
       return (issueComment.user.login === 'WebFundBot');
     });


### PR DESCRIPTION
WebFundBot current comments on a particular commit instead of the PR. Apply this to multiple commits lead to long threads from the bot.

This PR *should* make the bot comment on the PR itself (instead of the commit) and it'll delete old comments (which will not be relevant after a new change has been filed.

This code is pretty much stripped out of [pr-bot](https://github.com/GoogleChromeLabs/pr-bot/)