### PR TITLE
[Translation zh-tw] Tools > Lighthouse (5)

### DIFF
--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-name.md
@@ -7,7 +7,7 @@ description:“清單包含名稱”Lighthouse 審查的參考文檔。
 
 # 清單包含名稱 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 網絡應用清單的 `name` 屬性是應用的用戶可讀名稱，因爲其作用是在用戶的移動設備上顯示。
 
@@ -15,7 +15,7 @@ description:“清單包含名稱”Lighthouse 審查的參考文檔。
 如果未提供 `short_name`，則 `name` 將作爲標籤顯示在移動設備主屏幕上的應用圖標旁。
 
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 在您的網絡應用清單中添加一個 `name` 屬性。
 
@@ -34,7 +34,8 @@ Chrome 的[最大長度](https://developer.chrome.com/apps/manifest/name)爲 45 
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-Lighthouse 提取清單並驗證它是否具有一個 `name` 屬性。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+Lighthouse 提取清單並驗證它是否具有一個 `name` 屬性。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用
+的清單，這可能會產生不準確的結果。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-name.md
@@ -1,0 +1,42 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“清單包含名稱”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-09-21 #}
+{# wf_published_on:2016-09-21 #}
+
+# 清單包含名稱 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+網絡應用清單的 `name` 屬性是應用的用戶可讀名稱，因爲其作用是在用戶的移動設備上顯示。
+
+
+如果未提供 `short_name`，則 `name` 將作爲標籤顯示在移動設備主屏幕上的應用圖標旁。
+
+
+## 如何通過此審查{: #how }
+
+在您的網絡應用清單中添加一個 `name` 屬性。
+
+    {
+      ...
+      "name": "Air Horner",
+      ...
+    }
+
+Chrome 的[最大長度](https://developer.chrome.com/apps/manifest/name)爲 45 個字符。
+
+
+有關向您展示如何在應用中正確實現和測試“添加到主屏幕”支持的指南清單，請查看[清單是否存在](manifest-exists#how)。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 提取清單並驗證它是否具有一個 `name` 屬性。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -7,13 +7,13 @@ description:“清單包含簡稱”Lighthouse 審查的參考文檔。
 
 # 清單包含簡稱 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 在用戶將您的應用添加到主屏幕後，`short_name` 是顯示在主屏幕上您的應用圖標旁的文本。
 一般情況下，在沒有充足的空間顯示應用的完整名稱時使用它。
 
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 在您的網絡應用清單中添加一個 `short_name` 屬性。
 
@@ -33,7 +33,8 @@ Chrome 的[最大建議長度](https://developer.chrome.com/apps/manifest/name#s
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-如果清單包含一個 `short_name` 或 `name` 屬性，則表示通過了審查。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+如果清單包含一個 `short_name` 或 `name` 屬性，則表示通過了審查。Lighthouse 提取的清單獨立於 Chrome 當前在
+頁面上使用的清單，這可能會產生不準確的結果。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -1,0 +1,41 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“清單包含簡稱”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-09-21 #}
+{# wf_published_on:2016-09-21 #}
+
+# 清單包含簡稱 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+在用戶將您的應用添加到主屏幕後，`short_name` 是顯示在主屏幕上您的應用圖標旁的文本。
+一般情況下，在沒有充足的空間顯示應用的完整名稱時使用它。
+
+
+## 如何通過此審查{: #how }
+
+在您的網絡應用清單中添加一個 `short_name` 屬性。
+
+    {
+      ...
+      "short_name": "Air Horner",
+      ...
+    }
+
+Chrome 的[最大建議長度](https://developer.chrome.com/apps/manifest/name#short_name)爲 12 個字符。
+
+
+
+有關向您展示如何在應用中正確實現和測試“添加到主屏幕”支持的指南清單，請查看[清單是否存在](manifest-exists#how)。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+如果清單包含一個 `short_name` 或 `name` 屬性，則表示通過了審查。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-start_url.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-start_url.md
@@ -1,0 +1,40 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“清單包含 start_url”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-09-21 #}
+{# wf_published_on:2016-09-21 #}
+
+# 清單包含 start_url {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+將您的網絡應用添加到用戶的主屏幕後，當用戶從主屏幕啓動應用時，網絡應用清單中的 `start_url` 屬性決定首先加載應用的哪個頁面。
+
+
+
+如果 `start_url` 屬性不存在，當用戶決定將應用添加到主屏幕時，瀏覽器將默認跳轉到任何處於活動狀態的頁面。
+
+
+## 如何通過此審查{: #how }
+
+在您的網絡應用清單中添加一個 `start_url` 屬性。
+
+    {
+      ...
+      "start_url": ".",
+      ...
+    }
+
+有關向您展示如何在應用中正確實現和測試“添加到主屏幕”支持的指南清單，請查看[清單是否存在](manifest-exists#how)。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 提取清單並驗證它是否具有一個 `start_url` 屬性。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-start_url.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-contains-start_url.md
@@ -7,16 +7,17 @@ description:“清單包含 start_url”Lighthouse 審查的參考文檔。
 
 # 清單包含 start_url {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
-將您的網絡應用添加到用戶的主屏幕後，當用戶從主屏幕啓動應用時，網絡應用清單中的 `start_url` 屬性決定首先加載應用的哪個頁面。
+將您的網絡應用添加到用戶的主屏幕後，當用戶從主屏幕啓動應用時，網絡應用清單中的 `start_url` 屬性決定首先加載
+應用的哪個頁面。
 
 
 
 如果 `start_url` 屬性不存在，當用戶決定將應用添加到主屏幕時，瀏覽器將默認跳轉到任何處於活動狀態的頁面。
 
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 在您的網絡應用清單中添加一個 `start_url` 屬性。
 
@@ -32,7 +33,8 @@ description:“清單包含 start_url”Lighthouse 審查的參考文檔。
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-Lighthouse 提取清單並驗證它是否具有一個 `start_url` 屬性。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+Lighthouse 提取清單並驗證它是否具有一個 `start_url` 屬性。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上
+使用的清單，這可能會產生不準確的結果。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-exists.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-exists.md
@@ -7,13 +7,13 @@ description:“清單是否存在”Lighthouse 審查的參考文檔。
 
 # 清單是否存在 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 網絡應用清單是一項網絡技術，允許您將網絡應用添加到用戶的主屏幕。
 此功能通常稱爲“添加到主屏幕 (A2HS)”。
 
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 有關在現有應用中添加 A2HS 支持的實用分步指南，請查看以下代碼實驗室：[將網絡應用添加到用戶的主屏幕](https://codelabs.developers.google.com/codelabs/add-to-home-screen)。
 
@@ -32,7 +32,8 @@ description:“清單是否存在”Lighthouse 審查的參考文檔。
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-Lighthouse 提取清單並驗證它是否具有數據。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+Lighthouse 提取清單並驗證它是否具有數據。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能
+會產生不準確的結果。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-exists.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-exists.md
@@ -1,0 +1,40 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“清單是否存在”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on: 2017-10-06 #}
+{# wf_published_on:2016-09-20 #}
+
+# 清單是否存在 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+網絡應用清單是一項網絡技術，允許您將網絡應用添加到用戶的主屏幕。
+此功能通常稱爲“添加到主屏幕 (A2HS)”。
+
+
+## 如何通過此審查{: #how }
+
+有關在現有應用中添加 A2HS 支持的實用分步指南，請查看以下代碼實驗室：[將網絡應用添加到用戶的主屏幕](https://codelabs.developers.google.com/codelabs/add-to-home-screen)。
+
+
+
+如需結構較爲鬆散、深入探討網絡應用清單的指南，請參閱[通過網絡應用清單改進用戶體驗](/web/fundamentals/web-app-manifest)。
+
+
+
+運用您在這些指南中學到的知識，在您自己的網絡應用中添加 A2HS 支持。
+
+
+您可以在 Chrome DevTools 中模擬和測試 A2HS 事件。有關更多幫助，請參閱下文：[網絡應用清單](/web/tools/chrome-devtools/debug/progressive-web-apps/#manifest)。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 提取清單並驗證它是否具有數據。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-has-display-set.md
@@ -7,12 +7,12 @@ description:“清單的 display 屬性已設置”Lighthouse 審查的參考文
 
 # 清單的 display 屬性已設置 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 當您的應用從主屏幕啓動時，您可以使用網絡應用清單中的 `display` 屬性指定應用的顯示模式。
 
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 將一個 `display` 屬性添加到您的網絡應用清單，並將其設置爲以下值之一：`fullscreen`、`standalone` 或 `browser`。
 

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-has-display-set.md
@@ -1,0 +1,43 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“清單的 display 屬性已設置”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-09-21 #}
+{# wf_published_on:2016-09-21 #}
+
+# 清單的 display 屬性已設置 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+當您的應用從主屏幕啓動時，您可以使用網絡應用清單中的 `display` 屬性指定應用的顯示模式。
+
+
+## 如何通過此審查{: #how }
+
+將一個 `display` 屬性添加到您的網絡應用清單，並將其設置爲以下值之一：`fullscreen`、`standalone` 或 `browser`。
+
+
+    {
+      ...
+      "display": "fullscreen",
+      ...
+    }
+
+如需瞭解每個值的詳細信息，請參閱 [MDN 上針對顯示屬性的參考](https://developer.mozilla.org/en-US/docs/Web/Manifest#display)。
+
+
+
+有關向您展示如何在應用中正確實現和測試“添加到主屏幕”支持的指南清單，請查看[清單是否存在](manifest-exists#how)。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 提取清單並驗證 `display` 屬性是否存在，且其值是否爲 `fullscreen`、`standalone` 或 `browser`。
+
+
+Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+
+
+
+{# wf_devsite_translation #}


### PR DESCRIPTION
Chinese (Traditional) translation of:
- src/content/zh-tw/tools/lighthouse/audits/manifest-contains-name.md
- src/content/zh-tw/tools/lighthouse/audits/manifest-contains-short_name.md
- src/content/zh-tw/tools/lighthouse/audits/manifest-contains-start_url.md
- src/content/zh-tw/tools/lighthouse/audits/manifest-exists.md
- src/content/zh-tw/tools/lighthouse/audits/manifest-has-display-set.md

Note: All the articles are directly translated from zh-CN.