### PR TITLE
[lighthouse] update headings

### DIFF
--- a/src/content/en/tools/lighthouse/audits/_template.md
+++ b/src/content/en/tools/lighthouse/audits/_template.md
@@ -2,16 +2,17 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-30 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-30 #}
+{# wf_blink_components: N/A #}
 
 # AUDIT_NAME  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 [Audit source][src]{:.external}
 

--- a/src/content/en/tools/lighthouse/audits/address-bar.md
+++ b/src/content/en/tools/lighthouse/audits/address-bar.md
@@ -2,17 +2,18 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Address Bar Matches Brand Colors" Lighthouse audit.
 
-{# wf_updated_on: 2017-09-02 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-05-12 #}
+{# wf_blink_components: N/A #}
 
 # Address Bar Matches Brand Colors  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Theming the browser's address bar to match your brand's colors provides
 a more immersive user experience.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 To ensure that the address bar is always themed to your colors:
 
@@ -45,10 +46,10 @@ CSS color value.
       ...
     }
 
-See [Manifest Exists](manifest-exists#how) for more resources on adding a
+See [Manifest Exists](manifest-exists#recommendations) for more resources on adding a
 manifest to your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 The audit passes if Lighthouse finds a `theme-color` meta tag in the page's
 HTML and a `theme_color` property in the Web App Manifest. Lighthouse does

--- a/src/content/en/tools/lighthouse/audits/alt-attribute.md
+++ b/src/content/en/tools/lighthouse/audits/alt-attribute.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Every Image Element Has An alt Attribute" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-27 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-23 #}
+{# wf_blink_components: N/A #}
 
 # Every Image Element Has An alt Attribute  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Informative images should have an `alt` attribute that includes a text
 description of the contents of that image. Screen readers enable
@@ -18,7 +19,7 @@ information is not accessible to visually-impaired users.
 
 See [Text Alternatives for Images](/web/fundamentals/accessibility/semantics-builtin/text-alternatives-for-images) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -41,7 +42,7 @@ useful as possible for them. You don't need to explain every detail of the
 image, instead consider the context in which the image is being used, and try
 to convey the gist of the scene as efficiently as possible.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Images must have
 alternate text][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/appcache.md
+++ b/src/content/en/tools/lighthouse/audits/appcache.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Application Cache" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-04 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Application Cache  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Application Cache, also known as AppCache, is [deprecated][deprecated].
 
 [deprecated]: https://html.spec.whatwg.org/multipage/browsers.html#offline
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Consider using the service worker [Cache API][API] instead.
 
@@ -30,7 +31,7 @@ offline.
 
 [sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 The audit passes if no AppCache manifest is detected.
 

--- a/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
@@ -2,19 +2,20 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Element aria-* Attributes Are Allowed For This Role" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-13 #}
+{# wf_blink_components: N/A #}
 
 # Element aria-* Attributes Are Allowed For This Role  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Invalid role-attribute combinations can disable the accessibility of your
 page.
 
 See [Introduction to ARIA](/web/fundamentals/accessibility/semantics-aria/) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -39,7 +40,7 @@ attributes.
 [xp]: /web/tools/chrome-devtools/console/command-line-reference#xpath
 [roles]: https://www.w3.org/TR/wai-aria/roles#role_definitions
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Elements must only
 use allowed ARIA attributes][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/blocking-resources.md
+++ b/src/content/en/tools/lighthouse/audits/blocking-resources.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Render-blocking stylesheets" and "Render-blocking scripts" Lighthouse audits.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-01 #}
+{# wf_blink_components: N/A #}
 
 # Render-Blocking Resources {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Fast page loads result in higher user engagement, more pageviews, and
 improved conversion.
@@ -15,13 +16,12 @@ improved conversion.
 You can improve your page load speed by inlining links and scripts that
 are required for first paint, and deferring those that aren't.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 In your report, Lighthouse lists all of the render-blocking links or scripts
 that it has detected. The goal is to reduce this number.
 
-As mentioned in [How the audit is implemented](#implementation), Lighthouse
-flags three types of render-blocking links: scripts, stylesheets, and HTML
+Lighthouse flags three types of render-blocking links: scripts, stylesheets, and HTML
 imports. How you optimize depends on what type of resource you're working with.
 
 Note: When a resource is referred to as "critical" below, it means that the
@@ -42,7 +42,7 @@ functionality.
 [js]: /web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript
 [css]: /web/fundamentals/performance/critical-rendering-path/render-blocking-css
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse identifies three types of blocking resources.
 

--- a/src/content/en/tools/lighthouse/audits/button-name.md
+++ b/src/content/en/tools/lighthouse/audits/button-name.md
@@ -2,17 +2,18 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Buttons have an accessible name" Lighthouse audit.
 
-{# wf_updated_on: 2017-05-11 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-05-11 #}
+{# wf_blink_components: N/A #}
 
 # Buttons Have An Accessible Name {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Buttons without names are unusable for users who rely on screen readers.
 When a button doesn't have a name, screen readers announce "button".
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Lighthouse flags each element that fails the audit. The fix depends on what
 type of element is flagged:
@@ -40,7 +41,7 @@ For `<input type="submit">` and `<input type="reset">`:
 * Set the `aria-labelledby` attribute. See the description in the bullet-point
   list above.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Buttons must have
 discernible text][axe].

--- a/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
@@ -2,17 +2,18 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Cache contains start_url from manifest" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-15 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-15 #}
+{# wf_blink_components: N/A #}
 
 # Cache Contains start_url From Manifest  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Ensures that a progressive web app properly launches from a mobile device
 homescreen while offline.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 1. Define a `start_url` property in your `manifest.json` file.
 2. Ensure that your service worker properly caches a resource that matches
@@ -27,9 +28,9 @@ this codelab to integrate "add to homescreen" functionality in your own app.
 
 For more help on how to cache files with service workers for offline use,
 see the "How to pass the audit" section of the following Lighthouse doc:
-[URL responds with a 200 when offline](http-200-when-offline#how)
+[URL responds with a 200 when offline](http-200-when-offline#recommendations)
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 When a progressive web app is launched from the homescreen of a mobile
 device, the app opens on a specific URL. That URL is defined in the app's

--- a/src/content/en/tools/lighthouse/audits/consistently-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/consistently-interactive.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Consistently Interactive" Lighthouse audit.
 
-{# wf_updated_on: 2017-08-04 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-23 #}
+{# wf_blink_components: N/A #}
 
 # Consistently Interactive {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The Consistently Interactive metric measures when a page is *fully* interactive:
 
@@ -26,7 +27,7 @@ to respond to user input in the target time of 100ms or less.
 
 See also [First Interactive](first-interactive).
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 To improve your Consistently Interactive score:
 
@@ -43,7 +44,7 @@ To improve your Consistently Interactive score:
 [OCE]: /web/fundamentals/performance/optimizing-content-efficiency
 [OJE]: /web/fundamentals/performance/rendering/optimize-javascript-execution
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 The score is a lognormal distribution of some complicated calculations based on
 the definition of the Consistently Interactive metric. See [First Interactive

--- a/src/content/en/tools/lighthouse/audits/console-time.md
+++ b/src/content/en/tools/lighthouse/audits/console-time.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids console.time() In Its Own Scripts" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-01 #}
+{# wf_blink_components: N/A #}
 
 # Avoids console.time() In Its Own Scripts  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 If you're using `console.time()` to measure your page's performance, consider
 using the User Timing API instead. Benefits include:
@@ -23,7 +24,7 @@ using the User Timing API instead. Benefits include:
 
 [timeline]: /web/tools/lighthouse/images/user-timing-measurement-in-devtools.png
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 In your report, Lighthouse lists every instance of `console.time()` that it
 finds under **URLs**. Replace each of these calls with `performance.mark()`.
@@ -35,7 +36,7 @@ to learn how to use the API.
 
 [html5rocks]: https://www.html5rocks.com/en/tutorials/webperformance/usertiming/
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse reports every instance of `console.time()` that it finds from
 scripts that are on the same host as the page. Scripts from other hosts are

--- a/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
+++ b/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
@@ -2,19 +2,20 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Content Sized Correctly for Viewport" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-04 #}
+{# wf_blink_components: N/A #}
 
 # Content Sized Correctly for Viewport  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 This audit checks that the width of the content on your page is equal
 to the width of the viewport. When content width is smaller or larger than
 viewport width, that's often a cue that the page is not optimized for
 mobile screens.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 This audit is a roundabout way of determining if your page is optimized for
 mobile devices. If your site is not optimized and you want it to be, then see
@@ -27,7 +28,7 @@ You can ignore this audit if:
 * The content width of your page is intentionally smaller or larger than the
   viewport width.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 The audit passes if `window.innerWidth === window.outerWidth`.
 

--- a/src/content/en/tools/lighthouse/audits/contrast-ratio.md
+++ b/src/content/en/tools/lighthouse/audits/contrast-ratio.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Background and Foreground Colors Have Sufficient Contrast Ratio" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-20 #}
+{# wf_blink_components: N/A #}
 
 # Background and Foreground Colors Have Sufficient Contrast Ratio  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Low-contrast text is difficult or impossible for many users to read.
 
 See [Accessible Styles](/web/fundamentals/accessibility/accessible-styles) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 To find and fix each of element that does not have a sufficient contrast ratio:
 
@@ -50,7 +51,7 @@ To find and fix each of element that does not have a sufficient contrast ratio:
 [AE]: https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US
 [CR]: http://leaverou.github.io/contrast-ratio/
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Text elements
 must have sufficient color contrast against the background][axe] for more

--- a/src/content/en/tools/lighthouse/audits/critical-request-chains.md
+++ b/src/content/en/tools/lighthouse/audits/critical-request-chains.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Critical Request Chains" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-06 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-06 #}
+{# wf_blink_components: N/A #}
 
 # Critical Request Chains  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The Critical Request Chain is a concept from the Critical Rendering Path (CRP)
 optimization strategy. CRP enables the browser to load a page as quickly as
@@ -18,7 +19,7 @@ Check out the [Critical Rendering
 Path](/web/fundamentals/performance/critical-rendering-path/) docs to learn
 more.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 This audit is currently not structured as something to "pass" or "fail". The
 information that this audit provides gives you an opportunity to improve
@@ -60,7 +61,7 @@ You can use this diagram to improve your CRP by:
 
 Optimizing any of these factors results in a faster page load.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse uses network priority as a proxy for identifying render-blocking
 critical resources. See [Chrome Resource Priorities and

--- a/src/content/en/tools/lighthouse/audits/custom-splash-screen.md
+++ b/src/content/en/tools/lighthouse/audits/custom-splash-screen.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Configured For A Custom Splash Screen" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-13 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-13 #}
+{# wf_blink_components: N/A #}
 
 # Configured For A Custom Splash Screen  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 A custom splash screen makes your progressive web app (PWA) feel more like a
 native app.
@@ -22,7 +23,7 @@ for more information.
 
 [splash]: /web/updates/2015/10/splashscreen
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Chrome for Android automatically shows your custom splash screen so long as
 you meet the following requirements in your web app manifest:
@@ -32,10 +33,7 @@ you meet the following requirements in your web app manifest:
 * The `icons` array specifies an icon that is at least 512px by 512px.
 * The icon exists and is a PNG.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
-
-The audit passes if all of the requirements specified in [How to pass the
-audit](#how) are met.
+More information {: #more-info }
 
 Note: See [Audit: icon size coverage][discuss] for a discussion on what icon
 sizes should be included in your project. Lighthouse's opinion is that a

--- a/src/content/en/tools/lighthouse/audits/date-now.md
+++ b/src/content/en/tools/lighthouse/audits/date-now.md
@@ -2,19 +2,20 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Date.now() In Its Own Scripts" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-01 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Date.now() In Its Own Scripts  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 If you're using `Date.now()` to measure time, consider using
 `performance.now()` instead. `performance.now()` provides a higher timestamp
 resolution, and always increases at a constant rate that is independent
 of the system clock, which can be adjusted or manually skewed.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 In your report, Lighthouse lists every instance of `Date.now()` that it
 finds under **URLs**. Replace each of these calls with `performance.now()`.
@@ -23,7 +24,7 @@ See [`performance.now()`][MDN] for more information on the API.
 
 [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse reports every instance of `Date.now()` that it finds from
 scripts that are on the same host as the page. Scripts from other hosts are

--- a/src/content/en/tools/lighthouse/audits/deprecated-apis.md
+++ b/src/content/en/tools/lighthouse/audits/deprecated-apis.md
@@ -2,17 +2,18 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Deprecated APIs" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-07-12 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Deprecated APIs  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Deprecated APIs are scheduled to be removed from Chrome. Calling these APIs
 after they're removed will cause errors on your site.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Lighthouse flags the deprecated APIs in your report. Go to [Chrome Platform
 Status][CPS]{:.external} and expand the entries for the APIs that you're using
@@ -21,7 +22,7 @@ them.
 
 [CPS]: https://www.chromestatus.com/features#deprecated
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse collects the deprecated API warnings that Chrome logs to the
 DevTools Console.

--- a/src/content/en/tools/lighthouse/audits/document-write.md
+++ b/src/content/en/tools/lighthouse/audits/document-write.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids document.write()" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-01 #}
+{# wf_blink_components: N/A #}
 
 # Avoids document.write() {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 For users on slow connections, such as 2G, 3G, or slow Wi-Fi, external
 scripts dynamically injected via `document.write()` can delay the display of
@@ -17,7 +18,7 @@ See [Intervening against `document.write()`][blog] to learn more.
 
 [blog]: /web/updates/2016/08/removing-document-write
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 In your report, Lighthouse lists out every call to `document.write()`.
 Review this list, and note any call that dynamically injects a script.
@@ -28,7 +29,7 @@ to change. See [How do I fix this?][fix] for possible solutions.
 
 [fix]: /web/updates/2016/08/removing-document-write#how_do_i_fix_this
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse reports every instance of `document.write()` that it encounters.
 Note that Chrome's intervention against `document.write()` only applies to

--- a/src/content/en/tools/lighthouse/audits/dom-size.md
+++ b/src/content/en/tools/lighthouse/audits/dom-size.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Uses An Excessive DOM Size" Lighthouse audit.
 
-{# wf_updated_on: 2017-11-06 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-11-06 #}
+{# wf_blink_components: N/A #}
 
 # Uses An Excessive DOM Size  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 A large DOM tree can harm your page performance in multiple ways.
 
@@ -21,7 +22,7 @@ A large DOM tree can harm your page performance in multiple ways.
   you may be unknowingly storing references to a very large number of nodes, which can overwhelm
   the memory capabilities of your users' devices.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 An optimal DOM tree:
 

--- a/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
+++ b/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
@@ -2,22 +2,23 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Estimated Input Latency" Lighthouse audit.
 
-{# wf_updated_on: 2017-11-03 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-05 #}
+{# wf_blink_components: N/A #}
 
 # Estimated Input Latency  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Input responsiveness is a key factor in how users perceive the performance
 of your app. Apps have 100ms to respond to user input. Any longer than that,
 and the user perceives the app as laggy. See [Measure Performance with the RAIL
 Model](/web/fundamentals/performance/rail) for more information.
 
-See [How the audit is implemented](#implementation) for an explanation of why this audit tests
+See [More information](#more-info) for an explanation of why this audit tests
 for a target score of 50ms (rather than 100ms, which is what the RAIL model recommends).
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 To make your app respond to user input faster, you need to optimize how
 your code runs in the browser. Check out the series of techniques outlined
@@ -42,7 +43,7 @@ to ensure that all stages of [the pixel
 pipeline](/web/fundamentals/performance/rendering/#the_pixel_pipeline) are
 complete within 50ms.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 The RAIL performance model recommends that apps respond to user input within
 100ms, whereas Lighthouse's target score is 50ms. Why?

--- a/src/content/en/tools/lighthouse/audits/fast-3g.md
+++ b/src/content/en/tools/lighthouse/audits/fast-3g.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Page Load Is Fast Enough On 3G" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-14 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-14 #}
+{# wf_blink_components: N/A #}
 
 # Page Load Is Fast Enough On 3G  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Many mobile users of your page experience the equivalent of a 3G network
 connection. Ensuring that your page loads fast over a simulated 3G network
@@ -18,7 +19,7 @@ Note: A fast page load on 3G is a baseline requirement for a site to be
 considered a Progressive Web App. See [Baseline Progressive Web App
 Checklist](/web/progressive-web-apps/checklist#baseline).
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 There are two main metrics regarding how users perceive load time:
 
@@ -46,7 +47,7 @@ Performance][RP] for strategies.
 [load]: /web/tools/chrome-devtools/evaluate-performance/reference#record-load
 [RP]: /web/fundamentals/performance/rendering/
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse throttles the page if the network connection is faster than
 3G and then measures the time to first interactive. If the time to first

--- a/src/content/en/tools/lighthouse/audits/first-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/first-interactive.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "First Interactive" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-23 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-23 #}
+{# wf_blink_components: N/A #}
 
 # First Interactive {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The First Interactive metric measures when a page is *minimally* interactive:
 
@@ -17,7 +18,7 @@ The First Interactive metric measures when a page is *minimally* interactive:
 
 See also [Consistently Interactive](consistently-interactive).
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 There are two general strategies for improving load time:
 
@@ -30,7 +31,7 @@ There are two general strategies for improving load time:
 [CRP]: /web/fundamentals/performance/critical-rendering-path
 [OCE]: /web/fundamentals/performance/optimizing-content-efficiency
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 The score is a lognormal distribution of some complicated calculations based on
 the definition of the First Interactive metric. See [First Interactive And

--- a/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
+++ b/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "First Meaningful Paint" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-05 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-05 #}
+{# wf_blink_components: N/A #}
 
 # First Meaningful Paint {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Page load is a key aspect of how a user perceives the performance of your
 page. See [Measure Performance with the RAIL Method](/web/fundamentals/performance/rail) for more information.
@@ -15,7 +16,7 @@ page. See [Measure Performance with the RAIL Method](/web/fundamentals/performan
 This audit identifies the time at which the user feels that the primary
 content of the page is visible.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 The lower your First Meaningful Paint score, the faster that the page
 appears to display its primary content.
@@ -23,7 +24,7 @@ appears to display its primary content.
 [Optimizing the Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/)
 is particularly helpful towards achieving a faster First Meaningful Paint.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 First Meaningful Paint is essentially the paint after which the biggest
 above-the-fold layout change has happened, and web fonts have loaded. See the

--- a/src/content/en/tools/lighthouse/audits/form-labels.md
+++ b/src/content/en/tools/lighthouse/audits/form-labels.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Every Form Element Has A Label" Lighthouse audit.
 
-{# wf_updated_on: 2017-01-23 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-23 #}
+{# wf_blink_components: N/A #}
 
 # Every Form Element Has A Label  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Labels clarify the purpose of form elements. Although the purpose of each
 element may be obvious for sighted users, this is often not the case for
@@ -15,7 +16,7 @@ users who rely on screen readers.
 
 See [Create Amazing Forms](/web/fundamentals/design-and-ux/input/forms/#label_and_name_inputs_properly) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -38,7 +39,7 @@ Explicit labels:
     <span id="foo">Select seat:</span>
     <custom-dropdown aria-labelledby="foo">...</custom-dropdown>
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Form elements must
 have labels][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Requesting The Geolocation Permission On Page Load" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-11-30 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Requesting The Geolocation Permission On Page Load  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Users are mistrustful of or confused by pages that automatically request
 their location on page load. Rather than automatically requesting a
@@ -15,7 +16,7 @@ user's location on page load, tie the request to a user's gesture, such as
 a tapping a "Find Stores Near Me" button. Make sure that the gesture clearly
 and explicitly expresses the need for the user's location.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Under **URLs**, Lighthouse reports the line and column numbers where your
 code is requesting the user's location. Remove these calls, and tie the
@@ -26,7 +27,7 @@ requesting a user's location.
 
 [ask]: /web/fundamentals/native-hardware/user-location/#ask_permission_responsibly
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 If geolocation permission was already granted to a page before Lighthouse's
 audit, Lighthouse cannot determine if the page requests the user's location

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Has A &lt;meta name="viewport"&gt; Tag With width Or initial-scale" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-04 #}
+{# wf_blink_components: N/A #}
 
 # Has A Viewport Meta Tag With width Or initial-scale {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Without a viewport meta tag, mobile devices render pages at typical desktop
 screen widths, and then scale the pages to fit the mobile screens. Setting
@@ -17,7 +18,7 @@ Check out the following links to learn more:
 * [Configure the Viewport](/speed/docs/insights/ConfigureViewport)
 * [Set the Viewport](/web/fundamentals/design-and-ux/responsive/#set-the-viewport)
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a viewport `<meta>` tag in the `<head>` of your HTML.
 
@@ -31,7 +32,7 @@ The `width=device-width` key-value pair sets the width of the viewport to
 the width of the device. The `initial-scale=1` key-value pair sets the initial
 zoom level when visiting the page.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse checks that there's a `<meta name="viewport">` tag in the `<head>`
 of the document. It also checks that the node contains a `content` attribute

--- a/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
+++ b/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Responds With A 200 When Offline" Lighthouse audit.
 
-{# wf_updated_on: 2017-11-03 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-15 #}
+{# wf_blink_components: N/A #}
 
 # Responds With A 200 When Offline {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Progressive web apps work offline. If Lighthouse does not receive an HTTP 200
 response when accessing a page while offline, then the page is not accessible
 offline.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 1. Add a service worker to your app.
 2. Use the service worker to cache files locally.
@@ -34,7 +35,7 @@ Workers](https://codelabs.developers.google.com/codelabs/debugging-service-worke
 Use the [Offline Cookbook](/web/fundamentals/instant-and-offline/offline-cookbook/) to
 determine which caching strategy fits your app best. This covers step 2 above.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse emulates an offline connection using the Chrome Debugging Protocol,
 and then attempts to retrieve the page using `XMLHttpRequest`.

--- a/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
+++ b/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Redirects HTTP Traffic To HTTPS" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-20 #}
+{# wf_blink_components: N/A #}
 
 # Redirects HTTP Traffic To HTTPS  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 All sites should be protected with HTTPS. See the following Lighthouse doc to
 learn why: [Site is on HTTPS](https).
@@ -15,7 +16,7 @@ learn why: [Site is on HTTPS](https).
 Once you've got HTTPS set up, you need to make sure that all unsecure HTTP
 traffic to your site is redirected to HTTPS.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 1. Use canonical links in the `head` of your HTML to help search engines figure
    out the best way to get to the page.
@@ -25,7 +26,7 @@ traffic to your site is redirected to HTTPS.
 2. Configure your server to redirect HTTP traffic to HTTPS. See your server's
    documentation to figure out the best way to do this.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse changes the page's URL to `http`, loads the page, and then waits for
 the event from the Chrome Debugger that indicates that the page is secure. If

--- a/src/content/en/tools/lighthouse/audits/http2.md
+++ b/src/content/en/tools/lighthouse/audits/http2.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Uses HTTP/2 For Its Own Resources" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # Uses HTTP/2 For Its Own Resources  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 HTTP/2 can serve your page's resources faster, and with less data moving over
 the wire.
@@ -20,7 +21,7 @@ See [Introduction to HTTP/2][intro] for an in-depth technical overview.
 [faq]: https://http2.github.io/faq/
 [intro]: /web/fundamentals/performance/http2/
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Under **URLs**, Lighthouse lists every resource that was not served over HTTP/2.
 To pass this audit, serve each of those resources over HTTP/2.
@@ -29,7 +30,7 @@ To learn how to enable HTTP/2 on your servers, see [Setting Up HTTP/2][setup].
 
 [setup]: https://dassur.ma/things/h2setup/
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse gathers all of the resources that are from the same host as the
 page, and then checks the HTTP protocol version of each resource.

--- a/src/content/en/tools/lighthouse/audits/https.md
+++ b/src/content/en/tools/lighthouse/audits/https.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Uses HTTPS" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-19 #}
+{# wf_blink_components: N/A #}
 
 # Uses HTTPS  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 All websites should be protected with HTTPS, even ones that don't handle
 sensitive data. HTTPS prevents intruders from tampering with or passively
@@ -23,7 +24,7 @@ service workers, require HTTPS.
 For more information on why all sites should be protected with HTTPS, see
 [Why You Should Always Use HTTPS](/web/fundamentals/security/encrypt-in-transit/why-https).
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Migrate your site to HTTPS.
 
@@ -42,7 +43,7 @@ requests an unprotected (HTTP) resource. Check out the following doc on the
 Chrome DevTools Security panel to learn how to debug these situations:
 [Understand security issues](/web/tools/chrome-devtools/debug/security).
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse waits for an event from the Chrome Debugger Protocol indicating that
 the page is running on a secure connection. If the event is not heard within 10

--- a/src/content/en/tools/lighthouse/audits/install-prompt.md
+++ b/src/content/en/tools/lighthouse/audits/install-prompt.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "User Can Be Prompted To Install The Web App" Lighthouse audit.
 
-{# wf_updated_on: 2017-10-06 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-16 #}
+{# wf_blink_components: N/A #}
 
 # User Can Be Prompted To Install The Web App  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The prompt to install a web app lets users add your app to their homescreen.
 Users that add apps to homescreens engage those apps more.
@@ -20,7 +21,7 @@ Twitter's case study.
 
 [TL]: /web/showcase/2017/twitter#increasing_engagement_with_add_to_homescreen_prompt_and_web_push_notifications
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Google Chrome automatically displays the install prompt once it detects that
 a site qualifies as a Progressive Web App. These are Chrome's criteria:
@@ -67,10 +68,7 @@ var feedback = {
 {% include "web/_shared/multichoice.html" %}
 {% endframebox %}
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
-
-The audit passes if all of the criteria specified in [How to pass the
-audit](#how) are met.
+More information {: #more-info }
 
 [Audit source][src]{:.external}
 

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains Icons at Least 192px" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest Contains Icons at Least 192px  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 When a user adds your app to the homescreen, the mobile device needs an icon to
 display. That icon is specified in the `icons` array of the Web App Manifest.
@@ -18,7 +19,7 @@ can scale down the 192-pixel icon with reasonable accuracy. In other words,
 although you can provide smaller-sized icons in your Web App Manifest, it's
 unnecessary.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a 192-pixel icon to your Web App Manifest.
 
@@ -32,11 +33,11 @@ Add a 192-pixel icon to your Web App Manifest.
       ...
     }
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit can only guarantee that your icon displays well on Android devices.
 Other operating systems may require a different icon size for optimal

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
@@ -2,19 +2,20 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains background_color" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest Contains background_color  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 When your web app is loading from a user's homescreen, the browser uses the
 `background_color` property to draw the background color of the browser while
 the app loads. This creates a smooth transition between launching the app and
 loading the app's content.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a `background_color` property in your Web App Manifest. The value can be any
 valid CSS color.
@@ -25,11 +26,11 @@ valid CSS color.
       ...
     }
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Audit passes if the manifest contains a `background_color` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains name" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest Contains name  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The `name` property of the Web App Manifest is a human-readable name of your
 application as it is intended to be displayed to the user's mobile device.
@@ -15,7 +16,7 @@ application as it is intended to be displayed to the user's mobile device.
 If a `short_name` is not provided, then the `name` is the label that will be
 used on the mobile device's homescreen, next to your app's icon.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a `name` property in your Web App Manifest.
 
@@ -28,11 +29,11 @@ Add a `name` property in your Web App Manifest.
 Chrome's [maximum
 length](https://developer.chrome.com/apps/manifest/name) is 45 characters.
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that it has a `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains short_name" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest Contains short_name  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 After a user adds your app to the homescreen, the `short_name` is the text that
 is displayed on the homescreen next to your app icon. In general, it is used
 wherever there is insufficient space to display the full name of your app.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a `short_name` property in your Web App Manifest.
 
@@ -27,11 +28,11 @@ Chrome's [maximum recommended
 length](https://developer.chrome.com/apps/manifest/name#short_name) is 12
 characters.
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Audit passes if the manifest contains either `short_name` or `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Contains start_url" Lighthouse audit.
 
-{# wf_updated_on: 2016-09-21 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest Contains Start URL  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 After your web app has been added to a user's homescreen, the `start_url`
 property in the Web App Manifest determines what page of your app loads first
@@ -16,7 +17,7 @@ when the user launches your app from the homescreen.
 If the `start_url` property is absent, then the browser defaults to whatever
 page was active when the user decided to add the app to the homescreen.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a `start_url` property in your Web App Manifest.
 
@@ -26,11 +27,11 @@ Add a `start_url` property in your Web App Manifest.
       ...
     }
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that it has a `start_url` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-exists.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-exists.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest Exists" Lighthouse audit.
 
-{# wf_updated_on: 2017-10-06 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-20 #}
+{# wf_blink_components: N/A #}
 
 # Manifest Exists  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The Web App Manifest is the web technology that enables you to add your web app
 to a user's homescreen. This feature is commonly referred to as "Add to
 Homescreen (A2HS)".
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 For a hands-on, step-by-step guide on adding A2HS support in an
 existing application, check out the following codelab: [Add Your Web App to a
@@ -30,7 +31,7 @@ You can emulate and test A2HS events in Chrome DevTools. See the following
 section for more help: [Web App
 Manifest](/web/tools/chrome-devtools/debug/progressive-web-apps/#manifest).
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that it has data. The manifest that
 Lighthouse fetches is separate from the one that Chrome is using on the page, which

--- a/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
@@ -2,17 +2,18 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest's display Property Is Set" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest's display Property Is Set  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 When your app is launched from the homescreen, you can use the `display`
 property in your Web App Manifest to specify the display mode for the app.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add a `display` property to your Web App Manifest and set it to one of the
 following values: `fullscreen`, `standalone`, or `browser`.
@@ -27,11 +28,11 @@ See [MDN's reference for the display
 property](https://developer.mozilla.org/en-US/docs/Web/Manifest#display) for
 more information on each of these values.
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that the `display` property
 exists and that it's value is `fullscreen`, `standalone`, or `browser`.

--- a/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Manifest's short_name won't be truncated when displayed on homescreen" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-21 #}
+{# wf_blink_components: N/A #}
 
 # Manifest's short_name Won't Be Truncated When Displayed on Homescreen {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 When a user adds your web app to the homescreen, the `short_name` property is
 displayed as the label next to your app's icon. If the `short_name` is longer
@@ -16,7 +17,7 @@ than 12 characters, it'll be truncated on the homescreen.
 Note that, if the `short_name` is not present, Chrome can fall back to the
 `name` property if it's short enough.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Make the `short_name` property in your Web App Manifest less than 12 characters.
 
@@ -29,11 +30,11 @@ Make the `short_name` property in your Web App Manifest less than 12 characters.
 Or, if you don't specify a `short_name` property in your manifest, make the
 `name` property less than 12 characters.
 
-Check out [Manifest Exists](manifest-exists#how)
+Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that the `short_name` property is
 less than 12 characters. Note that since the `name` property can be used as a

--- a/src/content/en/tools/lighthouse/audits/mutation-events.md
+++ b/src/content/en/tools/lighthouse/audits/mutation-events.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Mutation Events In Its Own Scripts" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-04 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Mutation Events In Its Own Scripts  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The following mutation events harm performance and are deprecated in the
 DOM events spec:
@@ -22,7 +23,7 @@ DOM events spec:
 * `DOMNodeRemovedFromDocument`
 * `DOMSubtreeModified`
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Under **URLs**, Lighthouse reports each mutation event listener that it found
 in your code. Replace each of these mutation events with a `MutationObserver`.
@@ -30,11 +31,9 @@ See [`MutationObserver`][mdn] on MDN for more help.
 
 [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse collects all of the event listeners on the page, and flags
-any listener that uses one of the types listed in [Why the audit is
-important](#why).
-
+any listener that uses one of the types listed above.
 
 {% include "web/tools/lighthouse/audits/_feedback/mutation-events.html" %}

--- a/src/content/en/tools/lighthouse/audits/network-payloads.md
+++ b/src/content/en/tools/lighthouse/audits/network-payloads.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Enormous Network Payloads" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-21 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-21 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Enormous Network Payloads  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Reducing the total size of network requests speeds up page load time and
 saves your users money that they would have spent on cellular data.
@@ -23,7 +24,7 @@ power.
 [httparchive]: http://httparchive.org/interesting.php#onLoad
 [cost]: https://whatdoesmysitecost.com/
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Click **View Details** to see your page's requests. The largest requests are
 presented first. Reduce the size of the requests to reduce your total
@@ -43,14 +44,14 @@ Here are some strategies for reducing payload size:
   visits. See [HTTP Caching][http] and [Service Workers: An Introduction][SW].
 
 [PRPL]: /web/fundamentals/performance/prpl-pattern/
-[txtcompression]: /web/tools/lighthouse/audits/text-compression#how
+[txtcompression]: /web/tools/lighthouse/audits/text-compression#recommendations
 [mini]: /web/fundamentals/performance/optimizing-content-efficiency/optimize-encoding-and-transfer#minification_preprocessing_context-specific_optimizations
 [webp]: /web/tools/lighthouse/audits/webp
-[opto]: /web/tools/lighthouse/audits/optimize-images#how
+[opto]: /web/tools/lighthouse/audits/optimize-images#recommendations
 [http]: /web/fundamentals/performance/optimizing-content-efficiency/http-caching
 [SW]: /web/fundamentals/getting-started/primers/service-workers
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse sums up the total byte size of all resources that the page
 requested.

--- a/src/content/en/tools/lighthouse/audits/no-js.md
+++ b/src/content/en/tools/lighthouse/audits/no-js.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Contains Some Content When JavaScript Is Not Available" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-09-20 #}
+{# wf_blink_components: N/A #}
 
 # Contains Some Content When JavaScript Is Not Available  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 [Progressive Enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement)
 is a web development strategy that ensures that your site is accessible to the
@@ -21,7 +22,7 @@ styling using CSS, or interactivity using JavaScript, can be layered on top for
 the browsers that support those technologies. But basic content and page
 functionality should not rely on CSS or JavaScript.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Progressive enhancement is a large and contentious topic. One camp says that,
 in order to adhere to the strategy of progressive enhancement, pages should
@@ -52,7 +53,7 @@ To see how your site looks and performs when JavaScript is disabled, use
 Chrome DevTools' [Disable
 JavaScript](/web/tools/chrome-devtools/settings#disable-js) feature.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse disables JavaScript on the page and then inspects the page's HTML. If
 the HTML is empty then the audit fails. If the HTML is not empty then the audit

--- a/src/content/en/tools/lighthouse/audits/noopener.md
+++ b/src/content/en/tools/lighthouse/audits/noopener.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Opens External Anchors Using rel="noopener"" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-11-30 #}
+{# wf_blink_components: N/A #}
 
 # Opens External Anchors Using rel="noopener"  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 When your page links to another page using `target="_blank"`, the new page
 runs on the same process as your page. If the new page is executing expensive
@@ -21,7 +22,7 @@ See [The Performance Benefits of rel=noopener][jake] for more information.
 
 [jake]: https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add `rel="noopener"` to each of the links that Lighthouse has identified in your
 report. In general, always add `rel="noopener"` when you open an external link
@@ -29,7 +30,7 @@ in a new window or tab.
 
     <a href="https://examplepetstore.com" target="_blank" rel="noopener">...</a>
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse uses the following algorithm to flag links as `rel="noopener"`
 candidates:

--- a/src/content/en/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/notifications-on-load.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Requesting The Notification Permission On Page Load" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-19 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Requesting The Notification Permission On Page Load  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 As explained in [What Makes a Good Notification][good], good notifications are
 timely, relevant, and precise. If your page asks for permission to send
@@ -18,13 +19,13 @@ after they opt-in.
 
 [good]: /web/fundamentals/push-notifications/
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Under **URLs**, Lighthouse reports the line and column numbers where your
 code is requesting permission to send notifications. Remove these calls,
 and tie the requests to user gestures instead.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 If notification permissions was already granted or denied to a page before
 Lighthouse's audit, Lighthouse cannot determine if the page requests

--- a/src/content/en/tools/lighthouse/audits/offscreen-images.md
+++ b/src/content/en/tools/lighthouse/audits/offscreen-images.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Offscreen Images" Lighthouse audit.
 
-{# wf_updated_on: 2017-05-31 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-05-31 #}
+{# wf_blink_components: N/A #}
 
 # Offscreen Images  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Offscreen images are images that appear [below the fold][BTF]. Since users can't
 see offscreen images when they load a page, there's no reason to download the
@@ -16,7 +17,7 @@ load of offscreen images can speed up page load time and time to interactive.
 
 [BTF]: https://en.wikipedia.org/wiki/Above_the_fold#Below_the_fold
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 To pass this audit, refactor your pages to only download above-the-fold images
 during the initial request. Applying this strategy to your JS, HTML, CSS, and
@@ -39,7 +40,7 @@ If you do use an IntersectionObserver, make sure to include the
 
 [polyfill]: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse flags offscreen images that were requested before the
 Time To Interactive (TTI) event.

--- a/src/content/en/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/en/tools/lighthouse/audits/old-flexbox.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Old CSS Flexbox" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-28 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Old CSS Flexbox  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The old, 2009 specification for Flexbox is deprecated and is 2.3x slower
 than the latest specification. See [Flexbox Layout Isn't Slow][slow] to learn
@@ -20,7 +21,7 @@ UCBrowser. See [googlechrome/lighthouse#1710][uc].
 
 [slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Under **URLs**, Lighthouse lists every instance of `display: box` that it found
 on your page's stylesheets. Replace every instance with the new syntax,
@@ -46,7 +47,7 @@ from printing out vendor prefixes by adding the following rule to your
 
 [map]: https://wiki.csswg.org/spec/flexbox-2009-2011-spec-property-mapping
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse collects all of the stylesheets used on the page and checks if any of
 them uses `display: box`. Lighthouse does not check if the stylesheets use any

--- a/src/content/en/tools/lighthouse/audits/optimize-images.md
+++ b/src/content/en/tools/lighthouse/audits/optimize-images.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Optimize Images" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-20 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-20 #}
+{# wf_blink_components: N/A #}
 
 # Optimize Images  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Optimized images load faster and consume less cellular data.
 
 Note: This audit only tests JPEG images.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Click **View details** to see each JPEG image that can be optimized.
 To pass the audit, set the compression level of each image to 85 or lower.
@@ -25,7 +26,7 @@ See [Image Optimization][IO] to learn more about the topic in general.
 Web services like [TinyJPG](https://tinyjpg.com/) can help automate the
 process of image optimization.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse collects each JPEG image on the page, sets each image's compression
 level to 85, and then compares the original version with the compressed

--- a/src/content/en/tools/lighthouse/audits/oversized-images.md
+++ b/src/content/en/tools/lighthouse/audits/oversized-images.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Properly Size Images" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-29 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-04-25 #}
+{# wf_blink_components: N/A #}
 
 # Properly Size Images  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Ideally, your page should never serve images that are larger than the
 version that's rendered on the user's screen. Anything larger than that
 just results in wasted bytes and slows down page load time.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 In the results of this audit, Lighthouse lists every image that failed.
 Refactor how you serve these images to pass the audit.
@@ -49,7 +50,7 @@ when you upload an image, or request it from your page.
 [gr]: https://www.npmjs.com/package/gulp-responsive
 [rig]: https://www.npmjs.com/package/responsive-images-generator
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 For each image on the page, Lighthouse compares the size of the rendered image
 against the size of the actual image. The rendered size also accounts

--- a/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Uses Passive Event Listeners to Improve Scrolling Performance" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-11-30 #}
+{# wf_blink_components: N/A #}
 
 # Uses Passive Event Listeners to Improve Scrolling Performance  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Setting the `passive` option on your touch and wheel event listeners can
 improve scrolling performance.
@@ -21,7 +22,7 @@ for a technical deep-dive.
 [blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Add the `passive` flag to all of the event listeners that Lighthouse
 has identified. In general, add the `passive` flag to every `wheel`,
@@ -42,7 +43,7 @@ implement passive event listeners.
 
 [polyfill]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse uses the following algorithm to flag potential passive event
 listener candidates:

--- a/src/content/en/tools/lighthouse/audits/registered-service-worker.md
+++ b/src/content/en/tools/lighthouse/audits/registered-service-worker.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Registers A Service Worker" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-07-25 #}
+{# wf_blink_components: N/A #}
 
 # Registers A Service Worker {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Registering a service worker is the first step towards enabling the following
 progressive web app features:
@@ -18,7 +19,7 @@ progressive web app features:
 
 See [Service Workers: an Introduction](/web/fundamentals/getting-started/primers/service-workers) to learn more.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Registering a service worker involves only a few lines of code, but the only
 reason you'd use a service worker is to implement one of the progressive
@@ -27,7 +28,7 @@ work.
 
 For more help on caching files for offline use, see the "How to pass the
 audit" section of the following Lighthouse doc: [URL responds with a 200 when
-offline](http-200-when-offline#how).
+offline](http-200-when-offline#recommendations).
 
 For enabling push notifications or "add to homescreen", complete the
 following step-by-step tutorials and then use what you learn to implement
@@ -38,7 +39,7 @@ the features in your own app:
 * [Add your web app to a user's home
   screen](https://codelabs.developers.google.com/codelabs/add-to-home-screen).
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Checks if the Chrome Debugger returns a service worker version.
 

--- a/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Elements With ARIA Roles Have The Required aria-* Attributes" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-19 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-17 #}
+{# wf_blink_components: N/A #}
 
 # Elements With ARIA Roles Have The Required aria-* Attributes  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The `role` attribute helps screen readers understand the purpose of an ARIA
 widget. A `role` may have a set of required, additional attributes that
@@ -15,7 +16,7 @@ describe the state of the widget to the screen reader.
 
 See [Introduction to ARIA](/web/fundamentals/accessibility/semantics-aria/) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -34,7 +35,7 @@ To find each element's missing required attributes:
 
 [roles]: https://www.w3.org/TR/wai-aria/roles#role_definitions
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Required ARIA
 attributes must be provided][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/speed-index.md
+++ b/src/content/en/tools/lighthouse/audits/speed-index.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Perceptual Speed Index" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-04 #}
+{# wf_blink_components: N/A #}
 
 # Perceptual Speed Index  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Perceptual Speed Index is a page load performance metric that shows you how
 quickly the contents of a page are visibly populated. The lower the score,
 the better.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 To lower your Speed Index score, you need to optimize your page to visually
 load faster. Two good starting places are:
@@ -21,7 +22,7 @@ load faster. Two good starting places are:
 * [Optimizing Content Efficiency](/web/fundamentals/performance/optimizing-content-efficiency/).
 * [Optimizing the Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/).
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse uses a node module called
 [Speedline](https://github.com/pmdartus/speedline)

--- a/src/content/en/tools/lighthouse/audits/tabindex.md
+++ b/src/content/en/tools/lighthouse/audits/tabindex.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "No Element Has a tabindex Attribute Greater Than 0" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-23 #}
+{# wf_blink_components: N/A #}
 
 # No Element Has a tabindex Attribute Greater Than 0  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The `tabindex` attribute makes elements keyboard navigable.
 Positive values indicate an explicit navigation ordering of elements.
@@ -17,7 +18,7 @@ creates unusable experiences for users who rely on assistive technologies.
 See [Using tabindex](/web/fundamentals/accessibility/focus/using-tabindex)
 for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -26,7 +27,7 @@ that should not be keyboard navigable, or `0`, for elements that should. If
 you need an element to appear earlier in the tab order, consider moving
 it earlier in the DOM.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Elements should not
 have tabindex greater than zero][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/text-compression.md
+++ b/src/content/en/tools/lighthouse/audits/text-compression.md
@@ -2,17 +2,18 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Enable Text Compression" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-12 #}
+{# wf_blink_components: N/A #}
 
 # Enable Text Compression  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Text compression minimizes the byte size of network responses that include text
 content. Less bytes downloaded means faster page loads.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Lighthouse lists each response that was sent without text compression. Enable
 text compression on the server(s) that served these responses in order to
@@ -78,7 +79,7 @@ To compare the compressed and de-compressed sizes of a response:
 
 [lg]: /web/tools/chrome-devtools/network-performance/reference#request-rows
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse gathers all responses that:
 

--- a/src/content/en/tools/lighthouse/audits/time-to-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/time-to-interactive.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Time to Interactive" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-05 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-05 #}
+{# wf_blink_components: N/A #}
 
 # Time to Interactive  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Page load is a key aspect of how a user perceives the performance of your
 page. See [Measure Performance with the RAIL Method](/web/fundamentals/performance/rail) for more information.
@@ -15,13 +16,12 @@ page. See [Measure Performance with the RAIL Method](/web/fundamentals/performan
 This audit identifies the time at which a page appears to be ready enough that
 a user can interact with it.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
-Check out the resources in the [How to pass the audit](speed-index#how) section
-of the Speed Index audit for more help on improving page load performance.
+See [Speed Index](speed-index#recommendations) for more help on improving page load performance.
 The lower your Time to Interactive score, the better.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Time to Interactive is defined as the point at which layout has stabilized,
 key webfonts are visible, and the main thread is available enough to handle

--- a/src/content/en/tools/lighthouse/audits/unoptimized-images.md
+++ b/src/content/en/tools/lighthouse/audits/unoptimized-images.md
@@ -2,19 +2,20 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Unoptimized Images" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-20 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-04-20 #}
+{# wf_blink_components: N/A #}
 
 # Unoptimized Images  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Optimized images take less time to download, resulting in faster page
 loads. Page load time is one of the most important metrics for how users
 perceive the performance of your site. See [Load: Deliver content under
 1000ms](/web/fundamentals/performance/rail#load) to learn more.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 There are two types of images: vector and raster. See [Vector vs. raster
 images][overview] for an overview.
@@ -41,7 +42,7 @@ tuning][tools] for some examples of optimization tools.
 
 [tools]: /web/fundamentals/performance/optimizing-content-efficiency/image-optimization#tools_and_parameter_tuning
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse optimizes each image it finds on the page, and then compares
 the version used on the page against its own optimized version. The audit

--- a/src/content/en/tools/lighthouse/audits/user-timing.md
+++ b/src/content/en/tools/lighthouse/audits/user-timing.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "User Timing Marks and Measures" Lighthouse audit.
 
-{# wf_updated_on: 2016-10-06 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-10-06 #}
+{# wf_blink_components: N/A #}
 
 # User Timing Marks and Measures  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 The User Timing API enables you to measure your app's JavaScript performance.
 The basic idea is that you decide which parts of your scripts you want to
@@ -16,7 +17,7 @@ Timing API. From there, you can access the results from JavaScript using the
 API, or view them on your [Chrome DevTools Timeline
 Recordings](/web/tools/chrome-devtools/evaluate-performance/timeline-tool).
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 This audit is not structured as a "pass" or "fail" test. It's just an
 opportunity to discover a useful API that can aid you in measuring your app's
@@ -30,7 +31,7 @@ Check out [User Timing API](https://www.html5rocks.com/en/tutorials/webperforman
 for an introduction on using the User Timing API to measure your app's
 JavaScript performance.
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse extracts User Timing data from Chrome's Trace Event Profiling Tool.
 

--- a/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent" Lighthouse audit.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-18 #}
+{# wf_blink_components: N/A #}
 
 # Element ARIA Attributes Are Valid And Not Misspelled Or Non-Existent  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Misspelled or nonexistent ARIA attributes may be preventing the screen reader
 from properly understanding the current state of a widget. This could make the
@@ -15,7 +16,7 @@ page unusable to users who rely on screen readers.
 
 See [Introduction to ARIA](/web/fundamentals/accessibility/semantics-aria/) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -36,7 +37,7 @@ To find each listed element's invalid attribute names:
 [xp]: /web/tools/chrome-devtools/console/command-line-reference#xpath
 [roles]: https://www.w3.org/TR/wai-aria/roles#role_definitions
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid names][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/valid-aria-values.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-values.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Element aria-* Attributes Have Valid Values" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-01-18 #}
+{# wf_blink_components: N/A #}
 
 # Element aria-* Attributes Have Valid Values  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Invalid ARIA attribute values may be preventing the screen reader
 from properly understanding the current state of a widget. This could make the
@@ -15,7 +16,7 @@ page unusable to users who rely on screen readers.
 
 See [Introduction to ARIA](/web/fundamentals/accessibility/semantics-aria/) for more information.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 <<_shared/query.md>>
 
@@ -35,7 +36,7 @@ To find each listed element's invalid attribute values:
 [xp]: /web/tools/chrome-devtools/console/command-line-reference#xpath
 [states]: https://www.w3.org/TR/wai-aria/states_and_properties#state_prop_def
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid values][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/web-sql.md
+++ b/src/content/en/tools/lighthouse/audits/web-sql.md
@@ -2,18 +2,19 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Avoids Web SQL" Lighthouse audit.
 
-{# wf_updated_on: 2017-04-18 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # Avoids Web SQL  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 Web SQL is deprecated. See [Web SQL Database][spec] to learn more.
 
 [spec]: https://www.w3.org/TR/webdatabase/
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Consider replacing your Web SQL database with a modern alternative, such as
 [IndexedDB][indexeddb].
@@ -24,7 +25,7 @@ storage options.
 [indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [overview]: /web/fundamentals/instant-and-offline/web-storage/
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse checks if the page has a Web SQL database instance.
 

--- a/src/content/en/tools/lighthouse/audits/webp.md
+++ b/src/content/en/tools/lighthouse/audits/webp.md
@@ -2,12 +2,13 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Serve Images As WebP" Lighthouse audit.
 
-{# wf_updated_on: 2017-06-20 #}
+{# wf_updated_on: 2017-12-11 #}
 {# wf_published_on: 2017-06-20 #}
+{# wf_blink_components: N/A #}
 
 # Serve Images As WebP  {: .page-title }
 
-## Why the audit is important {: #why }
+## Overview {: #overview }
 
 WebP is a new image format that provides better lossy and lossless compression
 for images on the web, compared to PNG and JPEG. Encoding your images in WebP
@@ -15,7 +16,7 @@ rather than JPEG or PNG means that they will load faster and consume less
 cellular data. See [A New Image Format For The Web](/speed/webp/) for more on
 WebP.
 
-## How to pass the audit {: #how }
+## Recommendations {: #recommendations }
 
 Click **View Details** to see the potential savings of encoding your page's
 images with WebP rather than JPEG or PNG. To pass this audit, encode all of
@@ -27,7 +28,7 @@ support for WebP?][fallback] for an overview of fallback techniques.
 
 [fallback]: /speed/webp/faq#how_can_i_detect_browser_support_for_webp
 
-{% include "web/tools/lighthouse/audits/implementation-heading.html" %}
+More information {: #more-info }
 
 Lighthouse collects each JPEG and PNG image on the page, and then converts
 each to WebP. Lighthouse omits the image from its report if the potential


### PR DESCRIPTION
What's changed, or what was fixed?
- Updates the headings in the lighthouse reference docs from "why the audit is important", "how to pass the audit", "How the audit is implemented" to "Overview", "Recommendations", "More information". The new headings are more professional and concise and general (in a helpful way)

**Target Live Date:** 2017-12-18

- [x] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.

**R:** @petele
