### PR TITLE
[Translation zh-tw] Tools > Lighthouse (6)

### DIFF
--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -7,7 +7,7 @@ description:“清單的簡稱在主屏幕上顯示時不會截斷”Lighthouse 
 
 # 清單的簡稱在主屏幕上顯示時不會截斷 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 在用戶將您的網絡應用添加到主屏幕時，`short_name` 屬性作爲標籤顯示在您的應用的圖標旁。
 如果 `short_name` 超過 12 個字符，則它在主屏幕上顯示時將被截斷。
@@ -16,7 +16,7 @@ description:“清單的簡稱在主屏幕上顯示時不會截斷”Lighthouse 
 請注意，如果 `short_name` 不存在，Chrome 可以回退到 `name` 屬性（如果它足夠短）。
 
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 在您的網絡應用清單中將 `short_name` 屬性設置爲少於 12 個字符。
 
@@ -36,7 +36,9 @@ description:“清單的簡稱在主屏幕上顯示時不會截斷”Lighthouse 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
 Lighthouse 提取清單並驗證 `short_name` 屬性是否少於 12 個字符。
-請注意，由於 `name` 屬性可以用作 `short_name` 的後備選項，因此，Lighthouse 還會將此屬性作爲後備選項進行測試。因此，如果您沒有在清單中添加 `short_name`，但是您的 `name` 少於 12 個字符，則可以通過審查。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+請注意，由於 `name` 屬性可以用作 `short_name` 的後備選項，因此，Lighthouse 還會將此屬性作爲後備選項進行
+測試。因此，如果您沒有在清單中添加 `short_name`，但是您的 `name` 少於 12 個字符，則可以通過審查。
+Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -1,0 +1,44 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“清單的簡稱在主屏幕上顯示時不會截斷”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-09-21 #}
+{# wf_published_on:2016-09-21 #}
+
+# 清單的簡稱在主屏幕上顯示時不會截斷 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+在用戶將您的網絡應用添加到主屏幕時，`short_name` 屬性作爲標籤顯示在您的應用的圖標旁。
+如果 `short_name` 超過 12 個字符，則它在主屏幕上顯示時將被截斷。
+
+
+請注意，如果 `short_name` 不存在，Chrome 可以回退到 `name` 屬性（如果它足夠短）。
+
+
+## 如何通過此審查{: #how }
+
+在您的網絡應用清單中將 `short_name` 屬性設置爲少於 12 個字符。
+
+    {
+      ...
+      "short_name": "Air Horner",
+      ...
+    }
+
+或者，如果您沒有在清單中指定 `short_name` 屬性，則將 `name` 屬性設置爲少於 12 個字符。
+
+
+有關向您展示如何在應用中正確實現和測試“添加到主屏幕”支持的指南清單，請查看[清單是否存在](manifest-exists#how)。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 提取清單並驗證 `short_name` 屬性是否少於 12 個字符。
+請注意，由於 `name` 屬性可以用作 `short_name` 的後備選項，因此，Lighthouse 還會將此屬性作爲後備選項進行測試。因此，如果您沒有在清單中添加 `short_name`，但是您的 `name` 少於 12 個字符，則可以通過審查。Lighthouse 提取的清單獨立於 Chrome 當前在頁面上使用的清單，這可能會產生不準確的結果。
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/mutation-events.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/mutation-events.md
@@ -7,7 +7,7 @@ description:“網站在其自身的腳本中不使用突變事件”Lighthouse 
 
 # 網站在其自身的腳本中不使用突變事件 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 以下突變事件會損害性能，在 DOM 事件規範中已棄用：
 
@@ -22,7 +22,7 @@ description:“網站在其自身的腳本中不使用突變事件”Lighthouse 
 * `DOMNodeRemovedFromDocument`
 * `DOMSubtreeModified`
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 在 **URLs** 下，Lighthouse 報告它在您的代碼中發現的每個突變事件偵聽器。
 將每個突變事件替換爲 `MutationObserver`。請參閱 MDN 上的 [`MutationObserver`][mdn] 以獲取更多幫助。
@@ -32,7 +32,8 @@ description:“網站在其自身的腳本中不使用突變事件”Lighthouse 
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-Lighthouse 收集頁面上的所有事件偵聽器，並對使用[爲什麼說此審查非常重要](#why)中列出的任意類型的任何偵聽器進行標記。
+Lighthouse 收集頁面上的所有事件偵聽器，並對使用[爲什麼說此審查非常重要](#why)中列出的任意類型的任何偵聽器
+進行標記。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/mutation-events.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/mutation-events.md
@@ -1,0 +1,40 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“網站在其自身的腳本中不使用突變事件”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-10-04 #}
+{# wf_published_on:2016-10-04 #}
+
+# 網站在其自身的腳本中不使用突變事件 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+以下突變事件會損害性能，在 DOM 事件規範中已棄用：
+
+
+* `DOMAttrModified`
+* `DOMAttributeNameChanged`
+* `DOMCharacterDataModified`
+* `DOMElementNameChanged`
+* `DOMNodeInserted`
+* `DOMNodeInsertedIntoDocument`
+* `DOMNodeRemoved`
+* `DOMNodeRemovedFromDocument`
+* `DOMSubtreeModified`
+
+## 如何通過此審查{: #how }
+
+在 **URLs** 下，Lighthouse 報告它在您的代碼中發現的每個突變事件偵聽器。
+將每個突變事件替換爲 `MutationObserver`。請參閱 MDN 上的 [`MutationObserver`][mdn] 以獲取更多幫助。
+
+
+[mdn]: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 收集頁面上的所有事件偵聽器，並對使用[爲什麼說此審查非常重要](#why)中列出的任意類型的任何偵聽器進行標記。
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/no-js.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/no-js.md
@@ -1,0 +1,52 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“頁面在其腳本不可用時包含一些內容”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-09-20 #}
+{# wf_published_on:2016-09-20 #}
+
+# 頁面在其腳本不可用時包含一些內容 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+[漸進式增強](https://en.wikipedia.org/wiki/Progressive_enhancement)是一個網絡開發策略，其確保讓儘可能多的目標設備能夠訪問您的網站。最常見的漸進式增強的定義如下：
+
+
+基本內容和頁面功能應僅依賴最基礎的網絡技術，以確保頁面在所有瀏覽條件下可用。增強的體驗，如使用 CSS 的精細樣式設計，或使用 JavaScript 的交互性，可在支持這些技術的瀏覽器的頂部進行分層。但是基本內容和頁面功能不應依賴於 CSS 或 JavaScript。
+
+
+## 如何通過此審查{: #how }
+
+漸進式增強是一個很大的話題，而且頗具爭議性。其中一派認爲，爲遵循漸進式增強的策略，應對頁面進行分層，這樣基本內容和功能就只需要 HTML。有關此方法的示例，請參閱[漸進式增強：
+概念及使用方式](https://www.smashingmagazine.com/2009/04/progressive-enhancement-what-it-is-and-how-to-use-it/)。
+
+
+另一派則認爲，對於許多現代的大型網絡應用，這個嚴格的方法不可行或者說沒有必要，並建議在文檔 `<head>` 中使用內聯關鍵路徑 CSS 以支持特別重要的頁面樣式。有關此方法的詳細信息，請參閱[關鍵渲染路徑](/web/fundamentals/performance/critical-rendering-path/)。
+
+
+
+
+基於上述因素，此 Lighthouse 審查執行一個簡單的檢查，以確保在停用 JavaScript 時您的頁面不會處於空白狀態。
+您的應用遵循漸進式增強的嚴格程度是一個爭議話題，但人們普遍認爲當停用 JavaScript 時，所有頁面都應至少顯示*一些*信息，即使顯示的內容只是提醒用戶使用此頁面需要 JavaScript。
+
+
+
+
+
+對於必須絕對依賴 JavaScript 的頁面，一種方法是使用一個 [`<noscript>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) 元素，以提醒用戶此頁面需要 JavaScript。這樣好過顯示空白頁面，因爲空白頁面會使用戶不確定是頁面有問題，還是他們的瀏覽器或計算機出現了問題。
+
+
+
+
+要查看停用 JavaScript 時您的網站的外觀和性能，請使用 Chrome DevTools 的[停用 JavaScript](/web/tools/chrome-devtools/settings#disable-js) 功能。
+
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 在頁面上停用 JavaScript，然後檢查頁面的 HTML。如果 HTML 爲空，則表示審查失敗。
+如果 HTML 不爲空，則表示通過了審查。
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/no-js.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/no-js.md
@@ -7,33 +7,40 @@ description:“頁面在其腳本不可用時包含一些內容”Lighthouse 審
 
 # 頁面在其腳本不可用時包含一些內容 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
-[漸進式增強](https://en.wikipedia.org/wiki/Progressive_enhancement)是一個網絡開發策略，其確保讓儘可能多的目標設備能夠訪問您的網站。最常見的漸進式增強的定義如下：
-
-
-基本內容和頁面功能應僅依賴最基礎的網絡技術，以確保頁面在所有瀏覽條件下可用。增強的體驗，如使用 CSS 的精細樣式設計，或使用 JavaScript 的交互性，可在支持這些技術的瀏覽器的頂部進行分層。但是基本內容和頁面功能不應依賴於 CSS 或 JavaScript。
+[漸進式增強](https://en.wikipedia.org/wiki/Progressive_enhancement)是一個網絡開發策略，其確保讓儘可能多
+的目標設備能夠訪問您的網站。最常見的漸進式增強的定義如下：
 
 
-## 如何通過此審查{: #how }
+基本內容和頁面功能應僅依賴最基礎的網絡技術，以確保頁面在所有瀏覽條件下可用。增強的體驗，如使用 CSS 的精細
+樣式設計，或使用 JavaScript 的交互性，可在支持這些技術的瀏覽器的頂部進行分層。但是基本內容和頁面功能不應依
+賴於 CSS 或 JavaScript。
 
-漸進式增強是一個很大的話題，而且頗具爭議性。其中一派認爲，爲遵循漸進式增強的策略，應對頁面進行分層，這樣基本內容和功能就只需要 HTML。有關此方法的示例，請參閱[漸進式增強：
+
+## 如何通過此審查 {: #how }
+
+漸進式增強是一個很大的話題，而且頗具爭議性。其中一派認爲，爲遵循漸進式增強的策略，應對頁面進行分層，這樣基本
+內容和功能就只需要 HTML。有關此方法的示例，請參閱[漸進式增強：
 概念及使用方式](https://www.smashingmagazine.com/2009/04/progressive-enhancement-what-it-is-and-how-to-use-it/)。
 
 
-另一派則認爲，對於許多現代的大型網絡應用，這個嚴格的方法不可行或者說沒有必要，並建議在文檔 `<head>` 中使用內聯關鍵路徑 CSS 以支持特別重要的頁面樣式。有關此方法的詳細信息，請參閱[關鍵渲染路徑](/web/fundamentals/performance/critical-rendering-path/)。
+另一派則認爲，對於許多現代的大型網絡應用，這個嚴格的方法不可行或者說沒有必要，並建議在文檔 `<head>` 中使用內
+聯關鍵路徑 CSS 以支持特別重要的頁面樣式。有關此方法的詳細信息，請參閱[關鍵渲染路徑](/web/fundamentals/performance/critical-rendering-path/)。
 
 
 
 
 基於上述因素，此 Lighthouse 審查執行一個簡單的檢查，以確保在停用 JavaScript 時您的頁面不會處於空白狀態。
-您的應用遵循漸進式增強的嚴格程度是一個爭議話題，但人們普遍認爲當停用 JavaScript 時，所有頁面都應至少顯示*一些*信息，即使顯示的內容只是提醒用戶使用此頁面需要 JavaScript。
+您的應用遵循漸進式增強的嚴格程度是一個爭議話題，但人們普遍認爲當停用 JavaScript 時，所有頁面都應至少
+顯示*一些*信息，即使顯示的內容只是提醒用戶使用此頁面需要 JavaScript。
 
 
 
 
 
-對於必須絕對依賴 JavaScript 的頁面，一種方法是使用一個 [`<noscript>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) 元素，以提醒用戶此頁面需要 JavaScript。這樣好過顯示空白頁面，因爲空白頁面會使用戶不確定是頁面有問題，還是他們的瀏覽器或計算機出現了問題。
+對於必須絕對依賴 JavaScript 的頁面，一種方法是使用一個 [`<noscript>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) 元素，以提醒用戶此頁面需要 
+JavaScript。這樣好過顯示空白頁面，因爲空白頁面會使用戶不確定是頁面有問題，還是他們的瀏覽器或計算機出現了問題。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/noopener.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/noopener.md
@@ -7,7 +7,7 @@ description:“網站使用 rel="noopener" 打開外部錨”Lighthouse 審查�
 
 # 網站使用 rel="noopener" 打開外部錨 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 當您的頁面鏈接至使用 `target="_blank"` 的另一個頁面時，新頁面將與您的頁面在同一個進程上運行。
 如果新頁面正在執行開銷極大的 JavaScript，您的頁面性能可能會受影響。
@@ -21,7 +21,7 @@ description:“網站使用 rel="noopener" 打開外部錨”Lighthouse 審查�
 
 [jake]: https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 將 `rel="noopener"` 添加至 Lighthouse 在您的報告中識別的每個鏈接。
 一般情況下，當您在新窗口或標籤中打開一個外部鏈接時，始終添加 `rel="noopener"`。
@@ -39,7 +39,8 @@ Lighthouse 使用以下算法將鏈接標記爲 `rel="noopener"` 候選項：
 
 
 由於 Lighthouse 會過濾主機相同的鏈接，因此，如果您處理大型網站，則會出現您可能需要注意的邊緣情況。
-如果您的頁面在未使用 `rel="noopener"` 的情況下打開一個指向網站另一個區域的鏈接，則此審查的性能影響仍然適用。不過，在您的 Lighthouse 結果中您不會看到這些鏈接。
+如果您的頁面在未使用 `rel="noopener"` 的情況下打開一個指向網站另一個區域的鏈接，則此審查的性能影響仍然適用。
+不過，在您的 Lighthouse 結果中您不會看到這些鏈接。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/noopener.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/noopener.md
@@ -1,0 +1,46 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“網站使用 rel="noopener" 打開外部錨”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-11-30 #}
+{# wf_published_on:2016-11-30 #}
+
+# 網站使用 rel="noopener" 打開外部錨 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+當您的頁面鏈接至使用 `target="_blank"` 的另一個頁面時，新頁面將與您的頁面在同一個進程上運行。
+如果新頁面正在執行開銷極大的 JavaScript，您的頁面性能可能會受影響。
+
+
+此外，`target="_blank"` 也是一個安全漏洞。新的頁面可以通過 `window.opener` 訪問您的窗口對象，並且它可以使用 `window.opener.location = newURL` 將您的頁面導航至不同的網址。
+
+
+
+如需瞭解詳細信息，請參閱 [rel=noopener 的性能優勢][jake]。
+
+[jake]: https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/
+
+## 如何通過此審查{: #how }
+
+將 `rel="noopener"` 添加至 Lighthouse 在您的報告中識別的每個鏈接。
+一般情況下，當您在新窗口或標籤中打開一個外部鏈接時，始終添加 `rel="noopener"`。
+
+
+    <a href="https://examplepetstore.com" target="_blank" rel="noopener">...</a>
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+Lighthouse 使用以下算法將鏈接標記爲 `rel="noopener"` 候選項：
+
+
+1. 收集所有包含屬性 `target="_blank"`、但不包含屬性 `rel="noopener"` 的 `<a>` 節點。
+1. 過濾任何主機相同的鏈接。
+
+
+由於 Lighthouse 會過濾主機相同的鏈接，因此，如果您處理大型網站，則會出現您可能需要注意的邊緣情況。
+如果您的頁面在未使用 `rel="noopener"` 的情況下打開一個指向網站另一個區域的鏈接，則此審查的性能影響仍然適用。不過，在您的 Lighthouse 結果中您不會看到這些鏈接。
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/notifications-on-load.md
@@ -7,16 +7,17 @@ description:“頁面在加載時不會自動請求通知權限”Lighthouse 審
 
 # 頁面在加載時不會自動請求通知權限 {: .page-title }
 
-## 爲什麼說此審查非常重要{: #why }
+## 爲什麼說此審查非常重要 {: #why }
 
 如[怎樣纔算好的通知][good]中所述，好的通知需要做到及時、相關且精確。
-如果您的頁面在加載時要求權限以發送通知，則這些通知可能與您的用戶無關或者不是他們的精準需求。爲提高用戶體驗，最好是向用戶發送特定類型的通知，並在他們選擇加入後顯示權限請求。
+如果您的頁面在加載時要求權限以發送通知，則這些通知可能與您的用戶無關或者不是他們的精準需求。爲提高用戶體驗，
+最好是向用戶發送特定類型的通知，並在他們選擇加入後顯示權限請求。
 
 
 
 [good]: /web/fundamentals/push-notifications/
 
-## 如何通過此審查{: #how }
+## 如何通過此審查 {: #how }
 
 在 **URLs** 下，Lighthouse 報告您的代碼在其中請求權限以發送通知的行號和列號。
 移除這些調用，將此請求與用戶手勢進行關聯。
@@ -24,10 +25,12 @@ description:“頁面在加載時不會自動請求通知權限”Lighthouse 審
 
 {% include "web/tools/lighthouse/audits/implementation-heading.html" %}
 
-如果在 Lighthouse 審查前，已向頁面授予或拒絕授予通知權限，則 Lighthouse 無法確定此頁面在加載時是否請求通知權限。重置權限並再次運行 Lighthouse。
+如果在 Lighthouse 審查前，已向頁面授予或拒絕授予通知權限，則 Lighthouse 無法確定此頁面在加載時是否請求通知
+權限。重置權限並再次運行 Lighthouse。
 請參閱[更改網站權限][help]以獲取更多幫助。
 
-Lighthouse 收集在頁面加載時執行的 JavaScript。如果此代碼包含對 `notification.requestPermission()` 的調用，且尚未授予通知權限，則會請求通知權限。
+Lighthouse 收集在頁面加載時執行的 JavaScript。如果此代碼包含對 `notification.requestPermission()` 
+的調用，且尚未授予通知權限，則會請求通知權限。
 
 
 

--- a/src/content/zh-tw/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/notifications-on-load.md
@@ -1,0 +1,37 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:“頁面在加載時不會自動請求通知權限”Lighthouse 審查的參考文檔。
+
+{# wf_updated_on:2016-12-05 #}
+{# wf_published_on:2016-12-05 #}
+
+# 頁面在加載時不會自動請求通知權限 {: .page-title }
+
+## 爲什麼說此審查非常重要{: #why }
+
+如[怎樣纔算好的通知][good]中所述，好的通知需要做到及時、相關且精確。
+如果您的頁面在加載時要求權限以發送通知，則這些通知可能與您的用戶無關或者不是他們的精準需求。爲提高用戶體驗，最好是向用戶發送特定類型的通知，並在他們選擇加入後顯示權限請求。
+
+
+
+[good]: /web/fundamentals/push-notifications/
+
+## 如何通過此審查{: #how }
+
+在 **URLs** 下，Lighthouse 報告您的代碼在其中請求權限以發送通知的行號和列號。
+移除這些調用，將此請求與用戶手勢進行關聯。
+
+
+{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+
+如果在 Lighthouse 審查前，已向頁面授予或拒絕授予通知權限，則 Lighthouse 無法確定此頁面在加載時是否請求通知權限。重置權限並再次運行 Lighthouse。
+請參閱[更改網站權限][help]以獲取更多幫助。
+
+Lighthouse 收集在頁面加載時執行的 JavaScript。如果此代碼包含對 `notification.requestPermission()` 的調用，且尚未授予通知權限，則會請求通知權限。
+
+
+
+[help]: https://support.google.com/chrome/answer/6148059
+
+
+{# wf_devsite_translation #}


### PR DESCRIPTION
Chinese (Traditional) translation of:
 - src/content/zh-tw/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
 - src/content/zh-tw/tools/lighthouse/audits/mutation-events.md
 - src/content/zh-tw/tools/lighthouse/audits/no-js.md
 - src/content/zh-tw/tools/lighthouse/audits/noopener.md
 - src/content/zh-tw/tools/lighthouse/audits/notifications-on-load.md

Note: All the articles are directly translated from zh-CN.