### PR TITLE
Make wf_blink_components required

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -571,15 +571,15 @@ function testMarkdown(filename, contents, options) {
           matched[1].split(',').forEach(function(component) {
             component = component.trim();
             if (options.blinkComponents.indexOf(component) === -1) {
-              msg = `The component \`${component}\` is unknown or misspelled.`;
+              msg = `Unknown 'wf_blink_component' (${component}), see ` +
+                `https://goo.gl/VXmg9e`;
               logError(filename, position, msg);
             }
           });
         }
       } else {
-        msg = 'No `wf_blink_components` attribute found. Please check ' +
-          'https://goo.gl/MVeN2r and add if appropriate.';
-        logWarning(filename, null, msg);
+        msg = `No 'wf_blink_components' found, see https://goo.gl/VXmg9e`;
+        logError(filename, null, msg);
       }
     }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Makes `wf_blink_components` required on new articles

**Fixes:** #5436 

Shortlink points to https://developers.google.com/web/resources/yaml-and-attr-reference#wf_blink_components which isn't live yet, but is essentially https://web-central.appspot.com/web/resources/yaml-and-attr-reference#wf_blink_components

- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.

**R:** @petele, @ebidel 
