### PR TITLE
[Translation zh-tw] Tools > Chrome Devtools > JavaScript 

### DIFF
--- a/src/content/zh-tw/tools/chrome-devtools/javascript/index.md
+++ b/src/content/zh-tw/tools/chrome-devtools/javascript/index.md
@@ -96,7 +96,7 @@ DevTools 讓您可以暫停執行中的代碼，並對暫停時刻的*所有*變
 
 
 
-注：這不過是 DevTools 提供的衆多斷點類型中的一種。應使用的斷點類型取決於您要調試的問題類型。
+Note: 這不過是 DevTools 提供的衆多斷點類型中的一種。應使用的斷點類型取決於您要調試的問題類型。
 
 
 [resume]: /web/tools/chrome-devtools/images/resume-script-execution.png

--- a/src/content/zh-tw/tools/chrome-devtools/javascript/index.md
+++ b/src/content/zh-tw/tools/chrome-devtools/javascript/index.md
@@ -1,0 +1,279 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:在本交互式教程中使用 Chrome DevTools 調試 JavaScript 入門。
+
+{# wf_updated_on:2017-01-04 #}
+{# wf_published_on:2017-01-04 #}
+
+<style>
+.devtools-inline {
+  max-height: 1em;
+  vertical-align: middle;
+}
+</style>
+
+<!-- TODO
+     make demo responsive
+-->
+
+# 在 Chrome DevTools 中調試 JavaScript 入門 {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+本交互式教程循序漸進地教您在 Chrome DevTools 中調試 JavaScript 的基本工作流程。
+雖然教程介紹的是如何調試一種具體問題，但您學到的一般工作流程對調試各種類型的 JavaScript 錯誤均有幫助。
+
+
+
+如果您使用 `console.log()` 來查找和修正代碼中的錯誤，可以考慮改用本教程介紹的工作流程。
+其速度快得多，也更有效。
+
+
+## 第 1 步：重現錯誤 {: #step-1 }
+
+重現錯誤始終是調試的第一步。“重現錯誤”是指找到一系列總是能導致錯誤出現的操作。
+
+您可能需要多次重現錯誤，因此要儘量避免任何多餘的步驟。
+
+
+請按照以下說明重現您要在本教程中修正的錯誤。
+
+
+1. 點擊 **Open Demo**。演示頁面在新標籤中打開。
+
+     <a href="https://googlechrome.github.io/devtools-samples/debug-js/get-started"
+       target="devtools"
+       rel="noopener noreferrer">
+       <button>Open Demo</button>
+     </a>
+
+1. 在演示頁面上，輸入 `5` 作爲 **Number 1**。
+1. 輸入 `1` 作爲 **Number 2**。
+1. 點擊 **Add Number 1 and Number 2**。
+1. 查看輸入和按鈕下方的標籤。上面顯示的是 `5 + 1 = 51`。
+
+啊嗚。這個結果是錯誤的。正確結果應爲 `6`。這就是您要修正的錯誤。
+
+
+## 第 2 步：使用斷點暫停代碼
+
+DevTools 讓您可以暫停執行中的代碼，並對暫停時刻的*所有*變量值進行檢查。
+用於暫停代碼的工具稱爲**斷點**。
+立即試一試：
+
+1. 按 <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>I</kbd> (Mac) 或 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>（Windows、Linux）在演示頁面上打開 DevTools。
+
+1. 點擊 **Sources** 標籤。
+
+<!-- TODO add a screenshot.Don't create the screenshot until demo design is
+     finished.Add it here rather than previous screenshot in case Sources
+     is hidden -->
+
+1. 點擊 **Event Listener Breakpoints** 將該部分展開。DevTools 顯示一個包含 **Animation** 和 **Clipboard** 等可展開事件類別的列表。
+
+
+
+<!-- TODO or maybe add it here -->
+
+1. 在 **Mouse** 事件類別旁，點擊 **Expand** ![Expand 圖標](/web/tools/chrome-devtools/images/expand.png){: .devtools-inline}。DevTools 顯示一個包含 **click** 等 Mouse 事件的列表，事件旁有相應的複選框。
+1. 選中 **click** 複選框。
+
+     <figure>
+       <img src="imgs/get-started-click-breakpoint.png"
+         alt="DevTools 在演示頁面上打開，Sources 面板獲得焦點，click 事件偵聽器斷點處於啓用狀態。"
+       <figcaption>
+         <b>圖 1</b>：DevTools 在演示頁面上打開，Sources 面板獲得焦點，click 事件偵聽器斷點處於啓用狀態。
+         如果 DevTools 窗口較大，則 <b>Event Listener Breakpoints</b> 窗格位於右側，而不是像屏幕截圖中那樣位於左下方。</figcaption>
+     </figure>
+
+1. 返回至演示頁面，再次點擊 **Add Number 1 and Number 2**。DevTools 暫停演示並在 **Sources** 面板中突出顯示一行代碼。
+   DevTools 突出顯示的是下面這行代碼：
+
+       `function onClick() {`
+
+當您選中 **click** 複選框時，就是在所有 `click` 事件上設置了一個基於事件的斷點。
+點擊了*任何*節點，並且該節點具有 `click` 處理程序時，DevTools 會自動暫停在該節點 `click` 處理程序的第一行。
+
+
+
+注：這不過是 DevTools 提供的衆多斷點類型中的一種。應使用的斷點類型取決於您要調試的問題類型。
+
+
+[resume]: /web/tools/chrome-devtools/images/resume-script-execution.png
+
+## 第 3 步：單步調試代碼
+
+一個常見的錯誤原因是腳本執行順序有誤。
+可以通過單步調試代碼一次一行地檢查代碼執行情況，準確找到執行順序異常之處。立即試一試：
+
+1. 在 DevTools 的 **Sources** 面板上，點擊 **Step into next function call** ![單步執行到下一個函數調用中][into]{:.devtools-inline}，一次一行地單步調試 `onClick()` 函數的執行。DevTools 突出顯示下面這行代碼：
+
+       `if (inputsAreEmpty()) {` 
+
+1. 點擊 **Step over next function call** ![單步執行時越過下一個函數調用][over]{:.devtools-inline}。
+DevTools 執行 `inputsAreEmpty()` 但不進入它。
+請注意 DevTools 是如何跳過幾行代碼的。
+   這是因爲 `inputsAreEmpty()` 求值結果爲 false，所以 `if` 語句的代碼塊未執行。
+
+
+這就是單步調試代碼的基本思路。如果您看一下 `get-started.js` 中的代碼，就能發現錯誤多半出在 `updateLabel()` 函數的某處。您可以不必單步調試每一行代碼，而是使用另一種斷點在靠近錯誤位置的地方暫停代碼。
+
+
+
+[into]: /web/tools/chrome-devtools/images/step-into.png
+[over]: /web/tools/chrome-devtools/images/step-over.png
+
+## 第 4 步：設置另一個斷點
+
+代碼行斷點是最常見的斷點類型。如果您想在執行到某一行代碼時暫停，請使用代碼行斷點。立即試一試：
+
+1. 看一下 `updateLabel()` 中的最後一行代碼，其內容類似於：
+
+       `label.textContent = addend1 + ' + ' + addend2 + ' = ' + sum;`
+
+1. 在這行代碼的左側，可以看到這行代碼的行號：
+**32**。點擊 **32**。DevTools 會在 **32** 上放置一個藍色圖標。
+這意味着這行代碼上有一個代碼行斷點。
+   DevTools 現在總是會在執行這行代碼之前暫停。
+1. 點擊 **Resume script execution** ![繼續執行腳本][resume]{:.devtools-inline}。
+腳本繼續執行，直至到達您設置了斷點的代碼行。
+1. 看一下 `updateLabel()` 中已執行的代碼行。
+
+   DevTools 打印輸出 `addend1`、`addend2` 和 `sum` 的值。
+
+`sum` 的值疑似有問題。其求值結果本應是數字，而實際結果卻是字符串。
+這可能就是造成錯誤的原因。
+
+## 第 5 步：檢查變量值
+
+另一種常見的錯誤原因是，變量或函數產生的值異常。
+許多開發者都利用 `console.log()` 來了解值隨時間變化的情況，但 `console.log()` 可能單調乏味而又效率低下，原因有兩個。
+其一，您可能需要手動編輯大量調用 `console.log()` 的代碼。
+其二，由於您不一定知曉究竟哪一個變量與錯誤有關，因此可能需要對許多變量進行記錄。
+
+
+DevTools 爲 `console.log()` 提供的其中一個替代工具是監視表達式。可以使用監視表達式來監視變量值隨時間變化的情況。顧名思義，監視表達式的監視對象不僅限於變量。您可以將任何有效的 JavaScript 表達式存儲在監視表達式中。
+立即試一試：
+
+1. 在 DevTools 的 **Sources** 面板上，點擊 **Watch**。該部分隨即展開。
+1. 點擊 **Add Expression** ![添加表達式][add]{:.devtools-inline}。
+1. 鍵入 `typeof sum`。
+1. 按 <kbd>Enter</kbd>。DevTools 顯示 `typeof sum: "string"`。冒號右側的值就是監視表達式的結果。
+
+
+     <figure>
+       <img src="imgs/get-started-watch-expression.png"
+         alt="“監視表達式”窗格。"
+       <figcaption>
+         <b>圖 1</b>：創建  <code>typeof sum</code> 監視表達式後的“監視表達式”窗格（右下方）。
+         如果 DevTools 窗口較大，則“監視表達式”窗格位於右側，<b>Event Listener Breakpoints</b> 窗格的上方。</figcaption>
+     </figure>
+
+正如猜想的那樣，`sum` 的求值結果本應是數字，而實際結果卻是字符串。
+這就是演示頁面錯誤的原因。
+
+DevTools 爲 `console.log()` 提供的另一個替代工具是 Console。可以使用 Console 對任意 JavaScript 語句求值。開發者通常利用 Console 在調試時覆蓋變量值。在您所處的情況下，Console 可幫助您測試剛發現的錯誤的潛在解決方法。
+立即試一試：
+
+1. 如果您尚未打開 Console 抽屜，請按 <kbd>Escape</kbd> 將其打開。
+它會在 DevTools 窗口底部打開。
+1. 在 Console 中，鍵入 `parseInt(addend1) + parseInt(addend2)`。
+1. 按 <kbd>Enter</kbd>。DevTools 對語句求值並打印輸出 `6`，即您預料演示頁面會產生的結果。
+
+
+     <figure>
+       <img src="imgs/get-started-console.png"
+         alt="對一個語句求值後的 Console 抽屜。"
+       <figcaption>
+         <b>圖 1</b>：對  <code>parseInt(addend1) + parseInt(addend2)</code> 求值後的 Console 抽屜。</figcaption>
+     </figure>
+
+[add]: /web/tools/chrome-devtools/javascript/imgs/add-expression.png
+
+## 第 6 步：應用修正
+
+您已找到錯誤的潛在解決方法。剩下的工作就是編輯代碼後重新運行演示頁面來測試修正效果。
+您不必離開 DevTools 就能應用修正。
+您可以直接在 DevTools UI 內編輯 JavaScript 代碼。
+立即試一試：
+
+1. 在 DevTools 的 **Sources** 面板上的代碼編輯器中，將 `var sum = addend1 + addend2` 替換爲 `var sum = parseInt(addend1) + parseInt(addend2);`。它就是您當前暫停位置上面那行代碼。
+1. 按 <kbd>Command</kbd>+<kbd>S</kbd> (Mac) 或 <kbd>Ctrl</kbd>+<kbd>S</kbd>（Windows、Linux）保存更改。代碼的背景色變爲紅色，這表示在 DevTools 內更改了腳本。
+1. 點擊 **Deactivate breakpoints** ![停用斷點][deactivate]{:.devtools-inline}。它變爲藍色，表示處於活動狀態。
+如果進行了此設置，DevTools 會忽略您已設置的任何斷點。
+1. 點擊 **Resume script execution** ![繼續執行腳本][resume]{:.devtools-inline}。
+1. 使用不同的值測試演示頁面。現在演示頁面應能正確計算求和。
+
+
+切記，此工作流程只對運行在瀏覽器中的代碼應用修正。
+它不會爲所有運行您的頁面的用戶修正代碼。
+要實現該目的，您需要修正運行在提供頁面的服務器上的代碼。
+
+
+[deactivate]: /web/tools/chrome-devtools/images/deactivate-breakpoints-button.png
+
+## 後續步驟
+
+恭喜！現在您已掌握了在 DevTools 中調試 JavaScript 的基礎知識。
+
+本教程只向您介紹了兩種設置斷點的方法。DevTools 還提供了許多其他方法，其中包括：
+
+
+* 僅在滿足您指定的條件時觸發的條件斷點。
+* 發生已捕獲或未捕獲異常時觸發的斷點。
+* 當請求的網址與您提供的子字符串匹配時觸發的 XHR 斷點。
+
+
+<a class="gc-analytics-event"
+   data-category="DevTools / Debug JS / Get Started / Next Steps / Breakpoints"
+   href="add-breakpoints" target="_blank"
+   rel="noopener noreferrer"><button>爲我演示所有斷點</button></a>
+
+有幾個代碼單步執行控件在本教程中未予說明。
+請點擊以下鏈接，瞭解有關它們的更多信息。
+
+<a class="gc-analytics-event"
+   data-category="DevTools / Debug JS / Get Started / Next Steps / Breakpoints"
+   href="step-code#stepping_in_action" target="_blank"
+   rel="noopener noreferrer"><button>我想要掌握代碼單步調試知識</button></a>
+
+## 反饋
+
+請通過回答下列問題幫助我們改進本教程。
+
+{% framebox width="auto" height="auto" %}
+
+<p>您是否已成功完成本教程？</p>
+
+<button class="gc-analytics-event"
+        data-category="DevTools / JS / Get Started"
+        data-label="Completed / Yes">支持</button>
+
+<button class="gc-analytics-event"
+        data-category="DevTools / JS / Get Started"
+        data-label="Completed / No">不支持</button>
+
+<p>本教程是否包含您在尋找的信息？</p>
+
+<button class="gc-analytics-event"
+        data-category="DevTools / JS / Get Started"
+        data-label="Relevant / Yes">支持</button>
+
+<button class="gc-analytics-event"
+        data-category="DevTools / JS / Get Started"
+        data-label="Relevant / No">不支持</button>
+
+<p>教程是否過長？</p>
+
+<button class="gc-analytics-event"
+        data-category="DevTools / JS / Get Started"
+        data-label="Too Long / Yes">支持</button>
+
+<button class="gc-analytics-event"
+        data-category="DevTools / JS / Get Started"
+        data-label="Too Long / No">不支持</button>
+
+{% endframebox %}
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/javascript/pretty-print.md
+++ b/src/content/zh-tw/tools/chrome-devtools/javascript/pretty-print.md
@@ -1,0 +1,26 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:點擊 Chrome DevTools 中的 Pretty-Print 圖標，將您的 JavaScript 轉換成更便於閱讀的形式。
+
+{# wf_updated_on:2016-02-21 #}
+{# wf_published_on:2015-04-13 #}
+
+# 美化 JavaScript 外觀 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+在 **Sources** 面板中查看腳本時，請點擊 **Pretty-Print**
+![pretty-print 圖標](imgs/prettyprint-icon.png){:.inline} 圖標，將縮減的腳本轉換成更便於人閱讀的形式。
+
+
+下面是縮減的腳本在 **Sources** 面板中可能的外觀：
+
+![縮減的腳本](imgs/pretty-print-off.jpg)
+
+下面是相同腳本在點擊 **Pretty-Print** 圖標後的外觀：
+
+![點擊 pretty print 之後縮減的腳本](imgs/pretty-print-on.jpg)
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/javascript/source-maps.md
+++ b/src/content/zh-tw/tools/chrome-devtools/javascript/source-maps.md
@@ -1,0 +1,78 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:保持您的客戶端代碼便於閱讀和調試，即使在您組合、縮減或編譯代碼後也應如此。
+
+{# wf_updated_on:2015-04-21 #}
+{# wf_published_on:2015-04-13 #}
+
+# 將預處理代碼映射到源代碼 {: .page-title }
+
+{% include "web/_shared/contributors/megginkearney.html" %}
+{% include "web/_shared/contributors/pbakaus.html" %}
+
+保持您的客戶端代碼便於閱讀和調試，即使在您組合、縮減或編譯代碼後也應如此。使用源映射將您的源代碼映射到編譯的代碼。
+
+
+### TL;DR {: .hide-from-toc }
+- 使用 Source Maps 將縮減的代碼映射到源代碼。隨後，您可以在其原始來源中閱讀和調試編譯的代碼。
+- 僅使用<a href=''/web/tools/setup/setup-preprocessors?#supported-preprocessors''>可以產生 Source Maps 的預處理器</a>。
+- 驗證您的網絡服務器可以提供 Source Maps。
+
+
+## 預處理器使用入門
+
+本文將說明如何與 DevTools Sources 面板中的 JavaScript Source Maps 交互。要初步瞭解什麼是預處理器、它們的作用以及 Source Maps 的工作方式，請轉至[設置 CSS 和 JS 預處理器](/web/tools/setup/setup-preprocessors?#debugging-and-editing-preprocessed-content)。
+
+## 使用支持的預處理器
+
+您需要使用可以創建源映射的壓縮工具。有關最常用的選項，[請參見我們的預處理器支持部分](/web/tools/setup/setup-preprocessors?#supported-preprocessors)。要詳細查看，請參見[源映射：語言、工具和其他信息](https://github.com/ryanseddon/source-map/wiki/Source-maps:-languages,-tools-and-other-info) Wiki 頁面。
+
+Source Maps 一般與下列類型的預處理器搭配使用：
+
+* 轉譯器（[Babel](https://babeljs.io/){: .external }、[Traceur](https://github.com/google/traceur-compiler/wiki/Getting-Started)）
+* 編譯器（[Closure Compiler](https://github.com/google/closure-compiler)、[TypeScript](http://www.typescriptlang.org/){: .external }、[CoffeeScript](http://coffeescript.org) 和 [Dart](https://www.dartlang.org)）
+* Minifiers ([UglifyJS](https://github.com/mishoo/UglifyJS))
+
+## DevTools Sources 面板中的 Source Maps
+
+預處理器中的 Source Maps 可以使 DevTools 加載縮減代碼與原始文件。然後，您可以使用原始文件設置斷點和瀏覽代碼。同時，Chrome 也會運行您的縮減代碼。這會讓您感覺到就像在生產環境中運行開發網站一樣。
+
+在 DevTools 中運行 Source Maps 時，您會注意到 JavaScript 不會編譯，也會看到 Source Maps 引用的所有 JavaScript 文件。這是使用源映射，不過後臺卻在實際運行編譯的代碼。任何錯誤、日誌和斷點都將映射到開發代碼，從而實現出色的調試！因此，您會感覺到就像在生產環境中運行開發網站一樣。
+
+### 在設置中啓用 Source Maps
+
+Source Maps 默認處於啓用狀態（自 Chrome 39 開始），不過，如果您想要仔細檢查或啓用它們，請先打開 DevTools，然後點擊設置配置 ![齒輪](imgs/gear.png){:.inline}。在 **Sources**下，選中 **Enable JavaScript Source Maps**。您也可以選中 **Enable CSS Source Maps**。
+
+![啓用 Source Maps](imgs/source-maps.jpg)
+
+### 使用 Source Maps 調試
+
+[調試代碼](/web/tools/chrome-devtools/debug/breakpoints/step-code) 和啓用 Source Maps 時，Source Maps 將在兩個地方顯示：
+
+1. 控制檯中（指向來源的鏈接應是原始文件，而不是生成的文件）
+2. 逐步執行代碼時（調用堆棧中的鏈接應打開原始的源文件）
+
+## @sourceURL 和 displayName
+
+雖然不是 Source Map 規範的一部分，`@sourceURL` 仍然可以讓您在處理 eval 時將開發變得更輕鬆。此幫助程序非常類似於 `//# sourceMappingURL` 屬性，並且實際上在 Source Map V3 規範中也有所提及。
+
+通過將下面的特殊註釋包含到代碼中（將進行 eval 處理），您可以命名 eval 和內嵌腳本與樣式，使其在 DevTools 中以更具邏輯的名稱顯示。
+
+`//# sourceURL=source.coffee`
+
+導航到此**[演示](http://www.thecssninja.com/demo/source_mapping/compile.html)**，然後執行以下操作：
+
+
+* 打開 DevTools 並轉至 **Sources** 面板。
+* 將一個文件名輸入“Name your code:”輸入字段。
+* 點擊 **compile** 按鈕。
+* 將出現一條提醒，以及 CoffeeScript 源的評估和。
+
+如果您展開“Sources”子面板，現在您會看到一個具有您之前輸入的自定義文件名的新文件。如果您雙擊來查看此文件，它將包含我們原始來源的已編譯 JavaScript。不過，最後一行將是 `// @sourceURL` 註釋，指示原始的源文件是什麼。處理語言抽象時，這樣可以爲調試提供很大幫助。
+
+![使用 sourceURL](imgs/coffeescript.jpg)
+
+
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/javascript/step-code.md
+++ b/src/content/zh-tw/tools/chrome-devtools/javascript/step-code.md
@@ -1,0 +1,301 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:通過每次執行一個代碼行或一個函數，您可以觀察數據和頁面中的變化，準確瞭解正在發生什麼。
+
+{# wf_updated_on: 2015-09-01 #}
+{# wf_published_on: 2015-04-13 #}
+
+# 如何單步調試代碼 {: .page-title }
+
+{% include "web/_shared/contributors/dgash.html" %}
+{% include "web/_shared/contributors/pbakaus.html" %}
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+通過每次執行一個代碼行或一個函數，您可以觀察數據和頁面中的變化，準確瞭解正在發生什麼。您還可以修改腳本使用的數據值，您甚至可以修改腳本本身。
+
+*爲什麼此變量值是 20 而不是 30？爲什麼該代碼行看上去沒什麼效果？爲什麼此標誌在應爲 false 的時候成爲 true？* 每個開發者都面臨這些問題，逐步執行代碼可瞭解問題所在。
+
+[設置斷點](add-breakpoints)後，返回此頁面，並正常地使用它，直到達到某個斷點。這將暫停頁面上的所有 JavaScript，焦點轉向“DevTools Sources”面板，並突出顯示斷點。現在，您可以有選擇性地執行代碼並逐步檢查其數據。
+
+
+### TL;DR {: .hide-from-toc }
+- 逐步執行代碼以便在問題發生之前或發生時觀察問題，並通過實時編輯測試更改。
+- 最好越過控制檯記錄，因爲記錄的數據在到達控制檯時已過時。
+- 啓用“Async call stack”功能以提高異步函數調用堆棧的可視性。
+- 將腳本設爲黑箱以使第三方代碼不出現在調用堆棧中。
+- 使用已命名的函數而不是匿名函數，以提高調用堆棧可讀性。
+
+
+## 步驟的操作
+
+所有步驟選項均通過邊欄中的可點擊圖標![斷點按鈕欄](imgs/image_7.png){:.inline}表示，但也可以通過快捷鍵觸發。下面是簡要介紹：
+
+<table>
+  <thead>
+    <tr>
+      <th data-th="Icon/Button">圖標/按鈕</th>
+      <th data-th="Action">操作</th>
+      <th data-th="Description">描述</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_8.png" alt="Resume" class="inline"></td>
+      <td data-th="Action">Resume</td>
+      <td data-th="Description">繼續執行直到下一個斷點。如果沒有遇到斷點，則繼續正常執行。</td>
+    </tr>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_9.png" alt="Long Resume" class="inline"></td>
+      <td data-th="Action">Long Resume</td>
+      <td data-th="Description">繼續執行，將斷點停用 500 毫秒。便於暫時跳過斷點，否則會持續暫停執行代碼，例如，循環內的斷點。<p><b>點擊並按住 <i>Resume</i>，直到展開以顯示操作。</b></p></td>
+    </tr>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_10.png" alt="Step Over" class="inline"></td>
+      <td data-th="Action">Step Over</td>
+      <td data-th="Description">不管下一行發生什麼都會執行，並跳轉到下一行。</td>
+    </tr>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_11.png" alt="Step Into" class="inline"></td>
+      <td data-th="Action">Step Into</td>
+      <td data-th="Description">如果下一行包含一個函數調用，<i>Step Into</i> 將跳轉並在其第一行暫停該函數。</td>
+    </tr>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_12.png" alt="Step Out" class="inline"></td>
+      <td data-th="Action">Step Out</td>
+      <td data-th="Description">函數調用後，執行當前函數剩餘部分，然後在下一個語句暫停。</td>
+    </tr>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_13.png" alt="Deactivate breakpoints" class="inline"></td>
+      <td data-th="Action">Deactivate breakpoints</td>
+      <td data-th="Description">暫時停用所有斷點。用於繼續完整執行，不會真正移除斷點。再次點擊以重新激活斷點。</td>
+    </tr>
+    <tr>
+      <td data-th="Icon/Button"><img src="imgs/image_14.png" alt="Pause on exceptions" class="inline"></td>
+      <td data-th="Action">Pause on exceptions</td>
+      <td data-th="Description">在發生異常時，自動暫停執行代碼。</td>
+    </tr>
+  </tbody>
+</table>
+
+使用 **step into** 作爲典型的“一次一行”操作，因爲它確保只有一個語句被執行，無論您進入或離開哪些函數。
+
+當您懷疑未捕獲的異常正在引發問題，但不知道異常在哪裏時，使用 [Pause on exceptions](add-breakpoints#break-on-uncaught-exception)。啓用此選項後，您可以通過點擊 **Pause On Caught Exceptions** 複選框優化它；在此情況下，僅當發生需要特別處理的異常時執行纔會暫停。
+
+## 按作用域查看屬性 {: #scope }
+
+當您暫停腳本時，**Scope** 窗格會顯示在該時刻當前已定義的所有屬性。
+
+
+在以下屏幕截圖中，此窗格用藍色突出顯示。
+
+![Sources 面板的 Scope 窗格](imgs/scope-pane.png)
+
+Scope 窗格只有在腳本暫停時纔會填充信息。頁面運行時，Scope 窗格不含任何信息。
+
+
+Scope 窗格顯示在 local、closure 和 global 級別定義的屬性。
+
+
+如果某個屬性旁有“Carat”圖標，這意味着此屬性指代一個對象。點擊“Carat”圖標可展開對象並查看其屬性。
+
+
+有時這些屬性的顯示會變暗。例如，在以下屏幕截圖中，屬性 `function Object() { [native code] }` 比 `confirm` 屬性暗淡。
+
+
+![顯示暗淡的屬性](imgs/enumerables.png)
+
+深顏色屬性可以計數。淺顏色、顯示暗淡的屬性則不可計數。
+如需瞭解詳細信息，請參閱以下 Stack Overflow 主題：[Chrome 開發者工具 Scope 面板中的顏色有何含義？](Chrome 開發者工具 Scope 面板中的顏色有何含義？)
+
+
+
+## 調用堆棧
+
+在靠近邊欄頂部的位置是 **Call Stack** 部分。在斷點處代碼暫停時，調用堆棧以倒序形式顯示將代碼帶到該斷點的執行路徑。這不但有助於瞭解執行*現在*所在位置，還有助於瞭解代碼的執行路徑，這是進行調試的一個重要因素。
+
+### 示例
+
+<img src="imgs/image_15.png" alt="Call stack" class="attempt-left">
+
+`index.html` 文件中位於第 50 行的一個初始 onclick 事件調用了位於 `dgjs.js` JavaScript 文件第 18 行的 `setone()` 函數，後者接着調用了位於同一文件第 4 行的 `setall()` 函數，執行在當前斷點處暫停。
+
+
+
+
+<div class="clearfix"></div>
+
+### 啓用異步調用堆棧
+
+啓用異步調用堆棧功能可提高執行異步函數調用的透明度。
+
+
+1. 打開 DevTools 的 **Sources** 面板。
+2. 在 **Call Stack** 窗格上，啓用 **Async** 複選框。
+
+以下視頻包含一個展示異步調用堆棧功能的簡單腳本。
+在此腳本中，第三方庫用於選擇一個 DOM 元素。
+一個名爲 `onClick` 的函數被註冊爲此元素的 `onclick` 事件處理程序。
+無論何時調用 `onClick`，它都會循序調用一個名爲 `f` 的函數，該函數通過 `debugger` 關鍵字強制腳本暫停。
+
+ 
+
+<video src="animations/async-call-stack-demo.mp4"
+       autoplay muted loop controls></video>
+
+在此視頻中，觸發了一個斷點並展開了調用堆棧。堆棧中只有一個調用：`f`。
+然後，啓用異步調用堆棧功能，腳本繼續執行，並再次觸發斷點和展開調用堆棧。此時，調用堆棧包含 `f` 之前的所有調用，包括第三方內容庫調用和 `onClick` 調用。首次調用該腳本時，調用堆棧中只有一個調用。
+第二次調用腳本時，有四個調用。簡言之，異步調用堆棧功能可提高完整的異步函數調用堆棧的可視性。
+
+
+
+### 提示：給函數命名以提高調用堆棧可讀性
+
+匿名函數使調用堆棧很難閱讀。爲函數命名以提高可讀性。
+
+
+以下兩個屏幕截圖中的代碼段功能效果相同：代碼功能並不重要，重要的是第一個屏幕截圖中的代碼使用匿名函數，而第二個屏幕截圖中的代碼使用已命名的函數。
+
+
+
+
+在第一個屏幕截圖的調用堆棧中，前兩個函數均標明 `(anonymous function)`。
+在第二個屏幕截圖中，前兩個函數已命名，從而讓您更容易瞭解程序流的大致情況。在處理大量的腳本文件（包括第三方內容庫和框架）時，您的調用堆棧爲五個或者十個調用深，在函數已命名後，理解調用堆棧流要容易得多。
+
+
+
+
+含匿名函數的調用堆棧：
+
+![包含可讀性低匿名函數的調用堆棧](imgs/anon.png)
+
+含已命名函數的調用堆棧： 
+
+![包含可讀性更高已命名函數的調用堆棧](imgs/named.png)
+
+<!-- blackbox OR disable third-party code??? -->
+
+### 將第三方代碼設置爲黑箱
+
+將腳本文件設置爲黑箱以忽略來自調用棧的第三方文件。
+
+設置爲黑箱之前：
+
+![設置爲黑箱之前的調用堆棧](imgs/before-blackbox.png)
+
+設置爲黑箱之後：
+
+![設置爲黑箱之後的調用堆棧](imgs/after-blackbox.png)
+
+如需將文件設置爲黑箱：
+
+1. 打開 DevTools Settings。
+
+   ![打開 DevTools 設置](imgs/open-settings.png)
+
+2. 在左側的導航菜單中，點擊 **Blackboxing**。
+
+   ![Chrome DevTools 中的 Blackboxing 面板](imgs/blackbox-panel.png)
+
+3. 點擊 **Add pattern**。
+
+4. 在 **Pattern** 文本字段中，輸入您想要從調用堆棧排除的文件名模式。
+DevTools 將排除與該模式匹配的任意腳本。
+ 
+
+   ![添加黑箱模式](imgs/add-pattern.png)
+
+5. 在文本字段右側的下拉菜單中，選擇 **Blackbox** 以執行腳本文件，但從調用堆棧排除調用，或選擇 **Disabled** 以阻止執行文件。
+
+
+
+6. 點擊 **Add** 保存。
+
+下次運行此頁面並觸發斷點時，DevTools 將使函數調用不出現在來自調用堆棧的已設置爲黑箱的腳本中。
+
+
+## 數據操作
+
+代碼執行暫停時，您可以觀察和修改其正在處理的數據。這對於嘗試追蹤一個看上去有錯誤值的變量或沒有如期收到的傳遞參數很關鍵。
+
+通過點擊 **Show/Hide drawer** 顯示 Console 抽屜![顯示/隱藏抽屜](imgs/image_16.png){: .inline}或按 <kbd class="kbd">ESC</kbd>.在執行步驟時打開控制檯，您現在可以：
+
+* 輸入變量的名稱以在當前函數範圍中查看其當前值
+* 輸入一個 JavaScript 分配語句以更改此值
+
+嘗試修改值，然後繼續執行以查看它如何改變您的代碼的結果，以及它是否如期運行。
+
+#### 示例
+
+<img src="imgs/image_17.png" alt="Console Drawer" class="attempt-left">
+
+我們發現參數 `dow` 的值當前爲 2，但在繼續執行前將其手動更改爲 3。
+
+
+<div class="clearfix"></div>
+
+## 實時編輯
+
+觀察並暫停執行代碼有助於您查找錯誤，而實時編輯讓您可以快速預覽更改，無需重新加載。
+
+如需實時編輯腳本，只需在執行步驟時點擊“Sources”面板的編輯器部分。在編輯器中進行所需的更改，然後按 <kbd class="kbd">Ctrl</kbd>+<kbd class="kbd">S</kbd>（或在 Mac 上按 <kbd class="kbd">Cmd</kbd>+<kbd class="kbd">S</kbd>）提交此更改。此時，整個 JS 文件將作爲補丁程序進入 VM，並且所有函數定義都將更新。 
+
+現在，您可以繼續執行；已修改的腳本將替代原始腳本執行，並且您可以觀察您的更改效果。
+
+#### 示例
+
+![實時編輯](imgs/image_18.png)
+
+我們懷疑參數 `dow` 在被傳遞到函數 `setone()` 時，在任何情況下都會增加 1，也就是說，收到的值 `dow<` 在應爲 0 時卻爲 1，在應爲 1 時卻爲 2，等等。爲了快速測試遞減的傳遞值是否確認這是一個問題，我們在函數的開頭添加第 17 行，並按 <kbd class="kbd">Ctrl</kbd> + <kbd class="kbd">S</kbd> 鍵提交併繼續。
+
+
+
+
+## 管理線程執行 {: #threads }
+
+使用 Sources 面板上的 **Threads** 窗格可暫停、進入以及檢查其他線程，例如服務工作線程或網絡工作線程。
+
+
+爲展示 Threads 窗格，此部分使用了以下演示：[網絡工作線程基本示例](http://mdn.github.io/simple-web-worker/)。
+
+
+如果您打開應用上的 DevTools，就能發現 main 腳本位於 `main.js` 中：
+
+
+![Main 腳本](imgs/main-script.png)
+
+網絡 worker 腳本位於 `worker.js` 中：
+
+![Worker 腳本](imgs/worker-script.png)
+
+Main 腳本偵聽對 **Multiply number 1** 或 **Multiply number 2** 輸入字段做出的更改。
+偵聽到更改時，main 腳本立即向網絡工作線程發送一則消息，內含這兩個需要相乘的數值。
+網絡工作線程執行完乘法運算後將結果返回給 main 腳本。
+
+
+
+假定您在 `main.js` 中設置了一個在第一個數字發生變化時觸發的斷點：
+
+
+![Main 腳本斷點](imgs/main-script-breakpoint.png)
+
+並且您還在 `worker.js` 中設置了一個在工作線程收到消息時觸發的斷點：
+
+
+![Worker 腳本斷點](imgs/worker-script-breakpoint.png)
+
+在此應用的 UI 觸發這兩個斷點時修改第一個數字。
+
+![觸發的 main 和 worker 腳本斷點](imgs/breakpoints-triggered.png)
+
+在 Threads 窗格中，藍色箭頭指示的是當前選定的線程。
+例如，在上面的屏幕截圖中，選定的是 **Main** 線程。 
+
+DevTools 所有用於單步調試代碼（繼續或暫停腳本執行、單步執行下一函數調用、進入並單步執行下一函數調用等）的控件都與該線程有關。換言之，如果您在 DevTools 顯示類似以上屏幕截圖的內容時按 **Resume script execution** 按鈕，Main 線程會繼續執行，但網絡工作線程仍將暫停。**Call Stack** 和 **Scope** 部分同樣只顯示 Main 線程的信息。
+
+
+如果您想爲網絡工作線程單步調試代碼，或查看其作用域和調用堆棧信息，只需在 Threads 窗格中點擊其標籤，使其旁邊出現藍色箭頭。以下屏幕截圖顯示的是選擇工作線程後調用堆棧和作用域信息的變化情況。同樣，如果您要按任何一個單步調試代碼按鈕（繼續執行腳本、單步執行下一函數調用等），該操作將只與工作線程有關。Main 線程不受影響。
+
+![獲得焦點的工作線程](imgs/worker-thread.png)
+
+
+{# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/chrome-devtools/javascript/watch-variables.md
+++ b/src/content/zh-tw/tools/chrome-devtools/javascript/watch-variables.md
@@ -1,0 +1,56 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description:利用 Chrome DevTools，您可以輕鬆地查看整個應用中的多個變量。
+
+{# wf_published_on:2016-02-11 #}
+{# wf_updated_on:2016-02-11 #}
+
+# 在 Sources 中觀察變量 {: .page-title }
+
+{% include "web/_shared/contributors/jonathangarbee.html" %}
+
+利用 Chrome DevTools，您可以輕鬆地查看整個應用中的多個變量。在 Sources 中觀察變量讓您可以不必使用控制檯，並將精力放在改進代碼上。
+
+
+Sources 面板讓您可以觀察應用中的變量。此功能位於調試程序邊欄的 Watch 部分。利用此功能，您無需將對象重複記錄到控制檯中。
+
+
+
+![調試程序的 Watch 部分](imgs/sources-watch-variables-location.png)
+
+## 添加變量
+
+要將變量添加至觀察列表，請使用此部分標題右側的 Add 圖標。這將打開內嵌輸入窗口，您在這裏提供要觀察的變量名稱。填好後，按 <kbd>Enter</kbd> 鍵將其添加到列表中。
+
+
+
+![添加到觀察列表按鈕](imgs/add-variable-to-watch.png)
+
+觀察窗口將顯示變量在添加時的當前值。如果變量未設置或無法找到，值將顯示爲 <samp>&lt;Not Available&gt;</samp>。
+
+
+![觀察列表中的未定義變量](imgs/undefined-variable-in-watch.png)
+
+## 更新變量
+
+應用繼續操作時，變量值會更改。觀察列表不是變量的實時視圖，除非您正在單步執行。當您使用[斷點](add-breakpoints)單步執行時，觀察值會自動更新。要手動重新檢查列表中的值，請按這一部分標題右側的 Refresh 按鈕。
+
+
+
+
+![刷新觀察變量按鈕](imgs/refresh-variables-being-watched.png)
+
+請求刷新時，將重新檢查當前應用狀態。每個觀察項目都會更新爲當前值。
+
+
+![所觀察的已更新變量](imgs/updated-variable-being-watched.png)
+
+## 移除變量
+
+爲了確保您觀察的內容儘可能少以加快工作速度，您需要從觀察列表中移除變量。可以將鼠標懸停在變量上，然後點擊右側的移除圖標。
+
+
+![將鼠標懸停在變量上以從觀察列表中移除](imgs/hover-to-delete-watched-variable.png)
+
+
+{# wf_devsite_translation #}


### PR DESCRIPTION
Chinese (Traditional) translation of:

- src/content/zh-tw/tools/chrome-devtools/javascript/index.md
- src/content/zh-tw/tools/chrome-devtools/javascript/pretty-print.md
- src/content/zh-tw/tools/chrome-devtools/javascript/source-maps.md
- src/content/zh-tw/tools/chrome-devtools/javascript/step-code.md
- src/content/zh-tw/tools/chrome-devtools/javascript/watch-variables.md

Note: All the articles are directly translated from zh-CN.