### PR TITLE
[Translation zh-tw] Tools > Chrome Devtools > Console

### DIFF
--- a/src/content/zh-tw/tools/chrome-devtools/console/command-line-reference.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/command-line-reference.md
@@ -1,0 +1,391 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:TODO
+
+{# wf_updated_on: 2015-08-02 #}
+{# wf_published_on: 2015-04-13 #}
+
+# Command Line API 參考 {: .page-title }
+
+{% include "web/_shared/contributors/andismith.html" %}
+{% include "web/_shared/contributors/megginkearney.html" %}
+
+Command Line API 包含一個用於執行以下常見任務的便捷函數集合：選擇和檢查 DOM 元素，以可讀格式顯示數據，停止和啓動分析器，以及監控 DOM 事件。
+
+注：此 API 僅能通過控制檯本身獲取。您無法通過網頁上的腳本訪問 Command Line API。
+
+
+## $_
+
+`$_` 返回最近評估的表達式的值。
+
+在以下示例中，對一個簡單的表達式 (`2 + 2`) 進行評估。然後評估 `$_` 屬性，其包含相同的值：
+
+
+
+
+![$_ 爲最近評估的表達式](images/recently-evaluated-expression-1.png)
+
+在下一個示例中，已評估的表達式最初包含一個名稱數組。評估 `$_.length` 以發現數組的長度，`$_` 中存儲的值變爲最新評估的表達式，即 4：
+
+
+
+
+
+![$_ 在評估新命令時更改](images/recently-evaluated-expression-2.png)
+
+## $0 - $4
+
+`$0`、`$1`、`$2`、`$3` 和 `$4` 命令用作在 Elements 面板中檢查的最後五個 DOM 元素或在 Profiles 面板中選擇的最後五個 JavaScript 堆對象的歷史參考。`$0` 返回最近一次選擇的元素或 JavaScript 對象，`$1` 返回僅在最近一次之前選擇的元素或對象，依此類推。
+
+
+
+
+在以下示例中，在 Elements 面板中選擇一個具有類 `medium` 的元素。在 Console 抽屜式導航欄中，`$0` 已評估，並顯示相同的元素：
+
+
+
+
+![$0 的示例](images/element-0.png)
+
+下圖顯示的是在同一個頁面中選擇的一個不同的元素。`$0` 現在指的是新選擇的元素，而 `$1` 返回以前選擇的元素：
+
+
+
+![$1 的示例](images/element-1.png)
+
+## $(selector)
+
+`$(selector)` 返回帶有指定的 CSS 選擇器的第一個 DOM 元素的引用。此函數等同於 [document.querySelector()](https://docs.webplatform.org/wiki/css/selectors_api/querySelector) 函數。
+
+
+
+
+以下示例在文檔中返回第一個 `<img>` 元素的引用：
+
+
+![$('img') 的示例](images/selector-img.png)
+
+右鍵點擊返回的結果並選擇“Reveal in Elements Panel”以在 DOM 中查找它，或選擇“Scroll in to View”以在頁面上顯示它。
+
+
+
+以下示例返回當前選擇的元素的引用，並顯示它的 src 屬性：
+
+![$('img').src 的示例](images/selector-img-src.png)
+
+注：如果您在使用庫，例如，使用  <code>$</code> 的 jQuery，則此功能將被覆蓋， <code>$</code> 將與該庫的實現對應。
+
+## $$(selector)
+
+`$$(selector)` 返回與給定 CSS 選擇器匹配的元素數組。此命令等同於調用 [document.querySelectorAll()](https://docs.webplatform.org/wiki/css/selectors_api/querySelectorAll)。
+
+
+
+
+以下示例使用 `$$()` 在當前文檔中創建一個所有 `<img>` 元素的數組，並顯示每個元素的 `src` 屬性值：
+
+
+
+		var images = $$('img');
+		for (each in images) {
+			console.log(images[each].src);
+		}
+
+![使用 $$() 選擇文檔中的所有圖像並顯示其來源的示例。](images/all-selector.png)
+
+注：在控制檯中按 <kbd class='kbd'>Shift</kbd> + <kbd class='kbd'>Enter</kbd> 以開始一個新行，無需執行腳本。
+
+## $x(path)
+
+`$x(path)` 返回一個與給定 XPath 表達式匹配的 DOM 元素數組。
+
+
+例如，以下命令返回頁面上的所有 `<p>` 元素：
+
+
+		$x("//p")
+
+![使用 XPath 選擇器的示例](images/xpath-p-example.png)
+
+以下示例返回包含 `<a>` 元素的所有 `<p>` 元素：
+
+
+		$x("//p[a]")
+
+![示例較複雜的 XPath 選擇器的示例](images/xpath-p-a-example.png)
+
+## clear()
+
+`clear()` 清除其歷史記錄的控制檯。
+
+		clear();
+
+## copy(object)
+
+`copy(object)` 將指定對象的字符串表示形式複製到剪貼板。
+
+
+		copy($0);
+
+## debug(function)
+
+調用指定的函數時，將觸發調試程序，並在 Sources 面板上使函數內部中斷，從而允許逐行執行代碼並進行調試。
+
+
+
+		debug(getData);
+
+![使用 debug() 在函數內部中斷](images/debug.png)
+
+使用 `undebug(fn)` 停止函數中斷，或使用 UI 停用所有斷點。
+
+
+如需瞭解有關斷點的詳細信息，請參閱[使用斷點進行調試](/web/tools/chrome-devtools/javascript/add-breakpoints)。
+
+
+## dir(object)
+
+`dir(object)` 顯示所有指定對象的屬性的對象樣式列表。此方法等同於 Console API 的 `console.dir()` 方法。
+
+
+
+以下示例顯示在命令行中直接評估 `document.body` 和使用 `dir()` 顯示相同元素之間的差異：
+
+
+
+		document.body;
+		dir(document.body);
+
+![包含/不含 dir() 函數的日誌記錄 document.body](images/dir.png)
+
+如需瞭解詳細信息，請參閱 Console API 中的 [`console.dir()`](/web/tools/chrome-devtools/debug/console/console-reference#console.dir(object)) 條目。
+
+
+## dirxml(object)
+
+`dirxml(object)` 輸出以 XML 形式表示的指定對象，如 Elements 標籤中所示。此方法等同於 [console.dirxml()](https://developer.mozilla.org/en-US/docs/Web/API/Console) 方法。
+
+
+
+## inspect(object/function) {:#inspect}
+
+`inspect(object/function)` 在相應的面板中打開並選擇指定的元素或對象：針對 DOM 元素使用 Elements 面板，或針對 JavaScript 堆對象使用 Profiles 面板。
+
+
+以下是在“Elements”面板中打開 `document.body` 的示例：
+
+		inspect(document.body);
+
+![使用 inspect() 檢查文檔](images/inspect.png)
+
+當傳遞要檢查的函數時，此函數在 Sources 面板中打開文檔以供您檢查。
+
+
+
+## getEventListeners(object)
+
+`getEventListeners(object)` 返回在指定對象上註冊的事件偵聽器。返回值是一個對象，其包含每個註冊的事件類型（例如，“click”或“keydown”）數組。每個數組的成員是描述爲每個類型註冊的偵聽器的對象。例如，下面列出了在文檔對象上註冊的所有事件偵聽器：
+
+
+
+
+
+
+
+
+
+		getEventListeners(document);
+
+![使用 getEventListeners() 時的輸出](images/get-event-listeners.png)
+
+如果在指定對象上註冊了多個偵聽器，則數組包含每個偵聽器的成員。以下示例中，在 #scrollingList 元素上爲“mousedown”事件註冊了兩個事件偵聽器：
+
+
+
+
+
+![多個偵聽器](images/scrolling-list.png)
+
+您可以進一步展開每個對象以查看他們的屬性：
+
+![展開的 listener 對象的視圖](images/scrolling-list-expanded.png)
+
+## keys(object)
+
+`keys(object)` 返回一個包含屬於指定對象的屬性名稱的數組。如需獲取相同屬性的關聯值，請使用 `values()`。
+
+
+
+
+例如，假設您的應用定義了以下對象：
+
+
+		var player1 = { "name": "Ted", "level": 42 }
+
+假設在全局命名空間中定義了 `player1`（爲簡單起見），那麼，在控制檯輸入 `keys(player1)` 和 `values(player1)` 會生成以下內容：
+
+
+![keys() 和 values() 方法的示例](images/keys-values.png)
+
+## monitor(function)
+
+調用指定函數時，系統會向控制檯記錄一條消息，其中指明函數名稱及在調用時傳遞到該函數的參數。
+
+
+
+
+		function sum(x, y) {
+			return x + y;
+		}
+		monitor(sum);
+
+![monitor() 方法的示例](images/monitor.png)
+
+使用 `unmonitor(function)` 停止監控。
+
+## monitorEvents(object[, events])
+
+當在指定對象上發生一個指定事件時，將 Event 對象記錄到控制檯。您可以指定一個要監控的單獨事件、一個事件數組或一個映射到預定義事件集合的常規事件“類型”。請參閱以下示例。
+
+以下命令監控 window 對象上的所有 resize 事件。
+
+		monitorEvents(window, "resize");
+
+![監控窗口大小調整事件](images/monitor-events.png)
+
+下面定義一個在 window 對象上同時監控“resize”和“scroll”事件的數組：
+
+		monitorEvents(window, ["resize", "scroll"])
+
+您還可以指定一個可用的事件“類型”、映射到預定義事件集的字符串。下表列出了可用的事件類型及其相關的事件映射：
+
+
+
+
+<table class="responsive">
+	<thead>
+		<tr>
+			<th colspan="2">事件類型和對應的已映射事件</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>mouse</td>
+			<td>"mousedown", "mouseup", "click", "dblclick", "mousemove", "mouseover", "mouseout", "mousewheel"</td>
+		</tr>
+		<tr>
+			<td>key</td>
+			<td>"keydown", "keyup", "keypress", "textInput"</td>
+		</tr>
+		<tr>
+			<td>touch</td>
+			<td>"touchstart", "touchmove", "touchend", "touchcancel"</td>
+		</tr>
+		<tr>
+			<td>control</td>
+			<td>"resize", "scroll", "zoom", "focus", "blur", "select", "change", "submit", "reset"</td>
+		</tr>
+	</tbody>
+</table>
+
+例如，以下示例爲 Elements 面板上當前選擇的輸入文本字段上的所有對應 key 事件使用使用“key”事件類型。
+
+
+
+		monitorEvents($0, "key");
+
+下面是在文本字段中輸入字符後的一個輸出示例：
+
+![監控關鍵事件](images/monitor-key.png)
+
+## profile([name]) and profileEnd([name])
+
+`profile()` 使用可選的名稱啓動一個 JavaScript CPU 分析會話。`profileEnd()` 在 Profile 面板中完成分析，並顯示結果。（另請參閱[加速 JavaScript 執行](/web/tools/chrome-devtools/rendering-tools/js-execution)。）
+
+
+
+
+
+開始分析：
+
+		profile("My profile")
+
+在“Profiles”面板中停止分析並顯示結果：
+
+		profileEnd("My profile")
+
+也可以嵌入配置文件。例如，這在任意順序下都起作用：
+
+		profile('A');
+		profile('B');
+		profileEnd('A');
+		profileEnd('B');
+
+“profiles”面板中的結果
+
+![分組的個人資料](images/grouped-profiles.png)
+
+
+注：一次可運行多個 CPU 配置文件，不需要您按創建順序結束它們。
+
+## table(data[, columns])
+
+通過傳入含可選列標題的數據對象記錄具有表格格式的對象數據。例如，要在控制檯中顯示使用 table 的名稱列表，您需要執行：
+
+
+
+
+
+		var names = {
+			0: { firstName: "John", lastName: "Smith" },
+			1: { firstName: "Jane", lastName: "Doe" }
+		};
+		table(names);
+
+![table() 方法的示例](images/table.png)
+
+## undebug(function)
+
+`undebug(function)` 可停止調試指定函數，以便在調用函數時，不再調用調試程序。
+
+
+
+		undebug(getData);
+
+## unmonitor(function)
+
+`unmonitor(function)` 可停止監控指定函數。它可與 `monitor(fn)` 結合使用。
+
+
+		unmonitor(getData);
+
+## unmonitorEvents(object[, events])
+
+`unmonitorEvents(object[, events])` 可停止針對指定對象和事件的事件監控。例如，以下命令可停止 window 對象上的所有事件監控：
+
+
+
+
+		unmonitorEvents(window);
+
+您也可以有選擇性地停止監控某個對象上的特定事件。例如，以下代碼可開始對當前所選元素上所有鼠標事件的監控，然後停止監控“mousemove”事件（可能會減少控制檯輸出的噪音）：
+
+
+
+
+
+		monitorEvents($0, "mouse");
+		unmonitorEvents($0, "mousemove");
+
+## values(object)
+
+`values(object)` 返回一個包含屬於指定對象的所有屬性值的數組。
+
+
+		values(object);
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/command-line-reference.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/command-line-reference.md
@@ -168,7 +168,7 @@ Command Line API 包含一個用於執行以下常見任務的便捷函數集合
 
 
 
-## inspect(object/function) {:#inspect}
+## inspect(object/function) {: #inspect }
 
 `inspect(object/function)` 在相應的面板中打開並選擇指定的元素或對象：針對 DOM 元素使用 Elements 面板，或針對 JavaScript 堆對象使用 Profiles 面板。
 

--- a/src/content/zh-tw/tools/chrome-devtools/console/console-reference.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/console-reference.md
@@ -15,7 +15,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 
 
-## console.assert(expression, object) {:#assert}
+## console.assert(expression, object) {: #assert }
 
 在被評估的表達式爲 `false` 時向控制檯寫入一個[錯誤](#error)。
  
@@ -29,7 +29,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 ![console.assert() 示例](images/assert.png)
 
-## console.clear() {:#clear}
+## console.clear() {: #clear }
 
 清除控制檯。
 
@@ -45,7 +45,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 如需瞭解詳細信息，請參閱[清除控制檯](index#clearing)。
 
-## console.count(label) {:#count}
+## console.count(label) {: #count }
 
 寫入在同一行使用相同標籤調用 `count()` 的次數。
 
@@ -66,7 +66,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 與 [`console.log()`](#log) 作用相同。
 
-## console.dir(object) {:#dir}
+## console.dir(object) {: #dir }
 
 輸出以 JavaScript 形式表示的指定對象。如果正在記錄的對象是 HTML 元素，將輸出其以 DOM 形式表示的屬性，如下所示：
 
@@ -95,7 +95,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 ![console.dirxml() example](images/dirxml.png)
 
-## console.error(object [, object, ...]) {:#error}
+## console.error(object [, object, ...]) {: #error }
 
 輸出一條類似於 [`console.log()`](#log) 的消息，將消息設置成錯誤樣式，並在調用此方法的地方包含一個堆疊追蹤。
 
@@ -161,7 +161,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
     console.groupEnd();
     
 
-## console.groupEnd() {:#groupend}
+## console.groupEnd() {: #groupend }
 
 關閉日誌組。相關示例請參閱 [`console.group`](#group)。
 
@@ -170,7 +170,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 輸出一條類似 [`console.log()`](#log) 的消息，但同時在輸出旁顯示一個圖標（帶白色“i”的藍色圓圈）。
  
 
-## console.log(object [, object, ...]) {:#log}
+## console.log(object [, object, ...]) {: #log}
 
 在控制檯中顯示一條消息。將一個或多個對象傳遞到此方法。每個對象都會進行評估並級聯到一個由空格分隔的字符串中。
 
@@ -179,7 +179,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
     console.log('Hello, Logs!');
     
 
-### 格式說明符{:#format-specifiers}
+### 格式說明符{: #format-specifiers }
 
 您傳遞的第一個對象可以包含一個或多個**格式說明符**。格式說明符由百分號 (`%`) 與緊跟其後面的一個字母組成，字母指示要應用的格式。
 
@@ -189,7 +189,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 * [組織控制檯輸出](console-write)
 
-## console.profile([label]) {:#profile}
+## console.profile([label]) {: #profile }
 
 啓動一個帶有可選標籤的 JavaScript CPU 配置文件。要完成配置文件，請調用 `console.profileEnd()`。
 每一個配置文件都會添加到 **Profiles** 面板中。
@@ -203,14 +203,14 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
     }
     
 
-## console.profileEnd() {:#profileend}
+## console.profileEnd() {: #profileend }
 
 停止當前的 JavaScript CPU 分析會話（如果正在進行此會話），並將報告輸出到 **Profiles** 面板中。
 
 
 相關示例請參閱 [`console.profile()`](#profile)。
 
-## console.time(label) {:#time}
+## console.time(label) {: #time  }
 
 啓動一個具有關聯標籤的新計時器。使用相同標籤調用 `console.timeEnd()` 時，定時器將停止，經過的時間將顯示在控制檯中。計時器值精確到亞毫秒。傳遞到 `time()` 和 `timeEnd()` 的字符串必須匹配，否則計時器不會結束。
 
@@ -227,14 +227,14 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 ![console.time() example](images/time.png)
 
-## console.timeEnd(label) {:#timeend}
+## console.timeEnd(label) {: #timeend }
 
 停止當前的計時器（如果正在運行一個計時器），並將計時器標籤和經過的時間輸出到控制檯。
  
 
 相關示例請參閱 [`console.time()`](#time)。 
 
-## console.timeStamp([label]) {:#timestamp}
+## console.timeStamp([label]) {: #timestamp }
 
 在錄製會話期間向 **Timeline** 添加一個事件。 
 
@@ -249,7 +249,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 * [使用 Timeline 工具](/web/tools/chrome-devtools/evaluate-performance/timeline-tool)
 
 
-## console.trace(object) {:#trace}
+## console.trace(object) {: #trace }
 
 從調用此方法的位置輸出一個堆疊追蹤。 
 
@@ -257,7 +257,7 @@ description:使用 Console API 可以向控制檯寫入信息、創建 JavaScrip
 
 ![console.trace() 示例](images/trace.png)
 
-## console.warn(object [, object, ...]) {:#warn}
+## console.warn(object [, object, ...]) {: #warn }
 
 輸出一條類似 [`console.log()`](#log) 的消息，但同時在記錄的消息旁顯示一個黃色警告圖標。
 

--- a/src/content/zh-tw/tools/chrome-devtools/console/console-reference.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/console-reference.md
@@ -1,0 +1,270 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:使用 Console API 可以向控制檯寫入信息、創建 JavaScript 配置文件，以及啓動調試會話。
+
+{# wf_updated_on: 2016-03-21 #}
+{# wf_published_on: 2016-03-21 #}
+
+# Console API 參考 {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/pbakaus.html" %}
+
+使用 Console API 可以向控制檯寫入信息、創建 JavaScript 配置文件，以及啓動調試會話。
+
+
+
+## console.assert(expression, object) {:#assert}
+
+在被評估的表達式爲 `false` 時向控制檯寫入一個[錯誤](#error)。
+ 
+
+
+    function greaterThan(a,b) {
+      console.assert(a > b, {"message":"a is not greater than b","a":a,"b":b});
+    }
+    greaterThan(5,6);
+    
+
+![console.assert() 示例](images/assert.png)
+
+## console.clear() {:#clear}
+
+清除控制檯。
+
+
+    console.clear();
+    
+
+如果已啓用 [**Preserve log**](index#preserve-log) 複選框，`console.clear()` 將停用。
+不過，在控制檯處於聚焦狀態時，按 **clear console** 按鈕 (![clear console 按鈕](images/clear-console-button.png){:.inline}) 或者輸入 <kbd>Ctrl</kbd>+<kbd>L</kbd> 快捷鍵仍然有效。
+
+
+ 
+
+如需瞭解詳細信息，請參閱[清除控制檯](index#clearing)。
+
+## console.count(label) {:#count}
+
+寫入在同一行使用相同標籤調用 `count()` 的次數。
+
+
+
+    function login(name) {
+      console.count(name + ' logged in');
+    }
+    
+
+![console.count() example](images/count.png)
+
+請參閱[對語句執行進行計數][cse]，查看更多示例。
+
+[cse]: track-executions#counting-statement-executions
+
+## console.debug(object [, object, ...])
+
+與 [`console.log()`](#log) 作用相同。
+
+## console.dir(object) {:#dir}
+
+輸出以 JavaScript 形式表示的指定對象。如果正在記錄的對象是 HTML 元素，將輸出其以 DOM 形式表示的屬性，如下所示：
+
+
+
+
+    console.dir(document.body);
+    
+
+![`console.dir()` example](images/dir.png)
+
+請參閱[字符串替代和格式設置][of]，瞭解功能相同的對象格式化程序 (`%O`) 和其他信息。
+
+
+[of]: console-write#string-substitution-and-formatting
+
+## console.dirxml(object)
+
+如果可以，輸出 `object` 子級元素的 XML 表示形式，否則輸出其 JavaScript 表示形式。
+在 HTML 和 XML 元素上調用 `console.dirxml()` 等同於調用 [`console.log()`](#log)。
+
+
+
+    console.dirxml(document);
+    
+
+![console.dirxml() example](images/dirxml.png)
+
+## console.error(object [, object, ...]) {:#error}
+
+輸出一條類似於 [`console.log()`](#log) 的消息，將消息設置成錯誤樣式，並在調用此方法的地方包含一個堆疊追蹤。
+
+
+
+
+    console.error('error: name is undefined');
+    
+
+![console.error() example](images/error.png)
+
+## console.group(object[, object, ...])
+
+啓動一個帶有可選標題的新日誌組。以可視化方式將在 `console.group()` 後、`console.groupEnd()` 前發生的所有控制檯輸出組合在一起。
+
+ 
+
+
+    function name(obj) {
+      console.group('name');
+      console.log('first: ', obj.first);
+      console.log('middle: ', obj.middle);
+      console.log('last: ', obj.last);
+      console.groupEnd();
+    }
+    
+    name({"first":"Wile","middle":"E","last":"Coyote"});
+    
+
+![console.group() example](images/group.png)
+
+您還可以嵌套組：
+
+
+    function name(obj) {
+      console.group('name');
+      console.log('first: ', obj.first);
+      console.log('middle: ', obj.middle);
+      console.log('last: ', obj.last);
+      console.groupEnd();
+    }
+    
+    function doStuff() {
+      console.group('doStuff()');
+      name({"first":"Wile","middle":"E","last":"coyote"});
+      console.groupEnd();
+    }
+    
+    doStuff();
+    
+
+![nested console.group() example](images/nested-group.png)
+
+{# include shared/related_guides.liquid inline=true list=page.related-guides.organizing #}
+
+## console.groupCollapsed(object[, object, ...])
+
+創建一個初始處於摺疊狀態而不是打開狀態的新日誌組。 
+
+
+    console.groupCollapsed('status');
+    console.log("peekaboo, you can't see me");
+    console.groupEnd();
+    
+
+## console.groupEnd() {:#groupend}
+
+關閉日誌組。相關示例請參閱 [`console.group`](#group)。
+
+## console.info(object [, object, ...])
+
+輸出一條類似 [`console.log()`](#log) 的消息，但同時在輸出旁顯示一個圖標（帶白色“i”的藍色圓圈）。
+ 
+
+## console.log(object [, object, ...]) {:#log}
+
+在控制檯中顯示一條消息。將一個或多個對象傳遞到此方法。每個對象都會進行評估並級聯到一個由空格分隔的字符串中。
+
+
+
+    console.log('Hello, Logs!');
+    
+
+### 格式說明符{:#format-specifiers}
+
+您傳遞的第一個對象可以包含一個或多個**格式說明符**。格式說明符由百分號 (`%`) 與緊跟其後面的一個字母組成，字母指示要應用的格式。
+
+ 
+
+相關指南：
+
+* [組織控制檯輸出](console-write)
+
+## console.profile([label]) {:#profile}
+
+啓動一個帶有可選標籤的 JavaScript CPU 配置文件。要完成配置文件，請調用 `console.profileEnd()`。
+每一個配置文件都會添加到 **Profiles** 面板中。
+
+
+
+    function processPixels() {
+      console.profile("processPixels()");
+      // later, after processing pixels
+      console.profileEnd();
+    }
+    
+
+## console.profileEnd() {:#profileend}
+
+停止當前的 JavaScript CPU 分析會話（如果正在進行此會話），並將報告輸出到 **Profiles** 面板中。
+
+
+相關示例請參閱 [`console.profile()`](#profile)。
+
+## console.time(label) {:#time}
+
+啓動一個具有關聯標籤的新計時器。使用相同標籤調用 `console.timeEnd()` 時，定時器將停止，經過的時間將顯示在控制檯中。計時器值精確到亞毫秒。傳遞到 `time()` 和 `timeEnd()` 的字符串必須匹配，否則計時器不會結束。
+
+
+
+
+    console.time("Array initialize");
+    var array = new Array(1000000);
+    for (var i = array.length - 1; i >= 0; i--) {
+      array[i] = new Object();
+    }
+    console.timeEnd("Array initialize");
+    
+
+![console.time() example](images/time.png)
+
+## console.timeEnd(label) {:#timeend}
+
+停止當前的計時器（如果正在運行一個計時器），並將計時器標籤和經過的時間輸出到控制檯。
+ 
+
+相關示例請參閱 [`console.time()`](#time)。 
+
+## console.timeStamp([label]) {:#timestamp}
+
+在錄製會話期間向 **Timeline** 添加一個事件。 
+
+
+    console.timeStamp('check out this custom timestamp thanks to console.timeStamp()!');
+    
+
+![console.timeStamp() example](images/timestamp.png)
+
+相關指南：
+
+* [使用 Timeline 工具](/web/tools/chrome-devtools/evaluate-performance/timeline-tool)
+
+
+## console.trace(object) {:#trace}
+
+從調用此方法的位置輸出一個堆疊追蹤。 
+
+    console.trace();
+
+![console.trace() 示例](images/trace.png)
+
+## console.warn(object [, object, ...]) {:#warn}
+
+輸出一條類似 [`console.log()`](#log) 的消息，但同時在記錄的消息旁顯示一個黃色警告圖標。
+
+
+    console.warn('user limit reached!');
+
+![console.warn() example](images/warn.png)
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/console-write.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/console-write.md
@@ -33,13 +33,13 @@ description:控制檯日誌是一種可以檢查您的頁面或應用所進行�
 將在控制檯中輸出以下內容：
 ![記錄多個](images/console-write-log-multiple.png)
 
-## 自動填充命令 {:#autocomplete}
+## 自動填充命令 {: #autocomplete}
 
 在控制檯中鍵入內容時，控制檯將自動顯示與您已鍵入文字匹配的相關方法的自動填充下拉菜單。其中包括您已經執行的前幾個命令。
 
 ![自動填充的示例](images/autocomplete.png)
 
-## 組織控制檯輸出 {:#organizing}
+## 組織控制檯輸出 {: #organizing }
 
 ### 將消息組織到一起
 

--- a/src/content/zh-tw/tools/chrome-devtools/console/console-write.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/console-write.md
@@ -1,0 +1,211 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:控制檯日誌是一種可以檢查您的頁面或應用所進行操作的強大方式。我們將先了解 console.log()，然後再探索其他高級用途。
+
+{# wf_updated_on: 2015-05-11 #}
+{# wf_published_on: 2015-04-13 #}
+
+# 診斷並記錄到控制檯中 {: .page-title }
+
+{% include "web/_shared/contributors/pbakaus.html" %}
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/flaviocopes.html" %}
+控制檯日誌是一種可以檢查您的頁面或應用所進行操作的強大方式。我們將先了解 console.log()，然後再探索其他高級用途。
+
+
+### TL;DR {: .hide-from-toc }
+- 使用 <a href=''/web/tools/chrome-devtools/debug/console/console-reference#consolelogobject--object-''>console.log()</a> 進行基本記錄
+- 使用 <a href=''/web/tools/chrome-devtools/debug/console/console-reference#consoleerrorobject--object-''>console.error()</a> 和 <a href=''/web/tools/chrome-devtools/debug/console/console-reference#consolewarnobject--object-''>console.warn()</a> 顯示引入注目的消息
+- 使用 <a href=''/web/tools/chrome-devtools/debug/console/console-reference#consolegroupobject-object-''>console.group()</a> 和 <a href=''/web/tools/chrome-devtools/debug/console/console-reference#consolegroupend''>console.groupEnd()</a> 對相關消息進行分組，避免混亂
+- 使用 <a href=''/web/tools/chrome-devtools/debug/console/console-reference#consoleassertexpression-object''>console.assert()</a> 顯示條件性錯誤消息
+
+
+## 寫入控制檯
+
+使用 <a href="/web/tools/chrome-devtools/debug/console/console-reference#consolelogobject--object-">console.log()</a> 方法可以向控制檯進行任何基本記錄。此方法採用一個或多個表達式作爲參數，並將其當前值寫入控制檯，從而將多個參數級聯到一個由空格分隔的行中。
+
+在您的 JavaScript 中執行下面一行代碼：
+
+
+    console.log("Node count:", a.childNodes.length, "and the current time is:", Date.now());
+    
+
+將在控制檯中輸出以下內容：
+![記錄多個](images/console-write-log-multiple.png)
+
+## 自動填充命令 {:#autocomplete}
+
+在控制檯中鍵入內容時，控制檯將自動顯示與您已鍵入文字匹配的相關方法的自動填充下拉菜單。其中包括您已經執行的前幾個命令。
+
+![自動填充的示例](images/autocomplete.png)
+
+## 組織控制檯輸出 {:#organizing}
+
+### 將消息組織到一起
+
+您可以使用組命令將相關輸出組織到一起。[`console.group()`](./console-reference#consolegroupobject-object-) 命令採用一個字符串參數設置組名稱。在您的 JavaScript 中調用此命令後，控制檯會開始將所有後續輸出都組織到一起。
+
+要結束分組，您只需要在完成後調用 [`console.groupEnd()`](./console-reference#consolegroupend)。
+
+示例輸入：
+
+
+    var user = "jsmith", authenticated = false;
+    console.group("Authentication phase");
+    console.log("Authenticating user '%s'", user);
+    // authentication code here...
+    if (!authenticated) {
+        console.log("User '%s' not authenticated.", user)
+    }
+    console.groupEnd();
+    
+
+示例輸出：
+![簡單的控制檯組輸出](images/console-write-group.png)
+
+#### 嵌套組
+
+日誌組也可以彼此嵌套。同時以小片段查看較大的組時，嵌套組非常有用。
+
+下面的示例顯示了登錄流程身份驗證階段的日誌組：
+
+
+    var user = "jsmith", authenticated = true, authorized = true;
+    // Top-level group
+    console.group("Authenticating user '%s'", user);
+    if (authenticated) {
+        console.log("User '%s' was authenticated", user);
+        // Start nested group
+        console.group("Authorizing user '%s'", user);
+        if (authorized) {
+            console.log("User '%s' was authorized.", user);
+        }
+        // End nested group
+        console.groupEnd();
+    }
+    // End top-level group
+    console.groupEnd();
+    console.log("A group-less log trace.");
+    
+
+下面是控制檯中的嵌套組輸出：
+![簡單的控制檯組輸出](images/console-write-nestedgroup.png)
+
+#### 自動摺疊組
+
+大量使用組時，即時查看所有信息可能不是非常有用。這些情況下，您可以通過調用 [`console.groupCollapsed()`](./console-reference#consolegroupcollapsedobject-object-) 而不是 `console.group()` 的方式自動摺疊組：
+
+
+    console.groupCollapsed("Authenticating user '%s'", user);
+    if (authenticated) {
+        ...
+    }
+    console.groupEnd();
+    
+
+groupCollapsed() 輸出：
+![初始處於摺疊狀態的組](images/console-write-groupcollapsed.png)
+
+## 錯誤和警告
+
+錯誤和警告的作用與正常日誌的作用相同。唯一的區別是 `error()` 和 `warn()` 的樣式引人注目。
+
+### console.error()
+
+[`console.error()`](./console-reference#consoleerrorobject--object-) 方法會顯示紅色圖標和紅色消息文本：
+
+
+    function connectToServer() {
+        console.error("Error: %s (%i)", "Server is  not responding",500);
+    }
+    connectToServer();
+    
+
+轉變爲
+
+![錯誤示例輸出](images/console-write-error-server-not-resp.png)
+
+### console.warn()
+
+[`console.warn()`](./console-reference#consolewarnobject--object-) 方法會顯示一個黃色警告圖標和相應的消息文本：
+
+
+    if(a.childNodes.length < 3 ) {
+        console.warn('Warning! Too few nodes (%d)', a.childNodes.length);
+    }
+    
+
+轉變爲
+
+![警告示例](images/console-write-warning-too-few-nodes.png)
+
+## 斷言
+
+[`console.assert()`](./console-reference#consoleassertexpression-object) 方法可以僅在其第一個參數爲 `false` 時有條件地顯示錯誤字符串（其第二個參數）。
+
+### 簡單的斷言及其顯示方式
+
+下面的代碼僅會在屬於 `list` 元素的子節點數大於 500 時在控制檯中顯示一條錯誤消息。
+
+
+    console.assert(list.childNodes.length < 500, "Node count is > 500");
+    
+
+斷言失敗在控制檯中的顯示方式：
+![斷言失敗](images/console-write-assert-failed.png)
+
+## 字符串替代和格式設置
+
+傳遞到任何記錄方法的第一個參數可能包含一個或多個格式說明符。格式說明符由一個 `%` 符號與後面緊跟的一個字母組成，字母指示應用到值的格式。字符串後面的參數會按順序應用到佔位符。
+
+下面的示例使用字符串和數字格式說明符來將值插入到輸出字符串中。您將在控制檯中看到“Sam has 100 points”。
+
+    console.log("%s has %d points", "Sam", 100);
+
+格式說明符的完整列表爲：
+
+| 說明符 | 輸出                                                                            |
+|-----------|:----------------------------------------------------------------------------------|
+| %s        | 將值格式化爲字符串                                                     |
+| %i 或 %d  | 將值格式化爲整型                                                   |
+| %f        | 將值格式化爲浮點值                                       |
+| %o        | 將值格式化爲可擴展 DOM 元素。如同在 Elements 面板中顯示的一樣     |
+| %O        | 將值格式化爲可擴展 JavaScript 對象                              |
+| %c        | 將 CSS 樣式規則應用到第二個參數指定的輸出字符串 |
+
+本示例使用數字說明符設置 `document.childNodes.length` 的值的格式。同時使用浮點說明符設置 `Date.now()` 的值的格式。
+
+代碼：
+
+
+    console.log("Node count: %d, and the time is %f.", document.childNodes.length, Date.now());
+    
+
+上一個代碼示例的輸出：
+![示例替代輸出](images/console-write-log-multiple.png)
+
+### 使用 CSS 設置控制檯輸出的樣式
+
+利用 CSS 格式說明符，您可以自定義控制檯中的顯示。使用說明符啓動字符串，並設置爲您希望的樣式，作爲第二個參數。
+
+
+嘗試使用下面的代碼：
+
+
+    console.log("%cThis will be formatted with large, blue text", "color: blue; font-size: x-large");
+    
+
+..將您的日誌輸出設置爲藍色的大字體：
+
+![設置了格式的字符串](images/console-write-format-string.png)
+
+### 將 DOM 元素格式化爲 JavaScript 對象
+
+默認情況下，DOM 元素將以其 HTML 的表示的形式記錄到控制檯中，不過有時，您希望以 JavaScript 對象的形式訪問 DOM 元素並檢查其屬性。爲此，您可以使用 `%o` 字符串說明符（參見上文），也可以使用 `console.dir` 達到同樣的效果： 
+
+![使用 dir() 記錄元素](images/dir-element.png)
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/events.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/events.md
@@ -1,0 +1,94 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:通過 Chrome DevTools Command Line API，您可以使用各種方式觀察和檢查事件偵聽器
+
+{# wf_updated_on: 2015-08-02 #}
+{# wf_published_on: 2015-04-13 #}
+
+# 監控事件 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/flaviocopes.html" %}
+通過 Chrome DevTools Command Line API，您可以使用各種方式觀察和檢查事件偵聽器。JavaScript 在交互式頁面中扮演着重要角色，瀏覽器爲您提供一些有用的工具來調試事件和事件處理程序。
+
+
+### TL;DR {: .hide-from-toc }
+- 使用  <code>monitorEvents()</code> 偵聽特定類型的事件。
+- 使用  <code>unmonitorEvents()</code> 停止偵聽。
+- 使用  <code>getEventListeners()</code> 獲取 DOM 元素的偵聽器。
+- 使用“Event Listeners Inspector”面板獲取有關事件偵聽器的信息。
+
+
+## 監控事件
+
+[monitorEvents()](/web/tools/chrome-devtools/debug/command-line/command-line-reference#monitoreventsobject-events) 方法指示 DevTools 記錄與指定目標有關的信息。
+
+
+第一個參數是要監控的對象。如果不提供第二個參數，所有事件都將返回。若要指定要偵聽的事件，則傳遞一個字符串或一個字符串數組作爲第二個參數。
+
+
+
+
+在頁面正文上偵聽“click”事件：
+
+    monitorEvents(document.body, "click");
+
+如果監控的事件是受支持的*事件類型*，DevTools 將其映射到一組標準事件名稱，則該方法偵聽該類型的事件。
+
+
+
+[Command Line API](/web/tools/chrome-devtools/debug/command-line/command-line-reference) 可提供完整的*事件類型*與其涵蓋的事件的對應情況。
+
+如需停止監控事件，請調用 `unmonitorEvents()` 方法併爲其提供對象以停止監控。
+
+
+停止偵聽 `body` 對象上的事件：
+
+    unmonitorEvents(document.body);
+
+## 查看在對象上註冊的事件偵聽器
+
+[getEventListeners() API](/web/tools/chrome-devtools/debug/command-line/command-line-reference#geteventlistenersobject) 返回在指定對象上註冊的事件偵聽器。
+
+
+返回值是一個對象，其包含每個註冊的事件類型（例如，`click` 或 `keydown`）數組。每個數組的成員是描述爲每個類型註冊的偵聽器的對象。例如，以下代碼列出了在文檔對象上註冊的所有事件偵聽器：
+
+
+
+
+
+    getEventListeners(document);
+
+![使用 getEventListeners() 時的輸出](images/events-call-geteventlisteners.png)
+
+如果在指定對象上註冊了多個偵聽器，則數組包含每個偵聽器的成員。以下示例中，在“#scrollingList”元素上爲 `mousedown` 事件註冊了兩個事件偵聽器：
+
+
+
+
+![附加到 mousedown 的事件偵聽器的視圖](images/events-geteventlisteners_multiple.png)
+
+進一步展開每個對象以查看它們的屬性：
+
+![展開的 listener 對象的視圖](images/events-geteventlisteners_expanded.png)
+
+## 查看在 DOM 元素上註冊的事件偵聽器
+
+默認情況下，Elements Inspector 中的 *Event Listeners* 面板顯示附加到頁面的所有事件：
+
+
+![Event listeners 面板](images/events-eventlisteners_panel.png)
+
+過濾器將事件限制在選定的節點：
+
+![Event listeners 面板，僅按選定的節點過濾](images/events-eventlisteners_panel_filtered.png)
+
+通過展開對象，此面板顯示事件偵聽器詳細信息。在此示例中，此頁面擁有兩個通過 jQuery 附加的事件偵聽器：
+
+
+
+![展開的事件偵聽器視圖](images/events-eventlisteners_panel_details.png)
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/expressions.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/expressions.md
@@ -1,0 +1,101 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:從 DevTools 控制檯查看頁面上任意項目的狀態。
+
+{# wf_updated_on:2015-05-11 #}
+{# wf_published_on:2015-04-13 #}
+
+# 評估表達式 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/josephmedley.html" %}
+從 DevTools 控制檯使用它的某個評估功能查看頁面上任意項目的狀態。
+
+DevTools 控制檯讓您可通過特定方式瞭解您頁面中的項目狀態。通過使用支持 JavaScript 的多個功能，再結合運用您的 JavaScript 知識，評估您可以輸入的任何表達式。
+
+
+
+
+
+### TL;DR {: .hide-from-toc }
+- 只需鍵入表達式即可對其進行評估。
+- 使用一個快捷鍵選擇元素。
+- 使用  <code>inspect()</code> 檢查 DOM 元素和 JavaScript 堆對象。
+- 使用 $0 - 4 訪問最近選擇的元素和對象。
+
+
+## 查看錶達式
+
+按下 <kbd class="kbd">Enter</kbd> 鍵後，此控制檯可評估您提供的任何 JavaScript 表達式。輸入表達式後，系統將顯示屬性名稱建議；控制檯還會提供自動填充和 Tab 自動補全功能。
+
+
+
+
+
+如果有多個匹配項，<kbd class="kbd">↑</kbd> 和 <kbd class="kbd">↓</kbd> 在它們之間循環切換。
+按 <kbd class="kbd">→</kbd> 鍵可選擇當前建議。如果有一個建議，按 <kbd class="kbd">Tab</kbd> 鍵選中它。
+
+
+
+![控制檯中的簡單表達式。](images/evaluate-expressions.png)
+
+## 選擇元素
+
+使用下列快捷鍵選擇元素：
+
+<table class="responsive">
+  <thead>
+    <tr>
+      <th colspan="2">快捷鍵及說明</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Shortcut">$()</td>
+      <td data-th="Description">返回與指定 CSS 選擇器匹配的第一個元素。 <code>document.querySelector()</code> 的快捷鍵。</td>
+    </tr>
+    <tr>
+      <td data-th="Shortcut">$$()</td>
+      <td data-th="Description">返回一個與指定 CSS 選擇器匹配的所有元素數組。等同於 <code>document.querySelectorAll()</code>。</td>
+    </tr>
+    <tr>
+      <td data-th="Shortcut">$x()</td>
+      <td data-th="Description">返回一個與指定 XPath 匹配的元素數組。</td>
+    </tr>
+  </tbody>
+</table>
+
+目標選擇的示例：
+
+    $('code') // Returns the first code element in the document.
+    $$('figure') // Returns an array of all figure elements in the document.
+    $x('html/body/p') // Returns an array of all paragraphs in the document body.
+
+## 檢查 DOM 元素和 JavaScript 堆對象
+
+`inspect()` 函數選取一個 DOM 元素或 JavaScript 引用作爲一個參數。如果您提供一個 DOM 元素，則 DevTools 進入“Elements”面板並顯示該元素。如果您提供一個 JavaScript 引用，則它進入“Profile”面板。
+
+
+
+
+
+
+當此代碼在該頁面上的控制檯中執行時，它會抓取此圖並在“Elements”面板上顯示它。這會利用到 `$_` 屬性以獲取最後一個評估的表達式的輸出。
+
+
+
+
+    $('[data-target="inspecting-dom-elements-example"]')
+    inspect($_)
+
+## 訪問最近選擇的元素和對象
+
+控制檯在變量中存儲最後使用的五個元素和對象，以方便訪問。使用 $0 - 4 從控制檯訪問這些元素。請記住，計算機從 0 開始計算，這意味着最新的項目是 $0，最早的項目是 $4。
+
+
+
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/index.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/index.md
@@ -1,0 +1,208 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:瞭解如何導航 Chrome DevTools JavaScript 控制檯。
+
+{# wf_updated_on:2016-02-01 #}
+{# wf_published_on:2015-05-10 #}
+
+# 使用控制檯 {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+{% include "web/_shared/contributors/andismith.html" %}
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/pbakaus.html" %}
+
+瞭解如何：打開 DevTools 控制檯；堆疊冗餘消息或將其顯示在各自的行上；清除或保留輸出，或者將其保存到文件中；過濾輸出，以及訪問其他控制檯設置。
+
+
+
+
+### TL;DR {: .hide-from-toc }
+- 以專用面板或任何其他面板旁的抽屜式導航欄的形式打開控制檯。
+- 堆疊冗餘消息，或者將其顯示在各自的行上。
+- 清除或保留頁面之間的輸出，或者將其保存到文件中。
+- 按嚴重性等級、通過隱藏網絡消息或者按正則表達式模式對輸出進行過濾。
+
+## 打開控制檯
+
+以全屏模式的專用面板形式訪問控制檯：
+
+![Console 面板](images/console-panel.png)
+
+或以任何其他面板旁的抽屜式導航欄的形式：
+
+![Console 抽屜式導航欄](images/console-drawer.png)
+
+### 以面板形式打開
+
+要打開專用的 **Console** 面板，請執行以下操作之一：
+
+* 按 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> (Windows / Linux) 或者 <kbd>Cmd</kbd>+<kbd>Opt</kbd>+<kbd class="kbd">J</kbd> (Mac)。
+* 如果 DevTools 已打開，則按 **Console** 按鈕。
+
+打開 Console 面板時，Console 抽屜式導航欄將自動摺疊。
+
+### 以抽屜式導航欄形式打開
+
+要以任何其他面板旁的抽屜式導航欄的形式打開控制檯，請執行以下操作之一：
+
+* 在 DevTools 處於聚焦狀態時按 <kbd>Esc</kbd>。
+* 按 **Customize and control DevTools** 按鈕，然後按 **Show console**。
+
+
+![顯示控制檯](images/show-console.png)
+
+## 消息堆疊
+
+如果一條消息連續重複，而不是在新行上輸出每一個消息實例，控制檯將“堆疊”消息並在左側外邊距顯示一個數字。此數字表示該消息已重複的次數。
+
+
+![消息堆疊](images/message-stacking.png)
+
+如果您傾向於爲每一個日誌使用一個獨特的行條目，請在 DevTools 設置中啓用 **Show timestamps**。
+
+
+![顯示時間戳](images/show-timestamps.png)
+
+由於每一條消息的時間戳均不同，因此，每一條消息都將顯示在各自的行上。
+
+
+![帶時間戳的控制檯](images/timestamped-console.png)
+
+## 處理控制檯歷史記錄
+
+### 清除歷史記錄{: #clearing}
+
+您可以通過以下方式清除控制檯歷史記錄：
+
+* 在控制檯中點擊右鍵，然後按 **Clear console**。
+* 在控制檯中鍵入 `clear()`。
+* 從您的 JavaScript 代碼內調用 `console.clear()`。
+* 按 <kbd class="kbd">Ctrl</kbd>+<kbd class="kbd">L</kbd> （Mac、Windows、Linux）。
+
+
+### 保留歷史記錄{: #preserve-log}
+
+啓用控制檯頂部的 **Preserve log** 複選框可以在頁面刷新或更改之間保留控制檯歷史記錄。
+消息將一直存儲，直至您清除控制檯或者關閉標籤。
+
+
+### 保存歷史記錄
+
+在控制檯中點擊右鍵，然後選擇 **Save as**，將控制檯的輸出保存到日誌文件中。
+
+
+![將控制檯的輸出保存到日誌文件](images/console-save-as.png)
+
+## 選擇執行環境{: #execution-context }
+
+以下屏幕截圖中以藍色突出顯示的下拉菜單稱爲 **Execution Context Selector**。
+
+
+![Execution Context Selector](images/execution-context-selector.png)
+
+通常，您會看到此環境設置爲 `top`（頁面的頂部框架）。
+
+其他框架和擴展程序在其自身的環境中運行。要使用這些其他環境，您需要從下拉菜單中選中它們。
+例如，如果您要查看 `<iframe>` 元素的日誌輸出，並修改該環境中存在的某個變量，您需要從 Execution Context Selector 下拉菜單中選中該元素。
+
+
+
+
+控制檯默認設置爲 `top` 環境，除非您通過檢查其他環境中的某個元素來訪問 DevTools。
+例如，如果您檢查 `<iframe>` 中的一個 `<p>` 元素，那麼，DevTools 將 Execution Context Selector 設置爲該 `<iframe>` 的環境。
+
+
+
+當您在 `top` 以外的環境中操作時，DevTools 將 Execution Context Selector 突出顯示爲紅色，如下面的屏幕截圖中所示。
+這是因爲開發者很少需要在 `top` 以外的任意環境中操作。
+輸入一個變量，期待返回一個值，只是爲了查看該變量是否爲 `undefined`（因爲該變量是在不同環境中定義的），這會非常令人困惑。
+
+
+
+![Execution Context Selector 突出顯示爲紅色](images/non-top-context.png)
+
+## 過濾控制檯輸出
+
+點擊 **Filter** 按鈕 
+(![filter 按鈕](images/filter-button.png){:.inline})
+可以過濾控制檯輸出。您可以按嚴重性等級、按正則表達式模式或者通過隱藏網絡消息的方式進行過濾。
+
+
+![過濾的控制檯輸出](images/filtered-console.png)
+
+按嚴重性等級進行過濾的說明如下所示：
+
+<table class="responsive">
+  <thead>
+     <tr>
+      <th colspan="2">選項及顯示的內容</th>
+    </tr>   
+  </thead>
+  <tbody>
+  <tr>
+    <td>All</td>
+    <td>顯示所有控制檯輸出</td>
+  </tr>
+  <tr>
+    <td>Errors</td>
+    <td>僅顯示 <a href="/web/tools/chrome-devtools/debug/console/console-reference#consoleerrorobject--object-">console.error()</a> 的輸出。</td>
+  </tr>
+  <tr>
+    <td>Warnings</td>
+    <td>僅顯示 <a href="/web/tools/chrome-devtools/debug/console/console-reference#consolewarnobject--object-">console.warn()</a> 的輸出。</td>
+  </tr>
+  <tr>
+    <td>Info</td>
+    <td>僅顯示 <a href="/web/tools/chrome-devtools/debug/console/console-reference#consoleinfoobject--object-">console.info()</a> 的輸出。</td>
+  </tr>
+  <tr>
+    <td>Logs</td>
+    <td>僅顯示 <a href="/web/tools/chrome-devtools/debug/console/console-reference#consolelogobject--object-">console.log()</a> 的輸出。</td>
+  </tr>
+  <tr>
+    <td>Debug</td>
+    <td>僅顯示 <a href="/web/tools/chrome-devtools/debug/console/console-reference#consoletimeendlabel">console.timeEnd()</a> 和<a href="/web/tools/chrome-devtools/debug/console/console-reference#consoledebugobject--object-">console.debug()</a> 的輸出。</td>
+  </tr>
+  </tbody>
+</table>
+
+## 其他設置
+
+打開 DevTools 設置，轉至 **General** 標籤，然後向下滾動到 **Console** 部分，查看更多控制檯設置。
+
+
+![控制檯設置](images/console-settings.png)
+
+<table class="responsive">
+  <thead>
+     <tr>
+      <th colspan="2">設置及說明</th>
+    </tr>   
+  </thead>
+  <tbody>
+  <tr>
+    <td>Hide network messages</td>
+    <td>默認情況下，控制檯將報告網絡問題。啓用此設置將指示控制檯不顯示這些錯誤的日誌。例如，將不會記錄 404 和 500 系列錯誤。</td>
+  </tr>
+  <tr>
+    <td>Log XMLHttpRequests</td>
+    <td>確定控制檯是否記錄每一個 XMLHttpRequest。</td>
+  </tr>
+  <tr>
+    <td>Preserve log upon navigation</td>
+    <td>在頁面刷新或導航時保留控制檯歷史記錄。</td>
+  </tr>
+  <tr>
+    <td>Show timestamps</td>
+    <td>在調用時向顯示的每條控制檯消息追加一個時間戳。對於發生特定事件時的調試非常實用。這會停用消息堆疊。</td>
+  </tr>
+  <tr>
+    <td>Enable custom formatters</td>
+    <td>控制 JavaScript 對象的<a href="https://docs.google.com/document/d/1FTascZXT9cxfetuPRT2eXPQKXui4nWFivUnS_335T3U/preview">格式設置</a>。</td>
+  </tr>
+  </tbody>
+</table>
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/index.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/index.md
@@ -71,7 +71,7 @@ description:瞭解如何導航 Chrome DevTools JavaScript 控制檯。
 
 ## 處理控制檯歷史記錄
 
-### 清除歷史記錄{: #clearing}
+### 清除歷史記錄 {: #clearing }
 
 您可以通過以下方式清除控制檯歷史記錄：
 
@@ -81,7 +81,7 @@ description:瞭解如何導航 Chrome DevTools JavaScript 控制檯。
 * 按 <kbd class="kbd">Ctrl</kbd>+<kbd class="kbd">L</kbd> （Mac、Windows、Linux）。
 
 
-### 保留歷史記錄{: #preserve-log}
+### 保留歷史記錄 {: #preserve-log }
 
 啓用控制檯頂部的 **Preserve log** 複選框可以在頁面刷新或更改之間保留控制檯歷史記錄。
 消息將一直存儲，直至您清除控制檯或者關閉標籤。
@@ -94,7 +94,7 @@ description:瞭解如何導航 Chrome DevTools JavaScript 控制檯。
 
 ![將控制檯的輸出保存到日誌文件](images/console-save-as.png)
 
-## 選擇執行環境{: #execution-context }
+## 選擇執行環境 {: #execution-context }
 
 以下屏幕截圖中以藍色突出顯示的下拉菜單稱爲 **Execution Context Selector**。
 

--- a/src/content/zh-tw/tools/chrome-devtools/console/structured-data.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/structured-data.md
@@ -1,0 +1,57 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:使用 table() 方法比較類似的數據對象。
+
+{# wf_updated_on:2015-05-11 #}
+{# wf_published_on:2015-04-13 #}
+
+# 比較類似的數據對象 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/pbakaus.html" %}
+使用 table() 方法查看結構化的數據和比較數據對象。
+
+使用 `table()` 方法，您可以輕鬆地查看包含類似數據的對象和數組。調用時，此方法將提取對象的屬性並創建一個標頭。行數據則來自每個索引的屬性值。
+
+
+## 基本示例：記錄對象數組
+
+在最基本的形式中，您只需要一個由具有相同屬性的多個對象組成的數組，`table()` 命令將執行剩餘操作：
+
+
+    console.table([{a:1, b:2, c:3}, {a:"foo", b:false, c:undefined}]);
+    console.table([[1,2,3], [2,3,4]]);
+    
+  
+這將輸出：
+
+![控制檯表格顯示](images/table-arrays.png)
+
+## 高級示例：記錄特定的屬性
+
+可以使用 `table()` 的第二個參數記錄更多高級對象。定義一個包含您希望顯示的屬性字符串的數組，如下所示：
+
+
+    function Person(firstName, lastName, age) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.age = age;
+    }
+    
+    var family = {};
+    family.mother = new Person("Susan", "Doyle", 32);
+    family.father = new Person("John", "Doyle", 33);
+    family.daughter = new Person("Lily", "Doyle", 5);
+    family.son = new Person("Mike", "Doyle", 8);
+    
+    console.table(family, ["firstName", "lastName", "age"]);
+    
+
+這將輸出以下內容：
+
+![包含表格對象的控制檯輸出](images/table-people-objects.png)
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/track-exceptions.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/track-exceptions.md
@@ -1,0 +1,130 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:利用 Chrome DevTools 提供的工具，您可以修復引發異常的網頁和在 JavaScript 中調試錯誤。
+
+{# wf_updated_on:2015-05-12 #}
+{# wf_published_on:2015-04-13 #}
+
+# 異常和錯誤處理 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/flaviocopes.html" %}
+利用 Chrome DevTools 提供的工具，您可以修復引發異常的網頁和在 JavaScript 中調試錯誤。
+
+如果您可以瞭解背後的詳細信息，頁面異常和 JavaScript 錯誤會非常有用。在頁面引發異常或腳本產生錯誤時，Console 可以提供具體、可靠的信息來幫助您定位和糾正問題。 
+
+在控制檯中，您可以跟蹤異常和引發異常的執行路徑，顯式或隱式捕捉異常（或忽略它們），甚至設置錯誤處理程序來自動收集和處理異常數據。
+
+
+### TL;DR {: .hide-from-toc }
+- 觸發異常時啓用 Pause on Exceptions 來調試代碼上下文。
+- 使用  <code>console.trace</code> 打印當前的 JavaScript 調用堆棧。
+- 使用  <code>console.assert()</code> 在您的代碼中放置斷言和引發異常。
+- 使用  <code>window.onerror</code> 記錄瀏覽器中發生的錯誤。
+
+
+## 跟蹤異常
+
+發生錯誤時，請打開 DevTools 控制檯 (`Ctrl+Shift+J` / `Cmd+Option+J`) 查看 JavaScript 錯誤消息。每一條消息都有一個指向文件名的鏈接，文件名帶有您可以導航到文件的行號。
+
+
+異常示例：
+![異常示例](images/track-exceptions-tracking-exceptions.jpg)
+
+### 視圖異常堆疊追蹤
+
+導致錯誤的執行路徑並不總是非常明顯。完整的 JavaScript 調用堆棧在控制檯中會伴隨着異常。展開這些控制檯消息可以查看堆棧框架和導航到代碼中的相應位置：
+
+
+
+![異常堆疊追蹤](images/track-exceptions-exception-stack-trace.jpg)
+
+### 出現 JavaScript 異常時暫停
+
+下一次引發異常時，請暫停 JavaScript 執行並檢查其調用堆棧、範圍變量以及您應用的狀態。利用 Scripts 面板底部的三態停止按鈕，您可以在不同的異常處理模式之間切換：![暫停按鈕](images/track-exceptions-pause-gray.png){:.inline}
+
+
+
+
+選擇暫停所有異常或僅暫停未捕捉的異常，您也可以集中忽略異常。
+
+![暫停執行](images/track-exceptions-pause-execution.jpg)
+
+## 打印堆疊追蹤
+
+通過將日誌消息輸出到控制檯可更好地瞭解網頁的行爲。通過包含關聯的堆疊追蹤讓日誌條目的信息更豐富。有多種方式可以實現此目標。
+
+### Error.stack
+每個 Error 對象都有一個包含堆疊追蹤的字符串屬性命名的堆棧：
+
+![Error.stack 示例](images/track-exceptions-error-stack.jpg)
+
+### console.trace()
+
+使用可以打印當前 JavaScript 調用跟蹤的 [`console.trace()`](./console-reference#consoletraceobject) 調用設置您的代碼：
+
+![console.trace() 示例](images/track-exceptions-console-trace.jpg)
+
+### console.assert()
+
+通過將帶有錯誤條件的 [`console.assert()`](./console-reference#consoleassertexpression-object) 作爲第一個參數調用，在您的 JavaScript 代碼中放置斷言。當此表達式評估爲 false 時，您將看到一條相應的 Console 記錄：
+
+
+
+
+![console.assert() 示例](images/track-exceptions-console-assert.jpg)
+
+## 如何檢查堆疊追蹤來查找觸發器
+
+我們來看一下如何使用剛剛學習的工具，並找出錯誤的真正原因。下面是一個包含兩個腳本的簡單 HTML 頁面：
+
+
+
+![示例代碼](images/track-exceptions-example-code.png)
+
+當用戶點擊頁面時，段落將更改其內部文本，將調用 `lib.js` 提供的 `callLibMethod()` 函數。
+
+
+
+此函數會輸出一個 `console.log`，然後調用 `console.slog`，後者不是一種由 Console API 提供的方法。調用應觸發一個錯誤。
+
+
+
+
+在頁面運行的時候點擊頁面時，將觸發下面的錯誤：
+
+
+![觸發的錯誤](images/track-exceptions-example-error-triggered.png)
+
+點擊箭頭可以展開錯誤消息：
+
+![展開的錯誤消息](images/track-exceptions-example-error-message-expanded.png)
+
+控制檯會告訴您錯誤在 `lib.js` 的第 4 行觸發，此腳本在 `addEventListener` 回調（匿名函數）的 `script.js` 中的第 3 行調用。
+
+
+
+這是一個非常簡單的示例，不過，即使最複雜的日誌跟蹤調試也遵循相同的流程。
+
+
+## 使用 window.onerror 處理運行時異常
+
+Chrome 會公開 `window.onerror` 處理程序函數，每當 JavaScript 代碼執行中發生錯誤時都會調用此函數。當 JavaScript 異常每次在窗口上下文中引發並且未被 try/catch 塊捕捉時，調用此函數時還會調用異常的消息、引發異常的文件的網址、該文件中的行號，三者按照此順序作爲三個參數傳遞。
+
+
+
+
+
+
+
+
+舉例來說，使用 AJAX POST 調用設置一個錯誤處理程序，用於收集未捕捉異常的相關信息並將其報告回服務器，您會發現這樣非常實用。這樣，您可以記錄用戶瀏覽器中發生的所有錯誤並獲得相關通知。
+
+使用 `window.onerror` 的示例：
+
+![window.onerror 處理程序的示例](images/runtime-exceptions-window-onerror.jpg)
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/console/track-executions.md
+++ b/src/content/zh-tw/tools/chrome-devtools/console/track-executions.md
@@ -1,0 +1,112 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:利用 Console API 測量執行時間和對語句執行進行計數。
+
+{# wf_updated_on:2015-05-11 #}
+{# wf_published_on:2015-04-13 #}
+
+# 測量執行時間和對執行進行計數 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/flaviocopes.html" %}
+{% include "web/_shared/contributors/pbakaus.html" %}
+
+利用 Console API 測量執行時間和對語句執行進行計數。
+
+
+### TL;DR {: .hide-from-toc }
+- 使用  <code>console.time()</code> 和  <code>console.timeEnd()</code> 跟蹤代碼執行點之間經過的時間。
+- 使用  <code>console.count()</code> 對相同字符串傳遞到函數的次數進行計數。
+
+
+## 測量執行時間
+
+[`time()`](./console-reference#consoletimelabel) 方法可以啓動一個新計時器，並且對測量某個事項花費的時間非常有用。將一個字符串傳遞到方法，以便爲標記命名。
+
+如果您想要停止計時器，請調用 [`timeEnd()`](./console-reference#consoletimeendlabel) 並向其傳遞已傳遞到初始值設定項的相同字符串。
+
+控制檯隨後會在 `timeEnd()` 方法觸發時記錄標籤和經過的時間。
+
+### 基本示例
+
+在這裏，我們將測量 100 萬個新 Array 的初始化：
+
+
+    console.time("Array initialize");
+    var array= new Array(1000000);
+    for (var i = array.length - 1; i >= 0; i--) {
+        array[i] = new Object();
+    };
+    console.timeEnd("Array initialize");
+    
+
+將在控制檯中輸出下列結果：
+![經過的時間](images/track-executions-time-duration.png)
+
+### Timeline 上的計時器
+
+當 [Timeline](/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool) 記錄在 `time()` 操作期間發生時，它也會對 Timeline 進行標註。如果您想要跟蹤應用的操作和操作來自何處，請使此記錄。
+
+執行 `time()` 時 Timeline 上的標註如下所示：
+
+![timeline 上的時間標註](images/track-executions-time-annotation-on-timeline.png)
+
+### 標記 Timeline
+
+*注：`timeStamp()` 方法只能在某個 Timeline 記錄正在進行時發揮作用。*
+
+[Timeline 面板](/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool)可以提供引擎時間消耗的完整概覽。您可以使用 [`timeStamp()`](./console-reference#consoletimestamplabel) 從控制檯向 Timeline 添加一個標記。
+這是一種將您應用中的事件與其他事件進行關聯的簡單方式。
+
+`timeStamp()` 會在以下地方對 Timeline 進行標註：
+
+- Timeline 彙總和詳細信息視圖中的黃色垂直線。
+- 會向事件列表添加一條記錄。
+
+以下示例代碼：
+
+
+    function AddResult(name, result) {
+        console.timeStamp("Adding result");
+        var text = name + ': ' + result;
+        var results = document.getElementById("results");
+        results.innerHTML += (text + "<br>");
+    }
+    
+
+將生成下面的 Timeline 時間戳：
+
+![Timeline 中的時間戳](images/track-executions-timestamp2.png)
+
+## 對語句執行進行計數
+
+使用 `count()` 方法記錄提供的字符串，以及相同字符串已被提供的次數。當完全相同的語句被提供給同一行上的 `count()` 時，此數字將增大。
+
+將 `count()` 與某些動態內容結合使用的示例代碼：
+
+
+    function login(user) {
+        console.count("Login called for user " + user);
+    }
+    
+    users = [ // by last name since we have too many Pauls.
+        'Irish',
+        'Bakaus',
+        'Kinlan'
+    ];
+    
+    users.forEach(function(element, index, array) {
+        login(element);
+    });
+    
+    login(users[0]);
+    
+
+代碼示例的輸出：
+
+![console.count() example output](images/track-executions-console-count.png)
+
+
+
+
+{# wf_devsite_translation #}


### PR DESCRIPTION
Chinese (Traditional) translation of:

- src/content/zh-tw/tools/chrome-devtools/console/command-line-reference.md
- src/content/zh-tw/tools/chrome-devtools/console/console-reference.md
- src/content/zh-tw/tools/chrome-devtools/console/console-write.md
- src/content/zh-tw/tools/chrome-devtools/console/events.md
- src/content/zh-tw/tools/chrome-devtools/console/expressions.md
- src/content/zh-tw/tools/chrome-devtools/console/index.md
- src/content/zh-tw/tools/chrome-devtools/console/structured-data.md
- src/content/zh-tw/tools/chrome-devtools/console/track-exceptions.md
- src/content/zh-tw/tools/chrome-devtools/console/track-executions.md

Note: All the articles are directly translated from zh-CN.