### PR TITLE
Only test on push

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "clean": "gulp clean",
     "start": "./start-appengine.sh",
     "test": "gulp test",
-    "precommit": "npm test",
     "prepush": "npm test",
     "prestart": "gulp build",
     "postinstall": "gulp build"


### PR DESCRIPTION
Testing on commit and push means if you write a commit with intention of more work, you get delayed, and if you intend to commit and push, you run the process twice one after the other.

Push should be enough and is what I've seen done on firebase and workbox.