### PR TITLE
Exclude workbox-cli from jsdocs

### DIFF
--- a/src/content/en/tools/workbox/_jsdoc.conf
+++ b/src/content/en/tools/workbox/_jsdoc.conf
@@ -3,6 +3,9 @@
     "include": [
       "packages"
     ],
+    "exclude": [
+      "packages/workbox-cli"
+    ],
     "includePattern": ".+\\.(js(doc|x)?|mjs)$",
     "excludePattern": "((^|\\/|\\\\)build(\\/|\\\\)|(^|\\/|\\\\)test(\\/|\\\\)|(^|\\/|\\\\)node_modules(\\/|\\\\)|(^|\\/|\\\\)demo(\\/|\\\\))"
   },


### PR DESCRIPTION
Previous PR epicly broke on merge - let's try again.