### PR TITLE
Lighthouse: Update WebP audit documentation

### DIFF
--- a/src/content/en/tools/lighthouse/audits/webp.md
+++ b/src/content/en/tools/lighthouse/audits/webp.md
@@ -1,19 +1,22 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Serve Images As WebP" Lighthouse audit.
+description: Reference documentation for the "Serve Images in Next-Gen Formats" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-11 #}
+{# wf_updated_on: 2017-12-15 #}
 {# wf_published_on: 2017-06-20 #}
 {# wf_blink_components: N/A #}
 
-# Serve Images As WebP  {: .page-title }
+# Serve Images in Next-Gen Formats  {: .page-title }
 
 ## Overview {: #overview }
 
-WebP is a new image format that provides better lossy and lossless compression
-for images on the web, compared to PNG and JPEG. Encoding your images in WebP
-rather than JPEG or PNG means that they will load faster and consume less
-cellular data. See [A New Image Format For The Web](/speed/webp/) for more on
+JPEG 2000, JPEG XR, and WebP are image formats that have superior compression and quality
+characteristics compared to their older JPEG and PNG counterparts. Encoding your images
+in these formats rather than JPEG or PNG means that they will load faster and consume
+less cellular data.
+
+WebP is supported in Chrome and Opera and provides better lossy and lossless compression
+for images on the web. See [A New Image Format For The Web](/speed/webp/) for more on
 WebP.
 
 ## Recommendations {: #recommendations }
@@ -22,15 +25,24 @@ Click **View Details** to see the potential savings of encoding your page's
 images with WebP rather than JPEG or PNG. To pass this audit, encode all of
 these images in WebP.
 
-Browser support is not universal for WebP. You'll need to serve a fallback PNG
-or JPEG image when WebP is not available. See [How can I detect browser
-support for WebP?][fallback] for an overview of fallback techniques.
+Browser support is not universal for WebP, but similar savings should be available in
+most major browsers in an alternative next-gen format. You'll need to serve a fallback PNG
+or JPEG image for other browser support. See [How can I detect browser
+support for WebP?][fallback] for an overview of fallback techniques and the table below for browser support of image formats.
 
 [fallback]: /speed/webp/faq#how_can_i_detect_browser_support_for_webp
 
+| Browser | WebP | JPEG 2000 | JPEG XR | JPEG | PNG |
+| -- | :--: | :--: | :--: | -- | -- |
+| Chrome | ✓ | | | ✓ | ✓ |
+| Edge/IE | | | ✓ | ✓ | ✓ |
+| Firefox | | | | ✓ | ✓ |
+| Opera | ✓ | | | ✓ | ✓ |
+| Safari | | ✓ |  | ✓ | ✓ |
+
 ## More information {: #more-info }
 
-Lighthouse collects each JPEG and PNG image on the page, and then converts
+Lighthouse collects each BMP, JPEG, and PNG image on the page, and then converts
 each to WebP. Lighthouse omits the image from its report if the potential
 savings are less than 8KB.
 
@@ -48,7 +60,7 @@ var url = 'https://github.com/google/webfundamentals/issues/new?title=[' +
 var feedback = {
   "category": "Lighthouse",
   "choices": [
-    { 
+    {
       "button": {
         "text": "This Doc Was Helpful"
       },

--- a/src/content/en/tools/lighthouse/audits/webp.md
+++ b/src/content/en/tools/lighthouse/audits/webp.md
@@ -28,7 +28,8 @@ these images in WebP.
 Browser support is not universal for WebP, but similar savings should be available in
 most major browsers in an alternative next-gen format. You'll need to serve a fallback PNG
 or JPEG image for other browser support. See [How can I detect browser
-support for WebP?][fallback] for an overview of fallback techniques and the table below for browser support of image formats.
+support for WebP?][fallback] for an overview of fallback techniques and the table below for browser 
+support of image formats.
 
 [fallback]: /speed/webp/faq#how_can_i_detect_browser_support_for_webp
 

--- a/src/content/en/tools/lighthouse/audits/webp.md
+++ b/src/content/en/tools/lighthouse/audits/webp.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Serve Images in Next-Gen Formats" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-15 #}
+{# wf_updated_on: 2018-01-03 #}
 {# wf_published_on: 2017-06-20 #}
 {# wf_blink_components: N/A #}
 
@@ -28,18 +28,16 @@ these images in WebP.
 Browser support is not universal for WebP, but similar savings should be available in
 most major browsers in an alternative next-gen format. You'll need to serve a fallback PNG
 or JPEG image for other browser support. See [How can I detect browser
-support for WebP?][fallback] for an overview of fallback techniques and the table below for browser 
-support of image formats.
+support for WebP?][fallback] for an overview of fallback techniques and the list below for
+browser support of image formats.
 
 [fallback]: /speed/webp/faq#how_can_i_detect_browser_support_for_webp
 
-| Browser | WebP | JPEG 2000 | JPEG XR | JPEG | PNG |
-| -- | :--: | :--: | :--: | -- | -- |
-| Chrome | ✓ | | | ✓ | ✓ |
-| Edge/IE | | | ✓ | ✓ | ✓ |
-| Firefox | | | | ✓ | ✓ |
-| Opera | ✓ | | | ✓ | ✓ |
-| Safari | | ✓ |  | ✓ | ✓ |
+To see the current browser support for each next-gen format, check out the entries below:
+
+* [WebP](https://caniuse.com/#feat=webp)
+* [JPEG 2000](https://caniuse.com/#feat=jpeg2000)
+* [JPEG XR](https://caniuse.com/#feat=jpegxr)
 
 ## More information {: #more-info }
 
@@ -50,40 +48,3 @@ savings are less than 8KB.
 [Audit source][src]{:.external}
 
 [src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/byte-efficiency/uses-webp-images.js
-
-## Feedback {: #feedback }
-
-{% framebox width="auto" height="auto" enable_widgets="true" %}
-<script>
-var label = 'WebP / Helpful';
-var url = 'https://github.com/google/webfundamentals/issues/new?title=[' +
-      label + ']';
-var feedback = {
-  "category": "Lighthouse",
-  "choices": [
-    {
-      "button": {
-        "text": "This Doc Was Helpful"
-      },
-      "response": "Thanks for the feedback.",
-      "analytics": {
-        "label": label
-      }
-    },
-    {
-      "button": {
-        "text": "This Doc Was Not Helpful"
-      },
-      "response": 'Sorry to hear that. Please <a href="' + url +
-          '" target="_blank">open a GitHub issue</a> and tell us how to ' +
-          'make it better.',
-      "analytics": {
-        "label": label,
-        "value": 0
-      }
-    }
-  ]
-};
-</script>
-{% include "web/_shared/multichoice.html" %}
-{% endframebox %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Updates WebP audit documentation to be more inclusive and reference other browser next-gen formats.
- Adds a matrix of browser support for each format.

**Target Live Date:** 2017-12-15 (anytime)

- [ ] This has been reviewed and approved by (@kaycebasques)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**R:** @kaycebasques 


Questions:
- Not sure if there's a policy on browser order so just did alphabetical
- [This](http://www.useragentman.com/blog/2015/01/14/using-webp-jpeg2000-jpegxr-apng-now-with-picturefill-and-modernizr/) was a great external blog post and using all of these formats with feature detection but not sure if we have something better or want to reference how-to on other formats