### PR TITLE
Fix PR template date format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ What's changed, or what was fixed?
 
 **Fixes:** #issue
 
-**Target Live Date:** YYYY-DD-MM
+**Target Live Date:** YYYY-MM-DD
 
 - [ ] This has been reviewed and approved by (NAME)
 - [ ] I have run `gulp test` locally and all tests pass.


### PR DESCRIPTION
The `YYYY-DD-MM` format is non-standard and has probably confused a few folks; this PR updates it to the standard.
