### PR TITLE
add "manual stage" checklist item to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,6 @@ What's changed, or what was fixed?
 - [ ] This has been reviewed and approved by (NAME)
 - [ ] I have run `gulp test` locally and all tests pass.
 - [ ] I have added the appropriate `type-something` label.
+- [ ] I've staged the site and manually verified that my content displays correctly.
 
 **R:** @petele


### PR DESCRIPTION
What's changed, or what was fixed?
- adds a checklist item to this PR template in order to prevent mess-ups such as https://github.com/google/WebFundamentals/pull/5486

**Target Live Date:** 2017-12-19

- [ ] This has been reviewed and approved by @petele 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.

**R:** @petele
