### PR TITLE
Workbox: Adding next release to TOC

### DIFF
--- a/src/content/en/tools/workbox/_toc.yaml
+++ b/src/content/en/tools/workbox/_toc.yaml
@@ -23,3 +23,5 @@ toc:
 - title: Github
   path: https://github.com/GoogleChrome/workbox
   status: external
+- title: Next Release
+  path: /web/tools/workbox/next


### PR DESCRIPTION
Now that URL's are stable, we can publish next release on DevSite.