### PR TITLE
Adds support for background color in announcements

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1004,6 +1004,7 @@ function testProject(filename, contents) {
           type: 'object',
           properties: {
             description: {type: 'string', required: true},
+            background: {type: 'string', required: false},
           },
           additionalProperties: false,
         },


### PR DESCRIPTION
What's changed, or what was fixed?
- added test support for announcement bar background color

- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.