### PR TITLE
Work around "Update on Reload" infinite loop bug

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -73,7 +73,12 @@ function onNewServiceWorker(registration, callback) {
 
 window.addEventListener('load', function() {
   // When the user asks to refresh the UI, we'll need to reload the window
+  var refreshing;
   navigator.serviceWorker.addEventListener('controllerchange', function(event) {
+    // Ensure refresh is only called once.
+    // This works around a bug in "force update on reload".
+    if (refreshing) return;
+    refreshing = true;
     console.log('Controller loaded');
     window.location.reload();
   });


### PR DESCRIPTION
When you check "Update on Reload" in Chrome Dev Tools and you configure the page to reload on every controller change, it refreshes the page in an infinite loop. We can work around this by using a variable to refresh the page only once.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
