### PR TITLE
Modules workbox webpack plugin

### DIFF
--- a/src/content/en/tools/workbox/guides/_shared/generate-sw-string-schema.html
+++ b/src/content/en/tools/workbox/guides/_shared/generate-sw-string-schema.html
@@ -13,7 +13,9 @@
     <p>
       This only needs to be set if you want to precache local files matching <code>glob</code>
       patterns. It does not need to be set if you have <code>self.__precacheManifest</code> defined
-      via a file included in <code>importScripts</code>.
+      via a file included in <code>importScripts</code>. In other words, developers using the
+      <code>workbox-webpack-plugin</code> do not need to set this option unless there are additional
+      files not included in your webpack bundles that you need to precache.
     </p>
     <p>
       If you do set this, make sure to also configure <code>globPatterns</code>.
@@ -44,7 +46,9 @@ globDirectory: '.'</pre>
     <p>
       This only needs to be set if you want to precache local files matching <code>glob</code>
       patterns. It does not need to be set if you have <code>self.__precacheManifest</code> defined
-      via a file included in <code>importScripts</code>.
+      via a file included in <code>importScripts</code>. In other words, developers using the
+      <code>workbox-webpack-plugin</code> do not need to set this option unless there are additional
+      files not included in your webpack bundles that you need to precache.
     </p>
     <p>
       If you do set this, make sure to also configure <code>globDirectory</code>.
@@ -76,12 +80,14 @@ globDirectory: '.'</pre>
       those entries will be automatically precached in the generated service worker.
     </p>
     <p>
-      This is also useful when you want to let Workbox create your top-level service worker file,
-      but want to include some additional code, such as a <code>push</code> event listener.
+      If you are using the <code>workbox-webpack-plugin</code> then this option will be
+      automatically set on your behalf, configured to import both the precache manifest and the
+      Workbox runtime code. You can list additional scripts, like code to add a
+      <code>push</code> event listener, that should be imported as well.
     </p>
     <p>
       <strong>Example:</strong>
     </p>
-    <pre class="prettyprint">importScripts: ['precache-manifest.abcd1234.js']</pre>
+    <pre class="prettyprint">importScripts: ['push-listener.js']</pre>
   </td>
 </tr>

--- a/src/content/en/tools/workbox/guides/_shared/generate-sw-string-schema.html
+++ b/src/content/en/tools/workbox/guides/_shared/generate-sw-string-schema.html
@@ -11,13 +11,6 @@
       current working directory.
     </p>
     <p>
-      This only needs to be set if you want to precache local files matching <code>glob</code>
-      patterns. It does not need to be set if you have <code>self.__precacheManifest</code> defined
-      via a file included in <code>importScripts</code>. In other words, developers using the
-      <code>workbox-webpack-plugin</code> do not need to set this option unless there are additional
-      files not included in your webpack bundles that you need to precache.
-    </p>
-    <p>
       If you do set this, make sure to also configure <code>globPatterns</code>.
     </p>
     <p>
@@ -42,13 +35,6 @@ globDirectory: '.'</pre>
     <p>
       For more information, see the
       <a href="https://github.com/isaacs/node-glob#glob-primer" class="external">glob primer</a>.
-    </p>
-    <p>
-      This only needs to be set if you want to precache local files matching <code>glob</code>
-      patterns. It does not need to be set if you have <code>self.__precacheManifest</code> defined
-      via a file included in <code>importScripts</code>. In other words, developers using the
-      <code>workbox-webpack-plugin</code> do not need to set this option unless there are additional
-      files not included in your webpack bundles that you need to precache.
     </p>
     <p>
       If you do set this, make sure to also configure <code>globDirectory</code>.
@@ -80,14 +66,12 @@ globDirectory: '.'</pre>
       those entries will be automatically precached in the generated service worker.
     </p>
     <p>
-      If you are using the <code>workbox-webpack-plugin</code> then this option will be
-      automatically set on your behalf, configured to import both the precache manifest and the
-      Workbox runtime code. You can list additional scripts, like code to add a
-      <code>push</code> event listener, that should be imported as well.
+      This is also useful when you want to let Workbox create your top-level service worker file,
+      but want to include some additional code, such as a <code>push</code> event listener.
     </p>
     <p>
       <strong>Example:</strong>
     </p>
-    <pre class="prettyprint">importScripts: ['push-listener.js']</pre>
+    <pre class="prettyprint">importScripts: ['push-notifications.abcd1234.js']</pre>
   </td>
 </tr>

--- a/src/content/en/tools/workbox/guides/_shared/webpack-specific.html
+++ b/src/content/en/tools/workbox/guides/_shared/webpack-specific.html
@@ -67,6 +67,89 @@ chunks: ['chunk-name-1', 'chunk-name-2']</pre>
   </td>
 </tr>
 
