### PR TITLE
changing update on reload recipe

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -54,7 +54,7 @@ function onNewServiceWorker(registration, callback) {
   }
 
   function listenInstalledStateChange() {
-    registration.installing.addEventListener('statechange', function() {
+    registration.installing.addEventListener('statechange', function(event) {
       if (event.target.state === 'installed') {
         // A new service worker is available, inform the user
         callback();

--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -119,7 +119,7 @@ self.addEventListener('message', (event) => {
 
   switch (event.data) {
     case 'skipWaiting':
-
+      self.skipeWaiting();
       break;
     default:
       // NOOP

--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -119,7 +119,7 @@ self.addEventListener('message', (event) => {
 
   switch (event.data) {
     case 'skipWaiting':
-      self.skipeWaiting();
+      self.skipWaiting();
       break;
     default:
       // NOOP


### PR DESCRIPTION
**Fixes:** #5504

cc @jeffposnick @dfabulich

This used controllerchange event listener instead of the messaging back and forth.

This will break update on reload in DevTools. I also noticed that controllerchange will fire as soon as skipWaiting is called (without clients claim) which suggests that the activation step is designed to happen *after* the page is controlled.