### PR TITLE
Make left nav a little smarter

### DIFF
--- a/devsiteHelper.py
+++ b/devsiteHelper.py
@@ -247,6 +247,17 @@ def getLeftNav(requestPath, bookYaml, lang='en'):
     lowerTabs = currentUpperTab['lower_tabs']['other']
     for lowerTab in lowerTabs:
       lowerTabPath = getFirstTabPath(lowerTab['contents'])
+
+      # If a left nav starts with a file like "/guides/get-started" in a TOC
+      # yaml we want "/guides/next-page" to have the same TOC.
+      # If the lower tab path does not end in a "/" remove the file name.
+      # Change "/guides/get-started" to '/guides/' to make it match for
+      # "/guides/next-page"
+      if lowerTabPath is not None and not lowerTabPath.endswith('/'):
+        tabPathParts = lowerTabPath.split('/')
+        tabPathParts.pop()
+        lowerTabPath = '/'.join(tabPathParts)+'/'
+
       if (lowerTabPath is None or
         requestPath.startswith(lowerTabPath)):
           result = '<ul class="devsite-nav-list devsite-nav-expandable">\n'


### PR DESCRIPTION
The Workbox navigation is pretty borked on the WebFundamentals version and it's due to the left navigation step.

The main thing causing issues is that in a few places we have a URL in the top of our TOC, like: "/web/tools/workbox/guides/get-started", so for other pages it has the logic "Does '/web/tools/workbox/guides/precaching-files' begin with '/web/tools/workbox/guides/get-started'" which is false. What we really mean is "What is the navigation for "/web/tools/workbox/guides/" since that is where "precaching-files".

This PR is a step in that direction by taking the first path found in a TOC and stripping it back to the containing directory. For "/web/tools/workbox/guides/get-started" the path is altered to "/web/tools/workbox/guides/" which will then match "/web/tools/workbox/guides/precaching-files".

I tested on a few pages throughout WebFundamentals and I didn't see any issues.