### PR TITLE
[Translation zh-tw] Tools > Chrome Devtools 

### DIFF
--- a/src/content/zh-tw/tools/chrome-devtools/index.md
+++ b/src/content/zh-tw/tools/chrome-devtools/index.md
@@ -1,0 +1,136 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: 選項1
+
+{# wf_updated_on: 2017-07-12 #}
+{# wf_published_on: 2016-03-28 #}
+
+# Chrome 開發者工具 {: .page-title }
+
+Chrome 開發者工具是一套內置於Google Chrome中的Web開發和調試工具，可用來對網站進行迭代、調試和分析。
+
+Dogfood: 尋找最新版本的Chrome 開發者工具, [Chrome Canary](https://www.google.com/intl/en/chrome/browser/canary.html) 總是有最新的DevTools.
+
+## 打開Chrome 開發者工具 {: #open }
+
+* 在Chrome菜單中選擇 **更多工具** > **開發者工具**
+* 在頁面元素上右鍵點擊，選擇 “檢查”
+* 使用 [快捷鍵 ](/web/tools/chrome-devtools/inspect-styles/shortcuts)
+<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> (Windows) 或 <kbd>Cmd</kbd>+<kbd>Opt</kbd>+<kbd>I</kbd> (Mac)
+
+## 瞭解面板
+
+### 設備模式
+
+<img src="images/device-mode.png" alt="Device Mode" class="attempt-right">
+
+使用設備模式構建完全響應式，移動優先的網絡體驗。
+
+* [Device Mode](/web/tools/chrome-devtools/device-mode/)
+* [Test Responsive and Device-specific Viewports](/web/tools/chrome-devtools/device-mode/emulate-mobile-viewports)
+* [Emulate Sensors: Geolocation &amp; Accelerometer](/web/tools/chrome-devtools/device-mode/device-input-and-sensors)
+
+<div style="clear:both;"></div>
+
+
+### 元素面板
+
+<img src="images/panels/elements.png" alt="Elements Panel" class="attempt-right">
+使用元素面板可以自由的操作DOM和CSS來迭代佈局和設計頁面.
+
+
+* [檢查和調整頁面](/web/tools/chrome-devtools/inspect-styles/)
+* [編輯樣式](/web/tools/chrome-devtools/inspect-styles/edit-styles)
+* [編輯DOM](/web/tools/chrome-devtools/inspect-styles/edit-dom)
+
+<div style="clear:both;"></div>
+
+
+### 控制檯面板
+
+<img src="images/panels/console.png" alt="Console Panel" class="attempt-right">
+
+在開發期間，可以使用控制檯面板記錄診斷信息，或者使用它作爲 shell在頁面上與JavaScript交互。
+
+* [使用控制檯面板](/web/tools/chrome-devtools/console/)
+* [命令行交互](/web/tools/chrome-devtools/console/)
+
+<div style="clear:both;"></div>
+
+
+### 源代碼面板
+
+<img src="images/panels/sources.png" alt="Sources Panel" class="attempt-right">
+
+在源代碼面板中設置斷點來調試 JavaScript ，或者通過Workspaces（工作區）連接本地文件來使用開發者工具的實時編輯器。
+
+* [斷點調試](/web/tools/chrome-devtools/javascript/add-breakpoints)
+* [調試混淆的代碼](/web/tools/chrome-devtools/javascript/add-breakpoints)
+* [使用開發者工具的Workspaces（工作區）進行持久化保存](/web/tools/setup/setup-workflow)
+
+<div style="clear:both;"></div>
+
+
+### 網絡面板
+<img src="images/panels/network.png" alt="Network Panel" class="attempt-right">
+
+使用網絡面板瞭解請求和下載的資源文件並優化網頁加載性能。
+
+* [網絡面板基礎](/web/tools/chrome-devtools/network-performance/resource-loading)
+* [瞭解資源時間軸](/web/tools/chrome-devtools/network-performance/understanding-resource-timing)
+* [網絡帶寬限制](/web/tools/chrome-devtools/network-performance/network-conditions)
+
+<div style="clear:both;"></div>
+
+
+### 性能面板
+Note: 在 Chrome 57 之後時間線面板更名爲性能面板.
+<img src="images/panels/performance.png" alt="Timeline Panel" class="attempt-right">
+
+使用時間軸面板可以通過記錄和查看網站生命週期內發生的各種事件來提高頁面的運行時性能。
+
+* [如何查看性能](/web/tools/chrome-devtools/evaluate-performance/timeline-tool)
+* [分析運行時性能](/web/tools/chrome-devtools/rendering-tools/)
+* [診斷強制的同步佈局](/web/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts)
+
+<div style="clear:both;"></div>
+
+
+### 內存面板
+Note: 在 Chrome 57 之後分析面板更名爲內存面板.
+<img src="images/panels/memory.png" alt="Profiles Panel" class="attempt-right">
+
+如果需要比時間軸面板提供的更多信息，可以使用“配置”面板，例如跟蹤內存泄漏。
+Use the Profiles panel if you need more information than the Timeline provide, for instance to track down memory leaks.
+
+* [JavaScript CPU 分析器](/web/tools/chrome-devtools/rendering-tools/js-execution)
+* [內存堆區分析器](/web/tools/chrome-devtools/memory-problems/)
+
+<div style="clear:both;"></div>
+
+
+### 應用面板
+Note: 在 Chrome 52 之後資源面板更名爲應用面板.
+<img src="images/panels/application.png" alt="Application Panel" class="attempt-right">
+
+使用資源面板檢查加載的所有資源，包括IndexedDB與Web SQL數據庫，本地和會話存儲，cookie，應用程序緩存，圖像，字體和樣式表。
+
+* [管理數據](/web/tools/chrome-devtools/manage-data/local-storage)
+
+<div style="clear:both;"></div>
+
+
+### 安全面板
+<img src="images/panels/security.png" alt="Security Panel" class="attempt-right">
+
+使用安全面板調試混合內容問題，證書問題等等。
+
+* [安全](/web/tools/chrome-devtools/security)
+
+<div style="clear:both;"></div>
+
+## 參與互動
+
+[Twitter](https://twitter.com/ChromeDevTools){: .button .button-white}
+[Stack Overflow](https://stackoverflow.com/questions/tagged/google-chrome-devtools){: .button .button-white}
+[Slack](https://chromiumdev.slack.com/messages/devtools/){: .button .button-white}

--- a/src/content/zh-tw/tools/chrome-devtools/progressive-web-apps.md
+++ b/src/content/zh-tw/tools/chrome-devtools/progressive-web-apps.md
@@ -29,7 +29,7 @@ description:使用 Application 面板檢查、修改和調試網絡應用清單�
 - 從 <strong>Clear Storage</strong> 窗格中點擊一次按鈕，註銷服務工作線程並清除所有存儲與緩存。
 
 
-## 網絡應用清單 {:#manifest}
+## 網絡應用清單 {: #manifest }
 
 如果您希望用戶能夠將您的應用添加到他們移動設備的主屏幕上，那麼您需要一個網絡應用清單。
 清單定義應用在主屏幕上的外觀、從主屏幕啓動時將用戶定向到何處，以及應用在啓動時的外觀。
@@ -55,7 +55,7 @@ description:使用 Application 面板檢查、修改和調試網絡應用清單�
 
 [manifest]: images/manifest.png
 
-### 模擬 Add to Homescreen 事件 {:#add-to-homescreen}
+### 模擬 Add to Homescreen 事件 {: #add-to-homescreen }
 
 只有至少已經訪問網站兩次、訪問至少間隔五分鐘時纔可以將網絡應用添加到主屏幕上。
 開發或調試您的 Add to Homescreen 工作流時，此條件非常不便。利用 **App Manifest** 窗格上的 **Add to homescreen** 按鈕，您可以隨時模擬 Add to Homescreen 事件。
@@ -86,7 +86,7 @@ Console 會告訴您清單是否存在任何問題，並記錄與 Add to Homescr
 [shelf]: images/io.png
 [remote debugging]: /web/tools/chrome-devtools/debug/remote-debugging/remote-debugging
 
-## 服務工作線程 {:#service-workers}
+## 服務工作線程 {: #service-workers }
 
 服務工作線程是未來網絡平臺中的一種基礎技術。它們是瀏覽器獨立於網頁在後臺運行的腳本。這些腳本使您可以訪問不需要網頁或用戶交互的功能，例如推送通知、後臺同步和離線體驗。
 
@@ -133,7 +133,7 @@ Console 會告訴您清單是否存在任何問題，並記錄與 Add to Homescr
 [tickle]: /web/fundamentals/push-notifications/how-push-works
 [errors]: images/sw-error.png
 
-## 服務工作線程緩存 {:#caches}
+## 服務工作線程緩存 { :#caches }
 
 **Cache Storage** 窗格提供了一個已使用（服務工作線程）[Cache API][sw-cache] 緩存的只讀資源列表。
 
@@ -152,7 +152,7 @@ Console 會告訴您清單是否存在任何問題，並記錄與 Add to Homescr
 [sw-cache-pane]: images/sw-cache.png
 [multiple-caches]: images/multiple-caches.png
 
-## 清除存儲 {:#clear-storage}
+## 清除存儲 {: #clear-storage }
 
 開發 Progressive Web App 時，**Clear Storage** 窗格是一個非常實用的功能。
 利用此窗格，只需點擊一次按鈕即可註銷服務工作線程並清除所有緩存與存儲。
@@ -164,7 +164,7 @@ Console 會告訴您清單是否存在任何問題，並記錄與 Add to Homescr
 * [清除存儲](/web/tools/chrome-devtools/iterate/manage-data/local-storage#clear-storage)
 
 
-## 其他 Application 面板指南 {:#other}
+## 其他 Application 面板指南 {: #other }
 
 參閱下面的部分，獲取有關 **Application** 面板其他窗格的更多幫助。
 

--- a/src/content/zh-tw/tools/chrome-devtools/progressive-web-apps.md
+++ b/src/content/zh-tw/tools/chrome-devtools/progressive-web-apps.md
@@ -1,0 +1,179 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:使用 Application 面板檢查、修改和調試網絡應用清單、服務工作線程和服務工作線程緩存。
+
+{# wf_updated_on: 2017-10-06 #}
+{# wf_published_on:2016-07-25 #}
+
+# 調試 Progressive Web App {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+使用 <strong>Application</strong> 面板檢查、修改和調試網絡應用清單、服務工作線程和服務工作線程緩存。
+
+
+相關指南： 
+
+* [Progressive Web App](/web/progressive-web-apps)
+
+本指南僅討論 **Application** 面板的 Progressive Web App 功能。
+如果您希望獲得其他窗格的幫助，請參閱本指南的最後一部分，即[其他 Application 面板指南](#other)。
+
+
+
+
+### TL;DR {: .hide-from-toc }
+- 使用 <strong>App Manifest</strong> 窗格檢查您的網絡應用清單和觸發 Add to Homescreen 事件。
+- 使用 <strong>Service Worker</strong> 窗格執行與服務工作線程相關的全部任務，例如註銷或更新服務、模擬推送事件、切換爲離線狀態，或者停止服務工作線程。
+- 從 <strong>Cache Storage</strong> 窗格查看您的服務工作線程緩存。
+- 從 <strong>Clear Storage</strong> 窗格中點擊一次按鈕，註銷服務工作線程並清除所有存儲與緩存。
+
+
+## 網絡應用清單 {:#manifest}
+
+如果您希望用戶能夠將您的應用添加到他們移動設備的主屏幕上，那麼您需要一個網絡應用清單。
+清單定義應用在主屏幕上的外觀、從主屏幕啓動時將用戶定向到何處，以及應用在啓動時的外觀。
+
+
+
+相關指南：
+
+* [通過網絡應用清單改進用戶體驗](/web/fundamentals/web-app-manifest)
+* [使用應用安裝橫幅](/web/fundamentals/app-install-banners)
+
+
+設置好清單後，您可以使用 **Application** 面板的 **Manifest** 窗格對其進行檢查。
+
+
+![Manifest 窗格][manifest]
+
+* 要查看清單來源，請點擊 **App Manifest** 標籤下方的鏈接（上方屏幕截圖中的 `https://airhorner.com/manifest.json`）。
+* 按 **Add to homescreen** 按鈕模擬 Add to Homescreen 事件。
+如需瞭解詳細信息，請參閱下一部分。
+* **Identity** 和 **Presentation** 部分以一種對用戶更加友好的方式顯示了清單來源中的字段。
+* **Icons** 部分顯示了您已指定的每一個圖標。
+
+[manifest]: images/manifest.png
+
+### 模擬 Add to Homescreen 事件 {:#add-to-homescreen}
+
+只有至少已經訪問網站兩次、訪問至少間隔五分鐘時纔可以將網絡應用添加到主屏幕上。
+開發或調試您的 Add to Homescreen 工作流時，此條件非常不便。利用 **App Manifest** 窗格上的 **Add to homescreen** 按鈕，您可以隨時模擬 Add to Homescreen 事件。
+
+
+
+
+您可以使用 [Google I/O 2016 Progressive Web App](https://events.google.com/io2016/){: .external } 測試此功能，該應用可以爲 Add to Homescreen 提供相應支持。在應用打開時點擊 **Add to Homescreen** 會提示 Chrome 顯示“add this site to your shelf”橫幅（桌面設備），而在移動設備上則會顯示“add to homescreen”橫幅。
+
+
+
+![添加到桌面設備文件架][shelf]
+
+**提示**：在模擬 Add to Homescreen 事件時請保持 **Console** 抽屜式導航欄處於打開狀態。
+Console 會告訴您清單是否存在任何問題，並記錄與 Add to Homescreen 生命週期有關的其他信息。
+
+
+**Add to Homescreen** 功能還不能模擬移動設備的工作流。
+注意“add to shelf”提示在上方屏幕截圖中的觸發方式（即使 DevTools 處於 Device Mode）。
+不過，如果您可以將應用成功添加到桌面設備文件架，那麼在移動設備上也可以獲得成功。
+
+
+
+如果您希望測試真實的移動體驗，則可以通過[遠程調試][remote debugging]將一臺真實的移動設備連接到 DevTools，然後點擊 DevTools 上的 **Add to Homescreen** 按鈕，在連接的移動設備上觸發“add to homescreen”提示。
+
+
+
+[shelf]: images/io.png
+[remote debugging]: /web/tools/chrome-devtools/debug/remote-debugging/remote-debugging
+
+## 服務工作線程 {:#service-workers}
+
+服務工作線程是未來網絡平臺中的一種基礎技術。它們是瀏覽器獨立於網頁在後臺運行的腳本。這些腳本使您可以訪問不需要網頁或用戶交互的功能，例如推送通知、後臺同步和離線體驗。
+
+
+
+
+相關指南：
+
+* [服務工作線程簡介](/web/fundamentals/primers/service-worker)
+* [推送通知：及時、相關且精確](/web/fundamentals/push-notifications)
+
+
+**Application** 面板中的 **Service Workers** 窗格是在 DevTools 中檢查和調試服務工作線程的主要地方。
+
+
+![Service Worker 窗格][sw]
+
+* 如果服務工作線程已安裝到當前打開的頁面上，您會看到它將列示在此窗格中。
+例如，在上方的屏幕截圖中，`https://events.google.com/io2016/` 的作用域內安裝了一個服務工作線程。
+* **Offline** 複選框可以將 DevTools 切換至離線模式。它等同於 **Network** 窗格中的離線模式，或者 [Command Menu][cm] 中的 `Go offline` 選項。
+* **Update on reload** 複選框可以強制服務工作線程在每次頁面加載時更新。
+* **Bypass for network** 複選框可以繞過服務工作線程並強制瀏覽器轉至網絡尋找請求的資源。
+* **Update** 按鈕可以對指定的服務工作線程執行一次性更新。
+* **Push** 按鈕可以在沒有負載的情況下模擬推送通知（也稱爲[操作消息][tickle]）。
+* **Sync** 按鈕可以模擬後臺同步事件。
+* **Unregister** 按鈕可以註銷指定的服務工作線程。參閱[清除存儲](#clear-storage)，瞭解點擊一次按鈕即可註銷服務工作線程並擦除存儲和緩存的方式。
+* **Source** 行可以告訴您當前正在運行的服務工作線程的安裝時間。
+鏈接是服務工作線程源文件的名稱。點擊鏈接會將您定向至服務工作線程來源。
+* **Status** 行可以告訴您服務工作線程的狀態。此行上的數字（上方屏幕截圖中的 `#1`）指示服務工作線程已被更新的次數。如果啓用 **update on reload** 複選框，您會注意到每次頁面加載時此數字都會增大。在狀態旁邊，您將看到 **start** 按鈕（如果服務工作線程已停止）或 **stop** 按鈕（如果服務工作線程正在運行）。服務工作線程設計爲可由瀏覽器隨時停止和啓動。
+使用 **stop** 按鈕明確停止服務工作線程可以模擬這一點。停止服務工作線程是測試服務工作線程再次重新啓動時的代碼行爲方式的絕佳方法。它通常可以揭示由於對持續全局狀態的不完善假設而引發的錯誤。
+* **Clients** 行可以告訴您服務工作線程作用域的原點。
+如果您已啓用 **show all** 複選框，**focus** 按鈕將非常實用。
+在此複選框啓用時，系統會列出所有註冊的服務工作線程。
+如果您點擊正在不同標籤中運行的服務工作線程旁的 **focus** 按鈕，Chrome 會聚焦到該標籤。
+
+
+如果服務工作線程導致任何錯誤，將顯示一個名爲 **Errors** 的新標籤。
+
+
+![包含錯誤的服務工作線程][errors]
+
+[sw]: images/sw.png
+[cm]: /web/tools/chrome-devtools/settings#command-menu
+[tickle]: /web/fundamentals/push-notifications/how-push-works
+[errors]: images/sw-error.png
+
+## 服務工作線程緩存 {:#caches}
+
+**Cache Storage** 窗格提供了一個已使用（服務工作線程）[Cache API][sw-cache] 緩存的只讀資源列表。
+
+
+![Service Worker Cache 窗格][sw-cache-pane]
+
+請注意，第一次打開緩存並向其添加資源時，DevTools 可能檢測不到更改。
+重新加載頁面後，您應當可以看到緩存。
+
+如果您打開了兩個或多個緩存，您將看到它們列在 **Cache Storage** 下拉菜單下方。
+
+
+![多個服務工作線程緩存][multiple-caches]
+
+[sw-cache]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
+[sw-cache-pane]: images/sw-cache.png
+[multiple-caches]: images/multiple-caches.png
+
+## 清除存儲 {:#clear-storage}
+
+開發 Progressive Web App 時，**Clear Storage** 窗格是一個非常實用的功能。
+利用此窗格，只需點擊一次按鈕即可註銷服務工作線程並清除所有緩存與存儲。
+參閱下面的部分了解詳情。
+
+
+相關指南：
+
+* [清除存儲](/web/tools/chrome-devtools/iterate/manage-data/local-storage#clear-storage)
+
+
+## 其他 Application 面板指南 {:#other}
+
+參閱下面的部分，獲取有關 **Application** 面板其他窗格的更多幫助。
+
+
+相關指南：
+
+* [檢查頁面資源](/web/tools/chrome-devtools/iterate/manage-data/page-resources)
+* [檢查和管理本地存儲與緩存](/web/tools/chrome-devtools/iterate/manage-data/local-storage)
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/security.md
+++ b/src/content/zh-tw/tools/chrome-devtools/security.md
@@ -1,0 +1,85 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:使用 Security 面板確保您的網站上的所有資源均通過 HTTPS 進行保護。
+
+{# wf_updated_on:2016-03-09 #}
+{# wf_published_on:2015-12-21 #}
+
+# 瞭解安全問題 {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+HTTPS 爲您的網站和將個人信息委託給您的網站的人提供了[重要的安全性和數據完整性][why-https]。在 Chrome DevTools 中使用 Security 面板調試安全問題，確保您已在自己的網站上恰當地實現 HTTPS。
+
+
+
+
+### TL;DR {: .hide-from-toc }
+- 使用 Security Overview 可以立即查看當前頁面是否安全。
+- 檢查各個源以查看連接和證書詳情（安全源）或找出具體哪些請求未受保護（非安全源）。
+
+
+## Security Overview
+
+要查看頁面的整體安全性，請打開 DevTools，然後轉至 Security 面板。
+ 
+
+您首先會看到 Security Overview。Security Overview 會一目瞭然地告訴您頁面是否安全。
+安全頁面會通過消息 `This page is secure (valid HTTPS).` 指示
+
+
+![Security Overview，安全頁面](images/overview-secure.png)
+
+點擊 **View certificate** 查看[主源][same-origin-policy]的服務器證書。
+ 
+
+![查看證書](images/view-certificate.png)
+
+非安全頁面會通過消息 `This page is not secure.` 指示
+
+Security 面板可以區分兩種非安全頁面。
+如果請求的頁面通過 HTTP 提供，則主源會被標記爲不安全。
+ 
+
+![Security Overview，非安全主源](images/overview-non-secure.png)
+
+如果請求的頁面通過 HTTPS 檢索，但頁面會繼續使用 HTTP 檢索其他源的內容，然後頁面仍然會被標記爲不安全。這稱爲[混合內容][mixed-content]頁面。
+混合內容頁面僅受部分保護，因爲 HTTP 內容可以被嗅探器獲取到且易受到中間人攻擊。
+ 
+
+![Security Overview，混合內容](images/overview-mixed.png)
+
+點擊 **View request in Network Panel** 打開 Network 面板的過濾視圖，然後查看具體是哪些請求通過 HTTP 提供。
+這將顯示來自所有源的所有未受保護的請求。
+ 
+
+![Network 面板，非安全資源，所有源](images/network-all.png)
+
+## 檢查源
+
+使用左側面板可以檢查各個安全或非安全源。 
+
+點擊安全源查看該源的連接和證書詳情。
+
+
+![源詳情，安全](images/origin-detail-secure.png)
+
+如果您點擊非安全源，Security 面板會提供 Network 面板過濾視圖的鏈接。 
+
+![源詳情，非安全](images/origin-detail-non-secure.png)
+
+點擊鏈接可以查看具體是源的哪些請求通過 HTTP 提供。
+ 
+
+![Network 面板，非安全資源，一個源](images/network-one.png)
+
+
+
+
+
+[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
+[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/shortcuts.md
+++ b/src/content/zh-tw/tools/chrome-devtools/shortcuts.md
@@ -1,0 +1,554 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:Chrome DevTools 中所有鍵盤快捷鍵的參考。
+
+{# wf_updated_on:2016-11-28 #}
+{# wf_published_on:2015-04-29 #}
+
+# 鍵盤快捷鍵參考 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+本頁介紹 Chrome DevTools 中所有鍵盤快捷鍵的參考信息。一些快捷鍵全局可用，而其他快捷鍵會特定於單一面板。
+
+
+
+您也可以在提示中找到快捷鍵。將鼠標懸停在 DevTools 的 UI 元素上可以顯示元素的提示。
+如果元素有快捷鍵，提示將包含快捷鍵。
+
+## 訪問 DevTools
+
+<table>
+  <thead>
+      <th>訪問 DevTools</th>
+      <th>在 Windows 上</th>
+      <th>在 Mac 上</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Launch DevTools">打開 Developer Tools</td>
+      <td data-th="Windows"><kbd class="kbd">F12</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">I</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">I</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Launch DevTools">打開/切換檢查元素模式和瀏覽器窗口</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">C</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">C</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Launch DevTools">打開 Developer Tools 並聚焦到控制檯</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">J</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">J</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Launch DevTools">檢查檢查器（取消停靠第一個後按）</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">I</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">I</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+## 全局鍵盤快捷鍵
+
+下列鍵盤快捷鍵可以在所有 DevTools 面板中使用：
+
+<table>
+  <thead>
+      <th>全局快捷鍵</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Global Shortcuts">顯示一般設置對話框</td>
+      <td data-th="Windows"><kbd class="kbd">?</kbd>、<kbd class="kbd">F1</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">?</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">下一個面板</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">]</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">]</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">上一個面板</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">[</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">[</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">在面板歷史記錄中後退</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Alt</kbd> + <kbd class="kbd">[</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">[</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">在面板歷史記錄中前進</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Alt</kbd> + <kbd class="kbd">]</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">]</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">更改停靠位置</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">D</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">D</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">打開 Device Mode</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">M</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">M</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">切換控制檯/在設置對話框打開時將其關閉</td>
+      <td data-th="Windows"><kbd class="kbd">Esc</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Esc</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">刷新頁面</td>
+      <td data-th="Windows"><kbd class="kbd">F5</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">R</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">R</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">刷新忽略緩存內容的頁面</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">F5</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">R</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">R</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">在當前文件或面板中搜索文本</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">F</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">F</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">在所有源中搜索文本</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">F</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">F</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">按文件名搜索（除了在 Timeline 上）</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">P</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">P</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">放大（焦點在 DevTools 中時）</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">+</kbd></td>
+      <td data-th="Mac"><kbd>Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">+</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">縮小</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">-</kbd></td>
+      <td data-th="Mac"><kbd>Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">-</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Global Shortcuts">恢復默認文本大小</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">0</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">0</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+## 按面板分類的鍵盤快捷鍵
+
+### Elements
+
+<table>
+  <thead>
+      <th>Elements 面板</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Elements Panel">撤消更改</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Z</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Z</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">重做更改</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Y</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Y</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">Z</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">導航</td>
+      <td data-th="Windows"><kbd class="kbd">向上鍵</kbd>、<kbd class="kbd">向下鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">向上鍵</kbd>、<kbd class="kbd">向下鍵</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">展開/摺疊節點</td>
+      <td data-th="Windows"><kbd class="kbd">向右鍵</kbd>、<kbd class="kbd">向左鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">向右鍵</kbd>、<kbd class="kbd">向左鍵</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">展開節點</td>
+      <td data-th="Windows"><kbd class="kbd">點擊箭頭</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">點擊箭頭</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">展開/摺疊節點及其所有子節點</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Alt</kbd> + <kbd class="kbd">點擊箭頭圖標</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">點擊箭頭圖標</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">編輯屬性</td>
+      <td data-th="Windows"><kbd class="kbd">Enter</kbd>、<kbd class="kbd">雙擊屬性</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Enter</kbd>、<kbd class="kbd">雙擊屬性</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">隱藏元素</td>
+      <td data-th="Windows"><kbd class="kbd">H</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">H</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Elements Panel">切換爲以 HTML 形式編輯</td>
+      <td data-th="Windows"><kbd class="kbd">F2</kbd></td>
+      <td data-th="Mac"></td>
+    </tr>
+  </tbody>
+</table>
+
+#### Styles 邊欄
+
+Styles 邊欄中可用的快捷鍵：
+
+<table>
+  <thead>
+      <th>Styles 邊欄</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Styles Sidebar">編輯規則</td>
+      <td data-th="Windows"><kbd class="kbd">點擊</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">點擊</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">插入新屬性</td>
+      <td data-th="Windows"><kbd class="kbd">點擊空格</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">點擊空格</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">轉到源中樣式規則屬性聲明行</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">點擊屬性</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">點擊屬性</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">轉到源中屬性值聲明行</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">點擊屬性值</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">點擊屬性值</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">在顏色定義值之間循環</td>
+      <td data-th="Windows"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">點擊顏色選取器框</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">點擊顏色選取器框</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">編輯下一個/上一個屬性</td>
+      <td data-th="Windows"><kbd class="kbd">Tab</kbd>、<kbd class="kbd">Shift</kbd> + <kbd class="kbd">Tab</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Tab</kbd>、<kbd class="kbd">Shift</kbd> + <kbd class="kbd">Tab</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">增大/減小值</td>
+      <td data-th="Windows"><kbd class="kbd">向上鍵</kbd>、<kbd class="kbd">向下鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">向上鍵</kbd>、<kbd class="kbd">向下鍵</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">以 10 爲增量增大/減小值</td>
+      <td data-th="Windows"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">Up</kbd>、<kbd class="kbd">Shift</kbd> + <kbd class="kbd">Down</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">Up</kbd>、<kbd class="kbd">Shift</kbd> + <kbd class="kbd">Down</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">以 10 爲增量增大/減小值</td>
+      <td data-th="Windows"><kbd class="kbd">PgUp</kbd>、<kbd class="kbd">PgDown</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">PgUp</kbd>、<kbd class="kbd">PgDown</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">以 100 爲增量增大/減小值</td>
+      <td data-th="Windows"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">PgUp</kbd>、<kbd class="kbd">Shift</kbd> + <kbd class="kbd">PgDown</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">PgUp</kbd>、<kbd class="kbd">Shift</kbd> + <kbd class="kbd">PgDown</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Styles Sidebar">以 0.1 爲增量增大/減小值</td>
+      <td data-th="Windows"><kbd class="kbd">Alt</kbd> + <kbd class="kbd">向上鍵</kbd>、<kbd class="kbd">Alt</kbd> + <kbd class="kbd">向下鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">向上鍵</kbd>、<kbd class="kbd">Opt</kbd> + <kbd class="kbd">向下鍵</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### Sources
+
+<table>
+  <thead>
+      <th>Sources 面板</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Sources Panel">暫停/繼續腳本執行</td>
+      <td data-th="Windows"><kbd class="kbd">F8</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">\</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">F8</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">\</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">越過下一個函數調用</td>
+      <td data-th="Windows"><kbd class="kbd">F10</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">'</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">F10</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">'</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">進入下一個函數調用</td>
+      <td data-th="Windows"><kbd class="kbd">F11</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">;</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">F11</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">;</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">跳出當前函數</td>
+      <td data-th="Windows"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">F11</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">;</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">F11</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">;</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">選擇下一個調用框架</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">.</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">.</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">選擇上一個調用框架</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">,</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">,</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">切換斷點條件</td>
+      <td data-th="Windows"><kbd class="kbd">點擊行號</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">B</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">點擊行號</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">B</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">編輯斷點條件</td>
+      <td data-th="Windows"><kbd class="kbd">右鍵點擊行號</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">右鍵點擊行號</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">刪除各個單詞</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Delete</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">Delete</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">爲某一行或選定文本添加註釋</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">/</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">/</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">將更改保存到本地修改</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">S</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">S</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">保存所有更改</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Alt</kbd> + <kbd class="kbd">S</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Opt</kbd> + <kbd class="kbd">S</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">轉到行</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">G</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">G</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">按文件名搜索</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">跳轉到行號</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">P</kbd> + <span class="kbd"><i>數字</i></span></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">P</kbd> + <span class="kbd"><i>數字</i></span></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">跳轉到列</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd> + <span class="kbd"><i>數字</i></span> + <span class="kbd"><i>數字</i></span></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd> + <span class="kbd"><i>數字</i></span> + <span class="kbd"><i>數字</i></span></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">轉到成員</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">O</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">O</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">關閉活動標籤</td>
+      <td data-th="Windows"><kbd class="kbd">Alt</kbd> + <kbd class="kbd">W</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">W</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Sources Panel">運行代碼段</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Enter</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Enter</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+#### 在代碼編輯器內
+
+<table>
+  <thead>
+      <th>代碼編輯器</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Code Editor">轉到匹配的括號</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">M</kbd></td>
+      <td data-th="Mac"><span class="kbd"></span></td>
+    </tr>
+    <tr>
+      <td data-th="Code Editor">跳轉到行號</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">P</kbd> + <span class="kbd"><i>數字</i></span></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">P</kbd> + <span class="kbd"><i>數字</i></span></td>
+    </tr>
+    <tr>
+      <td data-th="Code Editor">跳轉到列</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd> + <span class="kbd"><i>數字</i></span> + <span class="kbd"><i>數字</i></span></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd> + <span class="kbd"><i>數字</i></span> + <span class="kbd"><i>數字</i></span></td>
+    </tr>
+    <tr>
+      <td data-th="Code Editor"> 切換註釋</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">/</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">/</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Code Editor">選擇下一個實例</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">D</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">D</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Code Editor">撤消上一個選擇</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">U</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">U</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### Timeline
+
+<table>
+  <thead>
+      <th>Timeline 面板</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Timeline Panel">開始/停止記錄</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">E</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">E</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Timeline Panel">保存時間線數據</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">S</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">S</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Timeline Panel">加載時間線數據</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">O</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">O</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### Profiles
+
+<table>
+  <thead>
+      <th>Profiles 面板</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Profiles Panel">開始/停止記錄</td>
+	  <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">E</kbd></td>
+	  <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">E</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### 控制檯
+
+<table>
+  <thead>
+      <th>控制檯快捷鍵</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Console Shortcuts">接受建議</td>
+      <td data-th="Windows"><kbd class="kbd">向右鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">向右鍵</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Console Shortcuts">上一個命令/行</td>
+      <td data-th="Windows"><kbd class="kbd">向上鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">向上鍵</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Console Shortcuts">下一個命令/行</td>
+      <td data-th="Windows"><kbd class="kbd">向下鍵</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">向下鍵</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Console Shortcuts">聚焦到控制檯</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">`</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">`</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Console Shortcuts">清除控制檯</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">L</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">K</kbd>、<kbd class="kbd">Opt</kbd> + <kbd class="kbd">L</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Console Shortcuts">多行輸入</td>
+      <td data-th="Windows"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">Enter</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Return</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Console Shortcuts">執行</td>
+      <td data-th="Windows"><kbd class="kbd">Enter</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Return</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+### Device Mode
+
+<table>
+  <thead>
+      <th>Device Mode 快捷鍵</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Emulation Shortcuts">雙指張合放大和縮小</td>
+      <td data-th="Windows"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">滾動</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Shift</kbd> + <kbd class="kbd">滾動</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+#### 抓屏時
+
+<table>
+  <thead>
+      <th>抓屏快捷鍵</th>
+      <th>Windows</th>
+      <th>Mac</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Screencasting Shortcuts">雙指張合放大和縮小</td>
+      <td data-th="Windows"><kbd class="kbd">Alt</kbd> + <kbd class="kbd">滾動</kbd>、<kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">點擊並用兩個手指拖動</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Opt</kbd> + <kbd class="kbd">滾動</kbd>、<kbd class="kbd">Cmd</kbd> + <kbd class="kbd">點擊並用兩個手指拖動</kbd></td>
+    </tr>
+    <tr>
+      <td data-th="Screencasting Shortcuts">檢查元素工具</td>
+      <td data-th="Windows"><kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">C</kbd></td>
+      <td data-th="Mac"><kbd class="kbd">Cmd</kbd> + <kbd class="kbd">Shift</kbd> + <kbd class="kbd">C</kbd></td>
+    </tr>
+  </tbody>
+</table>
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/snippets.md
+++ b/src/content/zh-tw/tools/chrome-devtools/snippets.md
@@ -1,0 +1,82 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:代碼段是您可以在 Chrome DevTools 的 Sources 面板中製作和執行的小腳本。您可以從任何頁面訪問和運行它們。在您運行代碼段時，它會從當前已打開頁面的上下文執行。
+
+{# wf_updated_on:2016-06-26 #}
+{# wf_published_on:2015-10-12 #}
+
+# 從任何頁面運行代碼段 {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+代碼段是您可以在 Chrome DevTools 的 Sources 面板中製作和執行的小腳本。
+您可以從任何頁面訪問和運行它們。
+在您運行代碼段時，它會從當前已打開頁面的上下文執行。
+
+
+如果您有將在多個頁面上重複使用的實用程序或調試腳本，可以考慮將腳本保存爲代碼段。
+
+您也可以使用代碼段替代[小書籤](https://en.wikipedia.org/wiki/Bookmarklet)。
+
+
+
+### TL;DR {: .hide-from-toc }
+- 代碼段是您可以從任何頁面運行的小腳本（類似於小書籤）。
+- 使用“Evaluate in Console”功能可以在控制檯中運行部分代碼段。
+- 請注意，Sources 面板中的常用功能（如斷點）也可與代碼段結合使用。
+
+
+## 創建代碼段
+
+要創建代碼段，請打開 **Sources** 面板，點擊 **Snippets** 標籤，在導航器中點擊右鍵，然後選擇 **New**。
+
+
+![創建代碼段](images/create-snippet.png)
+
+在編輯器中輸入您的代碼。如果您未保存更改，您的腳本名稱旁會有一個星號，如下面的屏幕截圖所示。請按 <kbd>Command</kbd>+<kbd>S</kbd> (Mac) 或 <kbd>Ctrl</kbd>+<kbd>S</kbd>
+（Windows、Linux）以保存您的更改。 
+
+![未保存的代碼段](images/unsaved-snippet.png)
+
+## 運行代碼段
+
+可以通過三種方式運行代碼段： 
+
+* 右鍵點擊代碼段文件名（左側窗格列出了所有代碼段），然後選擇 **Run**。
+* 點擊 **Run** 按鈕 (![運行代碼段按鈕](images/run.png){:.inline})。
+* 按 <kbd>Command</kbd>+<kbd>Enter</kbd> (Mac) 或 <kbd>Ctrl</kbd>+<kbd>Enter</kbd>（Windows、Linux）。
+
+
+要在控制檯中評估部分代碼段，請突出顯示這一部分，在編輯器中的任意位置右鍵點擊，然後選擇 **Evaluate in Console**，或使用鍵盤快捷鍵 <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> (Mac) 或 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd>（Windows、Linux）。
+
+
+
+
+
+![在控制檯中評估](images/evaluate-in-console.png)
+
+## 查看本地修改
+
+<!-- TODO apply revision content doesn't really work... -->
+
+要查看您對代碼段所做修改的差異，請在編輯器中（顯示代碼段時）點擊右鍵，然後選擇 **Local modifications**。
+
+
+![本地修改](images/local-modifications.png)
+
+在控制檯抽屜式導航欄中會彈出名稱爲 **History** 的新標籤。
+
+![代碼段歷史記錄](images/snippet-history.png)
+
+每個時間戳代表一次修改。展開時間戳旁的三角符號，查看那個時間點所做修改的差異。**revert** 鏈接可以移除修訂歷史記錄。從 2016 年 6 月 27 日開始，**apply revision content** 和 **apply original content** 鏈接似乎無法按預期工作。
+
+
+
+## 設置斷點
+
+就像在其他腳本上一樣，您也可以在代碼段上設置斷點。請參閱[添加斷點](/web/tools/chrome-devtools/debug/breakpoints/add-breakpoints)，瞭解如何在 **Sources** 面板中添加斷點。
+
+
+
+
+{# wf_devsite_translation #}


### PR DESCRIPTION
Chinese (Traditional) translation of:

- src/content/zh-tw/tools/chrome-devtools/index.md
- src/content/zh-tw/tools/chrome-devtools/progressive-web-apps.md
- src/content/zh-tw/tools/chrome-devtools/security.md
- src/content/zh-tw/tools/chrome-devtools/shortcuts.md
- src/content/zh-tw/tools/chrome-devtools/snippets.md

Note: All the articles are directly translated from zh-CN.