### PR TITLE
Fix: semantics-builtin/index.md: markdown syntax

### DIFF
--- a/src/content/ja/fundamentals/accessibility/semantics-builtin/index.md
+++ b/src/content/ja/fundamentals/accessibility/semantics-builtin/index.md
@@ -138,8 +138,7 @@ ChromeVox Lite を有効にしてこのページを参照すると、スクリ�
 
 
 
-![スクリーン リーダーが DOM を使用して、アクセス可能なノードを作成]
-(imgs/nativecodetoacc.png)
+![スクリーン リーダーが DOM を使用して、アクセス可能なノードを作成](imgs/nativecodetoacc.png)
 
 
 {# wf_devsite_translation #}


### PR DESCRIPTION
I fixed the image markdown syntax to parse in Japanese