+
+<tr>
+  <td>
+    <p>globDirectory</p>
+  </td>
+  <td>
+    <p>
+      <em>Optional <code>String</code>, defaulting to <code>undefined</code></em>
+    </p>
+    <p>
+      The base directory you wish to match <code>globPatterns</code> against, relative to the
+      current working directory.
+    </p>
+    <p>
+      This only needs to be set if you want to precache additional local files that are not created
+      by the webpack build process.
+    </p>
+    <p>
+      If you do set this, make sure to also configure <code>globPatterns</code>.
+    </p>
+    <p>
+      <strong>Example:</strong>
+    </p>
+    <pre class="prettyprint">// Treat all patterns as relative to the current directory:
+globDirectory: '.'</pre>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <p>globPatterns</p>
+  </td>
+  <td>
+    <p>
+      <em>Optional <code>Array</code> of <code>String</code>, defaulting to <code>[]</code></em>
+    </p>
+    <p>
+      Files matching against any of these patterns will be included in the precache manifest.
+    </p>
+    <p>
+      For more information, see the
+      <a href="https://github.com/isaacs/node-glob#glob-primer" class="external">glob primer</a>.
+    </p>
+    <p>
+      This only needs to be set if you want to precache additional local files that are not created
+      by the webpack build process.
+    </p>
+    <p>
+      If you do set this, make sure to also configure <code>globDirectory</code>.
+    </p>
+    <p>
+      <strong>Example:</strong>
+    </p>
+    <pre class="prettyprint">globPatterns: ['dist/*.{js,png,html,css}']</pre>
+  </td>
+</tr>
+
+<tr>
+  <td>
+    <p>importScripts</p>
+  </td>
+  <td>
+    <p>
+      <em>Optional <code>Array</code> of <code>String</code></em>
+    </p>
+    <p>
+      An list of JavaScript files that should be passed to
+      <a href="https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts" class="external"><code>importScripts()</code></a>
+      inside the generated service worker file.
+    </p>
+    <p>
+      By default, the generated service worker file will automatically import both the precache
+      manifest and the Workbox runtime code. You can set this option if you need to import
+      additional scripts, like code to add a <code>push</code> event listener.
+    </p>
+    <p>
+      <strong>Example:</strong>
+    </p>
+    <pre class="prettyprint">importScripts: ['push-listener.abcd1234.js']</pre>
+  </td>
+</tr>
+
+
 <tr>
   <td>
     <p>manifestFilename</p>

--- a/src/content/en/tools/workbox/modules/_index.yaml
+++ b/src/content/en/tools/workbox/modules/_index.yaml
@@ -175,8 +175,8 @@ landing_page:
           As part of your Webpack build process add Workbox and precache
           assets.
         buttons:
-        # - label: Learn more
-        #  path: ./workbox-webpack-plugin
+        - label: Learn more
+          path: ./workbox-webpack-plugin
         - label: Reference
           path: ../reference-docs/prerelease/module-workbox-webpack-plugin
 

--- a/src/content/en/tools/workbox/modules/_toc.yaml
+++ b/src/content/en/tools/workbox/modules/_toc.yaml
@@ -30,5 +30,5 @@ toc:
   path: /web/tools/workbox/modules/workbox-cli
 # - title: workbox-build
 #  path: /web/tools/workbox/modules/workbox-build
