### PR TITLE
Don't abbreviate the credential object

### DIFF
--- a/src/content/en/updates/2017/06/credential-management-updates.md
+++ b/src/content/en/updates/2017/06/credential-management-updates.md
@@ -119,11 +119,11 @@ You can use existing methods to deliver credential information to your server:
         providers: [ 'https://accounts.google.com' ]
       },
       mediation: 'silent'
-    }).then(credential => {
-      if (credential) {
+    }).then(passwordCred => {
+      if (passwordCred) {
         let form = new FormData();
-        form.append('email', credential.id);
-        form.append('password', credential.password);
+        form.append('email', passwordCred.id);
+        form.append('password', passwordCred.password);
         form.append('csrf_token', csrf_token);
         return fetch('/signin', {
           method: 'POST',

--- a/src/content/en/updates/2017/06/credential-management-updates.md
+++ b/src/content/en/updates/2017/06/credential-management-updates.md
@@ -119,11 +119,11 @@ You can use existing methods to deliver credential information to your server:
         providers: [ 'https://accounts.google.com' ]
       },
       mediation: 'silent'
-    }).then(c => {
-      if (c) {
+    }).then(credential => {
+      if (credential) {
         let form = new FormData();
-        form.append('email', c.id);
-        form.append('password', c.password);
+        form.append('email', credential.id);
+        form.append('password', credential.password);
         form.append('csrf_token', csrf_token);
         return fetch('/signin', {
           method: 'POST',

--- a/src/content/en/updates/2017/06/credential-management-updates.md
+++ b/src/content/en/updates/2017/06/credential-management-updates.md
@@ -2,11 +2,12 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Latest Updates to the Credential Management API
 
-{# wf_updated_on: 2017-09-01 #}
+{# wf_updated_on: 2017-10-11 #}
 {# wf_published_on: 2017-06-12 #}
 {# wf_tags: performance #}
 {# wf_featured_image: /web/updates/images/generic/security.png #}
 {# wf_featured_snippet: Latest updates coming to the Credential Management API in Chrome 60. Also includes an update landed in Chrome 57. #}
+{# wf_blink_components: Blink #}
 
 # Latest Updates to the Credential Management API {: .page-title }
 
@@ -78,7 +79,8 @@ asynchronously creates credential objects.
   <strong>Warning:</strong>
 Because updates to the Credential Management API landed on Chrome 60 contains
 backward incompatible changes, it's important that your implementation won't be
-triggered on older versions. (If you intentionally want to do so, checkout <a href="https://docs.google.com/document/d/154cO-0d5paDFfhN79GNdet1VeMUmELKhNv3YHvVSOh8/edit">this
+triggered on older versions. (If you intentionally want to do so, checkout
+<a href="https://docs.google.com/document/d/154cO-0d5paDFfhN79GNdet1VeMUmELKhNv3YHvVSOh8/edit">this
 migration guide doc.</a>
 </aside>
 


### PR DESCRIPTION
The credential object should not be abbreviated since it is the whole point of this code example. It took me a second to infer what Eiji was referring to because of this.