### PR TITLE
[lighthouse] add "aspect ratio" reference

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -44,6 +44,8 @@ toc:
   path: /web/tools/lighthouse/audits/content-sized-correctly-for-viewport
 - title: Critical Request Chains
   path: /web/tools/lighthouse/audits/critical-request-chains
+- title: Displays Images With Incorrect Aspect Ratio
+  path: /web/tools/lighthouse/audits/aspect-ratio
 - title: Element aria-* Attributes Are Allowed For This Role
   path: /web/tools/lighthouse/audits/aria-allowed-attributes
 - title: Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent

--- a/src/content/en/tools/lighthouse/audits/aspect-ratio.md
+++ b/src/content/en/tools/lighthouse/audits/aspect-ratio.md
@@ -2,8 +2,8 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Displays Images With Incorrect Aspect Ratio" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-14 #}
-{# wf_published_on: 2017-12-14 #}
+{# wf_updated_on: 2018-01-03 #}
+{# wf_published_on: 2018-01-03 #}
 {# wf_blink_components: N/A #}
 
 # Displays Images With Incorrect Aspect Ratio  {: .page-title }
@@ -16,20 +16,18 @@ creating an unpleasant user experience.
 
 ## Recommendations {: #recommendations }
 
-Use `vw` for *both* the width and height of images.
-
-    img {
-      width: 20vw;
-      height: 20vw;
-    }
-
-`1vw` is equal to 1% of the width of the viewport. Adjust the width and height values based on
-the aspect ratio that you want to maintain. For example, for an image that is twice as wide as
-it is tall, you can preserve the aspect ratio by setting `width` to `20vw` and `height` to
-`10vw`. The `vw` unit is well-supported in modern browsers. See [Can I use viewport
-units?][caniuse] You could alternatively use the `vh` unit, which maps to the viewport height.
-
-[caniuse]: https://caniuse.com/#feat=viewport-units
+* Avoiding setting the width or height of an element as a percentage of a variably-sized
+  container.
+* Avoid setting explicit width or height values that differ from the source image's dimensions.
+* Consider using [css-aspect-ratio](https://www.npmjs.com/package/css-aspect-ratio) or
+  [Aspect Ratio Boxes](https://css-tricks.com/aspect-ratio-boxes/) to help preserve aspect
+  ratios.
+* When possible, it's a good practice to specify image width and height in HTML, so that the
+  browser can allocate space for the image, which prevents it from jumping around as the page
+  loads. It's more optimal to specify width and height in HTML rather than CSS, because the
+  browser allocates space before parsing the CSS. In practice this approach can be difficult
+  if you're working with responsive images, because there's no way to specify width and height
+  until you know the viewport dimensions.
 
 ### Inspecting rendered images with incorrect aspect ratios {: #inspecting }
 

--- a/src/content/en/tools/lighthouse/audits/aspect-ratio.md
+++ b/src/content/en/tools/lighthouse/audits/aspect-ratio.md
@@ -1,0 +1,48 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Displays Images With Incorrect Aspect Ratio" Lighthouse audit.
+
+{# wf_updated_on: 2017-12-14 #}
+{# wf_published_on: 2017-12-14 #}
+{# wf_blink_components: N/A #}
+
+# Displays Images With Incorrect Aspect Ratio  {: .page-title }
+
+## Overview {: #overview }
+
+If a rendered image has a significantly different aspect ratio from the aspect ratio in its
+source file (the "natural" aspect ratio), then the rendered image may look distorted, possibly
+creating an unpleasant user experience.
+
+## Recommendations {: #recommendations }
+
+Use `vw` for *both* the width and height of images.
+
+    img {
+      width: 20vw;
+      height: 20vw;
+    }
+
+`1vw` is equal to 1% of the width of the viewport. Adjust the width and height values based on
+the aspect ratio that you want to maintain. For example, for an image that is twice as wide as
+it is tall, you can preserve the aspect ratio by setting `width` to `20vw` and `height` to
+`10vw`. The `vw` unit is well-supported in modern browsers. See [Can I use viewport
+units?][caniuse] You could alternatively use the `vh` unit, which maps to the viewport height.
+
+[caniuse]: https://caniuse.com/#feat=viewport-units
+
+### Inspecting rendered images with incorrect aspect ratios {: #inspecting }
+
+Chrome DevTools can show you the CSS declarations that affect an image's aspect ratio.
+See [View only the CSS that's actually applied to an element][DevTools].
+
+[DevTools]: /web/tools/chrome-devtools/css/reference#computed
+
+## More information {: #more-info }
+
+Lighthouse flags any image that has a rendered aspect ratio which is 5 percent or more different
+than its natural ratio.
+
+[Audit source][src]{:.external}
+
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/image-aspect-ratio.js


### PR DESCRIPTION
@patrickhulce @ThisIzKp I took a stab at "recommendations" for the aspect ratio lighthouse audit, but it's probably incomplete. Suggestions?

What's changed, or what was fixed?
- adds "aspect ratio" reference

**Fixes:** N/A

**Target Live Date:** 2017-12-21

- [ ] This has been reviewed and approved by @patrickhulce  
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**R:** @petele

  