-# - title: workbox-webpack-plugin
-#  path: /web/tools/workbox/modules/workbox-webpack-plugin
+- title: workbox-webpack-plugin
+  path: /web/tools/workbox/modules/workbox-webpack-plugin

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -14,6 +14,10 @@ This is a plugin for the [webpack](https://webpack.js.org/) which generates a li
 [precache](workbox-precaching) (known as a "precache manifest") based on the assets in a webpack
 compilation.
 
+Guidance on using the plugin within the context of a larger webpack build can be found in the
+"[Progressive Web Application](https://webpack.js.org/guides/progressive-web-application/)" section
+of the webpack documentation.
+
 ## Considerations
 
 There are a few decisions to make which will determine the right configuration for your use case.

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -1,0 +1,81 @@
+project_path: /web/tools/workbox/_project.yaml
+book_path: /web/tools/workbox/_book.yaml
+description: The module guide for workbox-webpack-plugin.
+
+{# wf_updated_on: 2017-12-15 #}
+{# wf_published_on: 2017-12-15 #}
+
+# Workbox webpack Plugin  {: .page-title }
+
+## What's the Workbox webpack Plugin?
+
+This is a plugin for the [webpack](https://webpack.js.org/) which generates a list of URLs to
+[precache](workbox-precaching) (known as a "precache manifest") based on the assets in a webpack
+compilation.
+
+## Considerations
+
+There are a few decisions to make which will determine the right configuration for your use case.
+
+### Should the plugin create your service worker file?
+
+If you leave out the `swSrc` configuration option, the plugin will create a service worker file for
+you and automatically add it to the webpack asset pipeline. This is referred to as `generateSW`
+mode.
+
+{% include "web/tools/workbox/_shared/when-to-use-generate-sw.md" %}
+
+If you set `swSrc` to the path of an existing service worker file (which does not have to be
+otherwise configured as a webpack asset) then the plugin will generate a list of URLs to precache
+and add a reference to that precache manifest, along with a reference to the Workbox runtime code,
+to your file. It will otherwise leave the file as-is. This is referred to as `injectManifest` mode.
+
+{% include "web/tools/workbox/_shared/when-to-use-inject-manifest.md" %}
+
+### Do you need to cache additional, non-webpack assets?
+
+By default, the plugin will generate a precache manifest that contains URLs for all of the assets
+that come from the current webpack compilation. Any assets that webpack doesn't "know" about will
+not be picked up.
+
+If you need to precache additional assets that are managed outside of webpack, then you can
+use the `globDirectory` and `globPatterns` options to specify how to find those additional assets.
+
+If you decide to use `globDirectory` and `globPatterns`, the following applies:
+
+- The [`glob` pattern matching](https://github.com/isaacs/node-glob#glob-primer) will be performed
+against the local file system, and the directory that `globDirectory` is set to must exist at the
+time the plugin runs. This might run afoul of
+[`webpack-dev-server` configurations](https://github.com/webpack/webpack-dev-server), where an
+in-memory file system is used.
+- The options that work with `glob`-based precache manifests, like `manifestTranforms` and
+`modifyUrlPrefix`, can also be used, but they'll apply **only** to the entries that are matched via
+`glob` patterns, and not to any assets that are picked up via the webpack compilation.
+
+## Configuration
+
+Once you've determined the answers to those considerations, you can pass the appropriate
+configuration as properties of an `Object` to the plugin's constructor. For example:
+
+    // Inside of webpack.config.js:
+    const WorkboxPlugin = require('workbox-webpack-plugin');
+    
+    module.exports = {
+      // Other webpack config...
+      plugins: [
+        // Other plugins...
+        WorkboxPlugin({option: 'value'})
+      ]
+    };
+
+<table class="responsive">
+  <tbody>
+    <tr>
+      <th colspan="2">Supported Options</th>
+    </tr>
+{% include "web/tools/workbox/guides/_shared/webpack-specific.html" %}
+{% include "web/tools/workbox/guides/_shared/generate-sw-string-schema.html" %}
+{% include "web/tools/workbox/guides/_shared/common-generate-schema.html" %}
+{% include "web/tools/workbox/guides/_shared/base-schema.html" %}
+  </tbody>
+</table>

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -4,6 +4,7 @@ description: The module guide for workbox-webpack-plugin.
 
 {# wf_updated_on: 2017-12-15 #}
 {# wf_published_on: 2017-12-15 #}
+{# wf_blink_components: Blink>ServiceWorker #}
 
 # Workbox webpack Plugin  {: .page-title }
 

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -10,9 +10,9 @@ description: The module guide for workbox-webpack-plugin.
 
 ## What's the Workbox webpack Plugin?
 
-This is a plugin for the [webpack](https://webpack.js.org/) which generates a list of URLs to
-[precache](workbox-precaching) (known as a "precache manifest") based on the assets in a webpack
-compilation.
+This is a plugin for [webpack](https://webpack.js.org/) which generates a list of URLs to
+[precache](/web/tools/workbox/guides/precache-files) (known as a "precache manifest") based on the
+assets in a webpack compilation.
 
 Guidance on using the plugin within the context of a larger webpack build can be found in the
 "[Progressive Web Application](https://webpack.js.org/guides/progressive-web-application/)" section
@@ -79,7 +79,6 @@ configuration as properties of an `Object` to the plugin's constructor. For exam
       <th colspan="2">Supported Options</th>
     </tr>
 {% include "web/tools/workbox/guides/_shared/webpack-specific.html" %}
-{% include "web/tools/workbox/guides/_shared/generate-sw-string-schema.html" %}
 {% include "web/tools/workbox/guides/_shared/common-generate-schema.html" %}
 {% include "web/tools/workbox/guides/_shared/base-schema.html" %}
   </tbody>


### PR DESCRIPTION
This adds a module guide for the `workbox-webpack-plugin` to the overall Workbox docs set. This is a follow-up from #5498.

CC: @johnnyreilly for any feedback he might have, as some of the content attempts to address questions he's raised while testing out `workbox-webpack-plugin`. 

**Target Live Date:** 2017-12-XX

- [x] This has been reviewed and approved by (@gauntface)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
