### PR TITLE
[lighthouse] fix formatting for "more info" heading

### DIFF
--- a/src/content/en/tools/lighthouse/audits/_template.md
+++ b/src/content/en/tools/lighthouse/audits/_template.md
@@ -12,7 +12,7 @@ description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
 
 ## Recommendations {: #recommendations }
 
-More information {: #more-info }
+## More information {: #more-info }
 
 [Audit source][src]{:.external}
 

--- a/src/content/en/tools/lighthouse/audits/address-bar.md
+++ b/src/content/en/tools/lighthouse/audits/address-bar.md
@@ -49,7 +49,7 @@ CSS color value.
 See [Manifest Exists](manifest-exists#recommendations) for more resources on adding a
 manifest to your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 The audit passes if Lighthouse finds a `theme-color` meta tag in the page's
 HTML and a `theme_color` property in the Web App Manifest. Lighthouse does

--- a/src/content/en/tools/lighthouse/audits/alt-attribute.md
+++ b/src/content/en/tools/lighthouse/audits/alt-attribute.md
@@ -42,7 +42,7 @@ useful as possible for them. You don't need to explain every detail of the
 image, instead consider the context in which the image is being used, and try
 to convey the gist of the scene as efficiently as possible.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Images must have
 alternate text][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/appcache.md
+++ b/src/content/en/tools/lighthouse/audits/appcache.md
@@ -31,7 +31,7 @@ offline.
 
 [sw-appcache-behavior]: https://github.com/GoogleChrome/sw-appcache-behavior
 
-More information {: #more-info }
+## More information {: #more-info }
 
 The audit passes if no AppCache manifest is detected.
 

--- a/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
@@ -40,7 +40,7 @@ attributes.
 [xp]: /web/tools/chrome-devtools/console/command-line-reference#xpath
 [roles]: https://www.w3.org/TR/wai-aria/roles#role_definitions
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Elements must only
 use allowed ARIA attributes][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/blocking-resources.md
+++ b/src/content/en/tools/lighthouse/audits/blocking-resources.md
@@ -42,7 +42,7 @@ functionality.
 [js]: /web/fundamentals/performance/critical-rendering-path/adding-interactivity-with-javascript
 [css]: /web/fundamentals/performance/critical-rendering-path/render-blocking-css
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse identifies three types of blocking resources.
 

--- a/src/content/en/tools/lighthouse/audits/button-name.md
+++ b/src/content/en/tools/lighthouse/audits/button-name.md
@@ -41,7 +41,7 @@ For `<input type="submit">` and `<input type="reset">`:
 * Set the `aria-labelledby` attribute. See the description in the bullet-point
   list above.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Buttons must have
 discernible text][axe].

--- a/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/cache-contains-start_url.md
@@ -30,7 +30,7 @@ For more help on how to cache files with service workers for offline use,
 see the "How to pass the audit" section of the following Lighthouse doc:
 [URL responds with a 200 when offline](http-200-when-offline#recommendations)
 
-More information {: #more-info }
+## More information {: #more-info }
 
 When a progressive web app is launched from the homescreen of a mobile
 device, the app opens on a specific URL. That URL is defined in the app's

--- a/src/content/en/tools/lighthouse/audits/consistently-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/consistently-interactive.md
@@ -44,7 +44,7 @@ To improve your Consistently Interactive score:
 [OCE]: /web/fundamentals/performance/optimizing-content-efficiency
 [OJE]: /web/fundamentals/performance/rendering/optimize-javascript-execution
 
-More information {: #more-info }
+## More information {: #more-info }
 
 The score is a lognormal distribution of some complicated calculations based on
 the definition of the Consistently Interactive metric. See [First Interactive

--- a/src/content/en/tools/lighthouse/audits/console-time.md
+++ b/src/content/en/tools/lighthouse/audits/console-time.md
@@ -36,7 +36,7 @@ to learn how to use the API.
 
 [html5rocks]: https://www.html5rocks.com/en/tutorials/webperformance/usertiming/
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse reports every instance of `console.time()` that it finds from
 scripts that are on the same host as the page. Scripts from other hosts are

--- a/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
+++ b/src/content/en/tools/lighthouse/audits/content-sized-correctly-for-viewport.md
@@ -28,7 +28,7 @@ You can ignore this audit if:
 * The content width of your page is intentionally smaller or larger than the
   viewport width.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 The audit passes if `window.innerWidth === window.outerWidth`.
 

--- a/src/content/en/tools/lighthouse/audits/contrast-ratio.md
+++ b/src/content/en/tools/lighthouse/audits/contrast-ratio.md
@@ -51,7 +51,7 @@ To find and fix each of element that does not have a sufficient contrast ratio:
 [AE]: https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US
 [CR]: http://leaverou.github.io/contrast-ratio/
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Text elements
 must have sufficient color contrast against the background][axe] for more

--- a/src/content/en/tools/lighthouse/audits/critical-request-chains.md
+++ b/src/content/en/tools/lighthouse/audits/critical-request-chains.md
@@ -61,7 +61,7 @@ You can use this diagram to improve your CRP by:
 
 Optimizing any of these factors results in a faster page load.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse uses network priority as a proxy for identifying render-blocking
 critical resources. See [Chrome Resource Priorities and

--- a/src/content/en/tools/lighthouse/audits/custom-splash-screen.md
+++ b/src/content/en/tools/lighthouse/audits/custom-splash-screen.md
@@ -33,7 +33,7 @@ you meet the following requirements in your web app manifest:
 * The `icons` array specifies an icon that is at least 512px by 512px.
 * The icon exists and is a PNG.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Note: See [Audit: icon size coverage][discuss] for a discussion on what icon
 sizes should be included in your project. Lighthouse's opinion is that a

--- a/src/content/en/tools/lighthouse/audits/date-now.md
+++ b/src/content/en/tools/lighthouse/audits/date-now.md
@@ -24,7 +24,7 @@ See [`performance.now()`][MDN] for more information on the API.
 
 [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse reports every instance of `Date.now()` that it finds from
 scripts that are on the same host as the page. Scripts from other hosts are

--- a/src/content/en/tools/lighthouse/audits/deprecated-apis.md
+++ b/src/content/en/tools/lighthouse/audits/deprecated-apis.md
@@ -22,7 +22,7 @@ them.
 
 [CPS]: https://www.chromestatus.com/features#deprecated
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse collects the deprecated API warnings that Chrome logs to the
 DevTools Console.

--- a/src/content/en/tools/lighthouse/audits/document-write.md
+++ b/src/content/en/tools/lighthouse/audits/document-write.md
@@ -29,7 +29,7 @@ to change. See [How do I fix this?][fix] for possible solutions.
 
 [fix]: /web/updates/2016/08/removing-document-write#how_do_i_fix_this
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse reports every instance of `document.write()` that it encounters.
 Note that Chrome's intervention against `document.write()` only applies to

--- a/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
+++ b/src/content/en/tools/lighthouse/audits/estimated-input-latency.md
@@ -43,7 +43,7 @@ to ensure that all stages of [the pixel
 pipeline](/web/fundamentals/performance/rendering/#the_pixel_pipeline) are
 complete within 50ms.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 The RAIL performance model recommends that apps respond to user input within
 100ms, whereas Lighthouse's target score is 50ms. Why?

--- a/src/content/en/tools/lighthouse/audits/fast-3g.md
+++ b/src/content/en/tools/lighthouse/audits/fast-3g.md
@@ -47,7 +47,7 @@ Performance][RP] for strategies.
 [load]: /web/tools/chrome-devtools/evaluate-performance/reference#record-load
 [RP]: /web/fundamentals/performance/rendering/
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse throttles the page if the network connection is faster than
 3G and then measures the time to first interactive. If the time to first

--- a/src/content/en/tools/lighthouse/audits/first-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/first-interactive.md
@@ -31,7 +31,7 @@ There are two general strategies for improving load time:
 [CRP]: /web/fundamentals/performance/critical-rendering-path
 [OCE]: /web/fundamentals/performance/optimizing-content-efficiency
 
-More information {: #more-info }
+## More information {: #more-info }
 
 The score is a lognormal distribution of some complicated calculations based on
 the definition of the First Interactive metric. See [First Interactive And

--- a/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
+++ b/src/content/en/tools/lighthouse/audits/first-meaningful-paint.md
@@ -24,7 +24,7 @@ appears to display its primary content.
 [Optimizing the Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/)
 is particularly helpful towards achieving a faster First Meaningful Paint.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 First Meaningful Paint is essentially the paint after which the biggest
 above-the-fold layout change has happened, and web fonts have loaded. See the

--- a/src/content/en/tools/lighthouse/audits/form-labels.md
+++ b/src/content/en/tools/lighthouse/audits/form-labels.md
@@ -39,7 +39,7 @@ Explicit labels:
     <span id="foo">Select seat:</span>
     <custom-dropdown aria-labelledby="foo">...</custom-dropdown>
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Form elements must
 have labels][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/geolocation-on-load.md
@@ -27,7 +27,7 @@ requesting a user's location.
 
 [ask]: /web/fundamentals/native-hardware/user-location/#ask_permission_responsibly
 
-More information {: #more-info }
+## More information {: #more-info }
 
 If geolocation permission was already granted to a page before Lighthouse's
 audit, Lighthouse cannot determine if the page requests the user's location

--- a/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
+++ b/src/content/en/tools/lighthouse/audits/has-viewport-meta-tag.md
@@ -32,7 +32,7 @@ The `width=device-width` key-value pair sets the width of the viewport to
 the width of the device. The `initial-scale=1` key-value pair sets the initial
 zoom level when visiting the page.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse checks that there's a `<meta name="viewport">` tag in the `<head>`
 of the document. It also checks that the node contains a `content` attribute

--- a/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
+++ b/src/content/en/tools/lighthouse/audits/http-200-when-offline.md
@@ -35,7 +35,7 @@ Workers](https://codelabs.developers.google.com/codelabs/debugging-service-worke
 Use the [Offline Cookbook](/web/fundamentals/instant-and-offline/offline-cookbook/) to
 determine which caching strategy fits your app best. This covers step 2 above.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse emulates an offline connection using the Chrome Debugging Protocol,
 and then attempts to retrieve the page using `XMLHttpRequest`.

--- a/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
+++ b/src/content/en/tools/lighthouse/audits/http-redirects-to-https.md
@@ -26,7 +26,7 @@ traffic to your site is redirected to HTTPS.
 2. Configure your server to redirect HTTP traffic to HTTPS. See your server's
    documentation to figure out the best way to do this.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse changes the page's URL to `http`, loads the page, and then waits for
 the event from the Chrome Debugger that indicates that the page is secure. If

--- a/src/content/en/tools/lighthouse/audits/http2.md
+++ b/src/content/en/tools/lighthouse/audits/http2.md
@@ -30,7 +30,7 @@ To learn how to enable HTTP/2 on your servers, see [Setting Up HTTP/2][setup].
 
 [setup]: https://dassur.ma/things/h2setup/
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse gathers all of the resources that are from the same host as the
 page, and then checks the HTTP protocol version of each resource.

--- a/src/content/en/tools/lighthouse/audits/https.md
+++ b/src/content/en/tools/lighthouse/audits/https.md
@@ -43,7 +43,7 @@ requests an unprotected (HTTP) resource. Check out the following doc on the
 Chrome DevTools Security panel to learn how to debug these situations:
 [Understand security issues](/web/tools/chrome-devtools/debug/security).
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse waits for an event from the Chrome Debugger Protocol indicating that
 the page is running on a secure connection. If the event is not heard within 10

--- a/src/content/en/tools/lighthouse/audits/install-prompt.md
+++ b/src/content/en/tools/lighthouse/audits/install-prompt.md
@@ -68,7 +68,7 @@ var feedback = {
 {% include "web/_shared/multichoice.html" %}
 {% endframebox %}
 
-More information {: #more-info }
+## More information {: #more-info }
 
 [Audit source][src]{:.external}
 

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-192px-icon.md
@@ -37,7 +37,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit can only guarantee that your icon displays well on Android devices.
 Other operating systems may require a different icon size for optimal

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-background_color.md
@@ -30,7 +30,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Audit passes if the manifest contains a `background_color` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-name.md
@@ -33,7 +33,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that it has a `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-short_name.md
@@ -32,7 +32,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Audit passes if the manifest contains either `short_name` or `name` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-contains-start_url.md
@@ -31,7 +31,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that it has a `start_url` property.
 The manifest that Lighthouse fetches is separate from the one that Chrome is

--- a/src/content/en/tools/lighthouse/audits/manifest-exists.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-exists.md
@@ -31,7 +31,7 @@ You can emulate and test A2HS events in Chrome DevTools. See the following
 section for more help: [Web App
 Manifest](/web/tools/chrome-devtools/debug/progressive-web-apps/#manifest).
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that it has data. The manifest that
 Lighthouse fetches is separate from the one that Chrome is using on the page, which

--- a/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-has-display-set.md
@@ -32,7 +32,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that the `display` property
 exists and that it's value is `fullscreen`, `standalone`, or `browser`.

--- a/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
+++ b/src/content/en/tools/lighthouse/audits/manifest-short_name-is-not-truncated.md
@@ -34,7 +34,7 @@ Check out [Manifest Exists](manifest-exists#recommendations)
 for a list of guides that teach you how to properly
 implement and test "Add to Homescreen" support in your app.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse fetches the manifest and verifies that the `short_name` property is
 less than 12 characters. Note that since the `name` property can be used as a

--- a/src/content/en/tools/lighthouse/audits/mutation-events.md
+++ b/src/content/en/tools/lighthouse/audits/mutation-events.md
@@ -31,7 +31,7 @@ See [`MutationObserver`][mdn] on MDN for more help.
 
 [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse collects all of the event listeners on the page, and flags
 any listener that uses one of the types listed above.

--- a/src/content/en/tools/lighthouse/audits/network-payloads.md
+++ b/src/content/en/tools/lighthouse/audits/network-payloads.md
@@ -51,7 +51,7 @@ Here are some strategies for reducing payload size:
 [http]: /web/fundamentals/performance/optimizing-content-efficiency/http-caching
 [SW]: /web/fundamentals/getting-started/primers/service-workers
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse sums up the total byte size of all resources that the page
 requested.

--- a/src/content/en/tools/lighthouse/audits/no-js.md
+++ b/src/content/en/tools/lighthouse/audits/no-js.md
@@ -53,7 +53,7 @@ To see how your site looks and performs when JavaScript is disabled, use
 Chrome DevTools' [Disable
 JavaScript](/web/tools/chrome-devtools/settings#disable-js) feature.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse disables JavaScript on the page and then inspects the page's HTML. If
 the HTML is empty then the audit fails. If the HTML is not empty then the audit

--- a/src/content/en/tools/lighthouse/audits/noopener.md
+++ b/src/content/en/tools/lighthouse/audits/noopener.md
@@ -30,7 +30,7 @@ in a new window or tab.
 
     <a href="https://examplepetstore.com" target="_blank" rel="noopener">...</a>
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse uses the following algorithm to flag links as `rel="noopener"`
 candidates:

--- a/src/content/en/tools/lighthouse/audits/notifications-on-load.md
+++ b/src/content/en/tools/lighthouse/audits/notifications-on-load.md
@@ -25,7 +25,7 @@ Under **URLs**, Lighthouse reports the line and column numbers where your
 code is requesting permission to send notifications. Remove these calls,
 and tie the requests to user gestures instead.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 If notification permissions was already granted or denied to a page before
 Lighthouse's audit, Lighthouse cannot determine if the page requests

--- a/src/content/en/tools/lighthouse/audits/offscreen-images.md
+++ b/src/content/en/tools/lighthouse/audits/offscreen-images.md
@@ -40,7 +40,7 @@ If you do use an IntersectionObserver, make sure to include the
 
 [polyfill]: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse flags offscreen images that were requested before the
 Time To Interactive (TTI) event.

--- a/src/content/en/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/en/tools/lighthouse/audits/old-flexbox.md
@@ -47,7 +47,7 @@ from printing out vendor prefixes by adding the following rule to your
 
 [map]: https://wiki.csswg.org/spec/flexbox-2009-2011-spec-property-mapping
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse collects all of the stylesheets used on the page and checks if any of
 them uses `display: box`. Lighthouse does not check if the stylesheets use any

--- a/src/content/en/tools/lighthouse/audits/optimize-images.md
+++ b/src/content/en/tools/lighthouse/audits/optimize-images.md
@@ -26,7 +26,7 @@ See [Image Optimization][IO] to learn more about the topic in general.
 Web services like [TinyJPG](https://tinyjpg.com/) can help automate the
 process of image optimization.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse collects each JPEG image on the page, sets each image's compression
 level to 85, and then compares the original version with the compressed

--- a/src/content/en/tools/lighthouse/audits/oversized-images.md
+++ b/src/content/en/tools/lighthouse/audits/oversized-images.md
@@ -50,7 +50,7 @@ when you upload an image, or request it from your page.
 [gr]: https://www.npmjs.com/package/gulp-responsive
 [rig]: https://www.npmjs.com/package/responsive-images-generator
 
-More information {: #more-info }
+## More information {: #more-info }
 
 For each image on the page, Lighthouse compares the size of the rendered image
 against the size of the actual image. The rendered size also accounts

--- a/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
@@ -43,7 +43,7 @@ implement passive event listeners.
 
 [polyfill]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse uses the following algorithm to flag potential passive event
 listener candidates:

--- a/src/content/en/tools/lighthouse/audits/registered-service-worker.md
+++ b/src/content/en/tools/lighthouse/audits/registered-service-worker.md
@@ -39,7 +39,7 @@ the features in your own app:
 * [Add your web app to a user's home
   screen](https://codelabs.developers.google.com/codelabs/add-to-home-screen).
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Checks if the Chrome Debugger returns a service worker version.
 

--- a/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/required-aria-attributes.md
@@ -35,7 +35,7 @@ To find each element's missing required attributes:
 
 [roles]: https://www.w3.org/TR/wai-aria/roles#role_definitions
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Required ARIA
 attributes must be provided][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/speed-index.md
+++ b/src/content/en/tools/lighthouse/audits/speed-index.md
@@ -22,7 +22,7 @@ load faster. Two good starting places are:
 * [Optimizing Content Efficiency](/web/fundamentals/performance/optimizing-content-efficiency/).
 * [Optimizing the Critical Rendering Path](/web/fundamentals/performance/critical-rendering-path/).
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse uses a node module called
 [Speedline](https://github.com/pmdartus/speedline)

--- a/src/content/en/tools/lighthouse/audits/tabindex.md
+++ b/src/content/en/tools/lighthouse/audits/tabindex.md
@@ -27,7 +27,7 @@ that should not be keyboard navigable, or `0`, for elements that should. If
 you need an element to appear earlier in the tab order, consider moving
 it earlier in the DOM.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [Elements should not
 have tabindex greater than zero][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/text-compression.md
+++ b/src/content/en/tools/lighthouse/audits/text-compression.md
@@ -79,7 +79,7 @@ To compare the compressed and de-compressed sizes of a response:
 
 [lg]: /web/tools/chrome-devtools/network-performance/reference#request-rows
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse gathers all responses that:
 

--- a/src/content/en/tools/lighthouse/audits/time-to-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/time-to-interactive.md
@@ -21,7 +21,7 @@ a user can interact with it.
 See [Speed Index](speed-index#recommendations) for more help on improving page load performance.
 The lower your Time to Interactive score, the better.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Time to Interactive is defined as the point at which layout has stabilized,
 key webfonts are visible, and the main thread is available enough to handle

--- a/src/content/en/tools/lighthouse/audits/unoptimized-images.md
+++ b/src/content/en/tools/lighthouse/audits/unoptimized-images.md
@@ -42,7 +42,7 @@ tuning][tools] for some examples of optimization tools.
 
 [tools]: /web/fundamentals/performance/optimizing-content-efficiency/image-optimization#tools_and_parameter_tuning
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse optimizes each image it finds on the page, and then compares
 the version used on the page against its own optimized version. The audit

--- a/src/content/en/tools/lighthouse/audits/user-timing.md
+++ b/src/content/en/tools/lighthouse/audits/user-timing.md
@@ -31,7 +31,7 @@ Check out [User Timing API](https://www.html5rocks.com/en/tutorials/webperforman
 for an introduction on using the User Timing API to measure your app's
 JavaScript performance.
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse extracts User Timing data from Chrome's Trace Event Profiling Tool.
 

--- a/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
@@ -37,7 +37,7 @@ To find each listed element's invalid attribute names:
 [xp]: /web/tools/chrome-devtools/console/command-line-reference#xpath
 [roles]: https://www.w3.org/TR/wai-aria/roles#role_definitions
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid names][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/valid-aria-values.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-values.md
@@ -36,7 +36,7 @@ To find each listed element's invalid attribute values:
 [xp]: /web/tools/chrome-devtools/console/command-line-reference#xpath
 [states]: https://www.w3.org/TR/wai-aria/states_and_properties#state_prop_def
 
-More information {: #more-info }
+## More information {: #more-info }
 
 This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid values][axe] for more information.

--- a/src/content/en/tools/lighthouse/audits/web-sql.md
+++ b/src/content/en/tools/lighthouse/audits/web-sql.md
@@ -25,7 +25,7 @@ storage options.
 [indexeddb]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [overview]: /web/fundamentals/instant-and-offline/web-storage/
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse checks if the page has a Web SQL database instance.
 

--- a/src/content/en/tools/lighthouse/audits/webp.md
+++ b/src/content/en/tools/lighthouse/audits/webp.md
@@ -28,7 +28,7 @@ support for WebP?][fallback] for an overview of fallback techniques.
 
 [fallback]: /speed/webp/faq#how_can_i_detect_browser_support_for_webp
 
-More information {: #more-info }
+## More information {: #more-info }
 
 Lighthouse collects each JPEG and PNG image on the page, and then converts
 each to WebP. Lighthouse omits the image from its report if the potential


### PR DESCRIPTION
What's changed, or what was fixed?
- fixes formatting for the "more info" heading in each lighthouse audit

**Target Live Date:** 2017-12-12 (today)

- [ ] This has been reviewed and approved by @petele 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.

**R:** @petele
