### PR TITLE
Meta changes to recent deps/rems articles.

### DIFF
--- a/src/content/en/updates/2017/09/chrome-62-deprecations.md
+++ b/src/content/en/updates/2017/09/chrome-62-deprecations.md
@@ -2,12 +2,14 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 62 to help you plan. In this version, security improvements, further webkit deprecations, and more.
 
-{# wf_updated_on: 2017-12-15 #}
+{# wf_updated_on: 2017-12-14 #}
 {# wf_published_on: 2017-09-15 #}
 {# wf_tags: deprecations,removals,chrome62 #}
 {# wf_blink_components: Blink>WebRTC>PeerConnection,Blink>PerformanceAPIs,Blink>SVG #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
 {# wf_featured_snippet: A round up of the deprecations and removals in Chrome 62 to help you plan. In this version, more restrictions on insecure origins and a change to the shadow-piercing descendant combinator. #}
+
+<<../../_deprecation-blurb.md>>
 
 # Deprecations and Removals in Chrome 62 {: .page-title }
 

--- a/src/content/en/updates/2017/10/chrome-63-deprecations.md
+++ b/src/content/en/updates/2017/10/chrome-63-deprecations.md
@@ -2,11 +2,14 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 63 to help you plan. In this version, new behavior on interface properties, removal of a webkit function, and a change to RTCRtcpMuxPolicy.
 
-{# wf_updated_on: 2017-10-23 #}
+{# wf_updated_on: 2017-12-14 #}
 {# wf_published_on: 2017-10-23 #}
 {# wf_tags: deprecations,removals,chrome63 #}
+{# wf_blink_components: Blink>Bindings,Blink>CSS,Blink>WebRTC>Network #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
 {# wf_featured_snippet: A round up of the deprecations and removals in Chrome 63 to help you plan. In this version, new behavior on interface properties, removal of a webkit function, and a change to <code>RTCRtcpMuxPolicy</code>. #}
+
+<<../../_deprecation-blurb.md>>
 
 # Deprecations and removals in Chrome 63 {: .page-title }
 
@@ -48,7 +51,7 @@ removed from Chrome in version 63. Developers who need this functionality can
 look at [this Stackoverflow post](https://stackoverflow.com/questions/2952667/find-all-css-rules-that-apply-to-an-element)
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/-_Al0I5Rm9Q/discussion) &#124;
-[Chromestatus Tracker](https://groups.google.com/a/chromium.org/d/topic/blink-dev/-_Al0I5Rm9Q/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/4606972603138048) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=437569&desc=2)
 
 ## Remove RTCRtcpMuxPolicy of "negotiate"

--- a/src/content/en/updates/2017/10/remove-shadow-piercing.md
+++ b/src/content/en/updates/2017/10/remove-shadow-piercing.md
@@ -2,12 +2,14 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Say goodbye to shadow-piercing CSS selectors.
 
-{# wf_updated_on: 2017-10-24 #}
+{# wf_updated_on: 2017-12-14 #}
 {# wf_published_on: 2017-10-24 #}
 {# wf_tags: webcomponents,shadowdom,style,css,deprecations,removals #}
 {# wf_featured_image: /web/updates/images/generic/styles.png #}
 {# wf_featured_snippet: Say goodbye to shadow-piercing CSS selectors. #}
 {# wf_blink_components: Blink>DOM #}
+
+<<../../_deprecation-blurb.md>>
 
 # Removing ::shadow and /deep/ in Chrome 63 {: .page-title }
 
@@ -56,5 +58,11 @@ try and remove any usage of `::shadow` and `/deep/`. If it's too difficult to
 remove usage of these selectors, consider switching from native shadow DOM over
 to the shady DOM polyfill. You should only need to make this change if your site
 relies on native shadow DOM v0.
+
+## More information
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/HX5Y8Ykr5Ns/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/6750456638341120) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=489954)
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2017/12/chrome-64-deprecations.md
+++ b/src/content/en/updates/2017/12/chrome-64-deprecations.md
@@ -9,6 +9,8 @@ description: A round up of the deprecations and removals in Chrome 64 to help yo
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
 {# wf_featured_snippet: A round up of the deprecations and removals in Chrome 64 to help you plan. In this version, performance API changes, removal of support for multiple shadow roots, and removal of a WebKit API. #}
 
+<<../../_deprecation-blurb.md>>
+
 # Deprecations and removals in Chrome 64 {: .page-title }
 
 {% include "web/_shared/contributors/josephmedley.html" %}
@@ -17,10 +19,6 @@ In nearly every version of Chrome, we see a significant number of updates and
 improvements to the product, its performance, and also capabilities of the Web
 Platform. This article describes some of the deprecations and removals in Chrome
 64, which is in beta as of December 14.
-
-To see all deprecations and removals for this and previous versions of Chrome,
-visit the [deprecations page](/web/updates/tags/deprecations). This list is
-subject to change at any time.
 
 ## Remove support for multiple shadow roots
 

--- a/src/content/en/updates/2017/12/chrome-loadtimes-deprecated.md
+++ b/src/content/en/updates/2017/12/chrome-loadtimes-deprecated.md
@@ -10,6 +10,8 @@ description: The non-standard chrome.loadTimes() API will be deprecated in Chrom
 {# wf_featured_snippet: The non-standard chrome.loadTimes() API will be deprecated in Chrome 64 now that standards-based equivalents exist for all of its useful features. #}
 {# wf_blink_components: Blink>PerformanceAPIs #}
 
+<<../../_deprecation-blurb.md>>
+
 # Chrome 64 to deprecate the chrome.loadTimes() API {: .page-title }
 
 {% include "web/_shared/contributors/philipwalton.html" %}

--- a/src/content/en/updates/_deprecation-blurb.md
+++ b/src/content/en/updates/_deprecation-blurb.md
@@ -1,0 +1,6 @@
+{# wf_md_include #}
+
+<aside>
+To see all deprecations and removals for this and previous versions of Chrome,
+visit the <a href='/web/updates/tags/deprecations'>deprecations page</a>.
+</aside>

--- a/src/content/en/updates/_deprecation-blurb.md
+++ b/src/content/en/updates/_deprecation-blurb.md
@@ -1,6 +1,6 @@
 {# wf_md_include #}
 
-<aside>
+<aside class="note">
 To see all deprecations and removals for this and previous versions of Chrome,
 visit the <a href='/web/updates/tags/deprecations'>deprecations page</a>.
 </aside>


### PR DESCRIPTION
Not merging today, because I'm guessing Pete will have something to say about the placement and appearance of the blurb.

What's changed, or what was fixed?
- Added a new blurb to deps/rems that links to a tag page.
- Add the blurb to recent relevant articles.
- Misc other changes to correct errors I stumbled on and create consistency.

**Target Live Date:** 2017-12-14

- [ ] This has been reviewed and approved by @petele 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
