### PR TITLE
Added missing await operator

### DIFF
--- a/src/content/en/fundamentals/primers/service-workers/high-performance-loading.md
+++ b/src/content/en/fundamentals/primers/service-workers/high-performance-loading.md
@@ -144,7 +144,7 @@ self.addEventListener('fetch', event => {
       }());
 
       // Prefer the cached response, falling back to the fetch response.
-      return caches.match(normalizedUrl) || fetchResponseP;
+      return (await caches.match(normalizedUrl)) || fetchResponseP;
     }());
   }
 });

--- a/src/content/en/fundamentals/primers/service-workers/high-performance-loading.md
+++ b/src/content/en/fundamentals/primers/service-workers/high-performance-loading.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Ensure you're getting the best performance out of your service worker implementation.
 
-{# wf_updated_on: 2017-09-27 #}
+{# wf_updated_on: 2017-11-30 #}
 {# wf_published_on: 2017-09-21 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 


### PR DESCRIPTION
Since caches.match() returns a promise, with the code as is, the async function
will always return that promise. Thus, if what we want is in cache, everything is OK,
but if it's not, the promise passed to e.respondWith() will be resolved with undefined, which
is not what we want. To fix this, we await the promise returned by caches.match().
If it resolves with a response object, we return it, otherwise, the || will make sure that
`fetchResponseP' is returned instead of undefined.