### PR TITLE
[lighthouse] add "unsuccessful http code" reference

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -92,6 +92,8 @@ toc:
   path: /web/tools/lighthouse/audits/optimize-images
 - title: Oversized Images
   path: /web/tools/lighthouse/audits/oversized-images
+- title: Page has unsuccessful HTTP status code
+  path: /web/tools/lighthouse/audits/successful-http-code
 - title: Page Load Is Fast Enough On 3G
   path: /web/tools/lighthouse/audits/fast-3g
 - title: Perceptual Speed Index

--- a/src/content/en/tools/lighthouse/audits/successful-http-code.md
+++ b/src/content/en/tools/lighthouse/audits/successful-http-code.md
@@ -1,0 +1,26 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Page has unsuccessful HTTP status code" Lighthouse audit.
+
+{# wf_updated_on: 2017-12-11 #}
+{# wf_published_on: 2017-12-11 #}
+{# wf_blink_components: N/A #}
+
+# Page has unsuccessful HTTP status code  {: .page-title }
+
+## Overview {: #overview }
+
+Search engines may not properly index pages that return unsuccessful HTTP status codes.
+
+## Recommendations {: #recommendations }
+
+When a page is requested, ensure that your server returns a 2XX or 3XX HTTP status code. Search
+engines may not properly index pages with 4XX or 5XX status codes.
+
+## More information {: #more-info }
+
+Lighthouse considers any HTTP status code between 400 and 599 (inclusive) to be unsuccessful.
+
+[Audit source][src]{:.external}
+
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/seo/http-status-code.js


### PR DESCRIPTION
What's changed, or what was fixed?
- adds reference doc for "unsuccessful HTTP status code" lighthouse audit

**Fixes:** googlechrome/lighthouse/issues/3787

**Target Live Date:** 2017-12-18

- [x] This has been reviewed and approved by @petele
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.

**R:** @petele
