### PR TITLE
Fix typo in workbox-cli.md

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-cli.md
+++ b/src/content/en/tools/workbox/modules/workbox-cli.md
@@ -80,7 +80,7 @@ are recommended to use `generateSW` mode.
 
 ### `injectManifest`
 
-For developers who ant more control of their final service worker file
+For developers who want more control of their final service worker file
 can use the `injectManifest` mode. This mode assumes that you have an
 existing service worker file (the location of which is specified in config.js).
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Typo in workbox-cli

**Fixes:** #issue

**Target Live Date:** YYYY-DD-MM

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.

**R:** @petele
