### PR TITLE
Use the correct document to get template for Custom Element. Fix #5032

### DIFF
--- a/src/content/en/fundamentals/web-components/customelements.md
+++ b/src/content/en/fundamentals/web-components/customelements.md
@@ -732,11 +732,11 @@ structure of a custom element**.
     </template>
 
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }

--- a/src/content/es/fundamentals/web-components/customelements.md
+++ b/src/content/es/fundamentals/web-components/customelements.md
@@ -672,11 +672,11 @@ Para aquellos que no lo conozcan, el [elemento `<template>`](https://html.spec.w
     </template>
     
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }

--- a/src/content/id/fundamentals/web-components/customelements.md
+++ b/src/content/id/fundamentals/web-components/customelements.md
@@ -672,11 +672,11 @@ Bagi mereka yang belum familier, [elemen `<template>`](https://html.spec.whatwg.
     </template>
     
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }

--- a/src/content/ja/fundamentals/web-components/customelements.md
+++ b/src/content/ja/fundamentals/web-components/customelements.md
@@ -666,11 +666,11 @@ if (supportsCustomElementsV1) {
     </template>
     
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }

--- a/src/content/ko/fundamentals/web-components/customelements.md
+++ b/src/content/ko/fundamentals/web-components/customelements.md
@@ -672,11 +672,11 @@ if (supportsCustomElementsV1) {
     </template>
     
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }

--- a/src/content/pt-br/fundamentals/web-components/customelements.md
+++ b/src/content/pt-br/fundamentals/web-components/customelements.md
@@ -672,11 +672,11 @@ Para os que não sabem, o [elemento `<template>`](https://html.spec.whatwg.org/m
     </template>
     
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }

--- a/src/content/zh-cn/fundamentals/web-components/customelements.md
+++ b/src/content/zh-cn/fundamentals/web-components/customelements.md
@@ -666,11 +666,11 @@ if (supportsCustomElementsV1) {
     </template>
     
     <script>
+      const t = document.currentScript.ownerDocument.querySelector('#x-foo-from-template');
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
           super(); // always call super() first in the ctor.
           let shadowRoot = this.attachShadow({mode: 'open'});
-          const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);
           shadowRoot.appendChild(instance);
         }


### PR DESCRIPTION
It fixes the #5032. In the example, it uses document.querySelector to get the template for custom element. But correct method will be document.currentScript.ownerDocument.querySelector. Because template resides in different document.