### PR TITLE
Removed https://developers.google.com/

### DIFF
--- a/src/content/en/fundamentals/media/fast-playback-with-video-preload.md
+++ b/src/content/en/fundamentals/media/fast-playback-with-video-preload.md
@@ -585,6 +585,6 @@ requests.
 [JW Player]: https://developer.jwplayer.com/
 [Video.js]: http://videojs.com/
 [Android bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=612909
-[Delivering Fast and Light Applications with Save-Data]: https://developers.google.com/web/updates/2016/02/save-data
+[Delivering Fast and Light Applications with Save-Data]: /web/updates/2016/02/save-data
 [Network Information sample]: https://googlechrome.github.io/samples/network-information/
 [in Chrome]: https://github.com/whatwg/fetch/issues/569

--- a/src/content/en/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/en/fundamentals/performance/prpl-pattern/index.md
@@ -248,5 +248,5 @@ PRPL can help deliver the minimal functional code needed to make the route your
 users land on interactive, addressing this challenge.
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push

--- a/src/content/en/fundamentals/web-components/examples/howto-checkbox.md
+++ b/src/content/en/fundamentals/web-components/examples/howto-checkbox.md
@@ -57,8 +57,8 @@ type="checkbox">` instead.
 
 [howto-github]: https://github.com/GoogleChromeLabs/howto-components
 [checkbox-pattern]: https://www.w3.org/TR/wai-aria-practices-1.1/#checkbox
-[what-aria]: https://developers.google.com/web/fundamentals/accessibility/semantics-aria/#what_can_aria_do
-[using-tabindex]: https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex
+[what-aria]: /web/fundamentals/accessibility/semantics-aria/#what_can_aria_do
+[using-tabindex]: /web/fundamentals/accessibility/focus/using-tabindex
 
 
 ## Demo {: #demo }

--- a/src/content/en/shows/lazyweb/2015/episode-5.md
+++ b/src/content/en/shows/lazyweb/2015/episode-5.md
@@ -4,6 +4,7 @@ description: Microsoft renames Spartan to Microsoft Edge, Paul Irish explains TC
 
 {# wf_updated_on: 2015-05-11 #}
 {# wf_published_on: 2015-05-11 #}
+{# wf_blink_components: N/A #}
 {# wf_youtube_id: ZY_zpMlpqLM #}
 
 # How is TCP like the 7th grade? {: .page-title }
@@ -49,7 +50,7 @@ description: Microsoft renames Spartan to Microsoft Edge, Paul Irish explains TC
 
 [http://www.webpagetest.org/video/compare.php?tests=150506_2G_ANE-r:1-c:1](http://www.webpagetest.org/video/compare.php?tests=150506_2G_ANE-r:1-c:1)
 
-[https://developers.google.com/speed/pagespeed/insights/?url=www.wired.com%2F2015%2F03%2Four-new-site%2F](/speed/pagespeed/insights/?url=www.wired.com%2F2015%2F03%2Four-new-site%2F) 
+[/speed/pagespeed/insights/?url=www.wired.com%2F2015%2F03%2Four-new-site%2F](/speed/pagespeed/insights/?url=www.wired.com%2F2015%2F03%2Four-new-site%2F) 
 
 ### CUTTING IN LINE
 

--- a/src/content/en/shows/ttt/series-1/ttt-psi.md
+++ b/src/content/en/shows/ttt/series-1/ttt-psi.md
@@ -4,6 +4,7 @@ description: A quick tip looking at Page Speed Insights and how it can improve y
 
 {# wf_updated_on: 2015-07-07 #}
 {# wf_published_on: 2015-07-07 #}
+{# wf_blink_components: N/A #}
 {# wf_youtube_id: bDUDuQy3R7Y #}
 
 # Totally Tooling Mini Tip: Page Speed Insights {: .page-title }
@@ -18,7 +19,7 @@ description: A quick tip looking at Page Speed Insights and how it can improve y
 
 A quick tip looking at Page Speed Insights and how it can improve your site's
 performance. Check it out at:
-[https://developers.google.com/speed/pagespeed/insights/](/speed/pagespeed/insights/)
+[/speed/pagespeed/insights/](/speed/pagespeed/insights/)
 
 Matt made a video on improving your page speed score last year which is worth checking out as well: https://www.youtube.com/watch?v=pNKnhBIVj4w
 

--- a/src/content/en/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/en/tools/chrome-devtools/memory-problems/index.md
@@ -4,6 +4,7 @@ description: Learn how to use Chrome and DevTools to find memory issues that aff
 
 {# wf_updated_on: 2015-08-03 #}
 {# wf_published_on: 2015-04-13 #}
+{# wf_blink_components: Blink>MemoryAllocator #}
 
 # Fix Memory Problems {: .page-title }
 
@@ -150,7 +151,7 @@ than it began (the "beginning" here being the point after the forced
 garbage collection). In the real world, if you saw this pattern of increasing
 JS heap size or node size, it would potentially mean a memory leak.
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/en/tools/chrome-devtools/security.md
+++ b/src/content/en/tools/chrome-devtools/security.md
@@ -4,6 +4,7 @@ description: Use the Security Panel to ensure that all resources on your  site a
 
 {# wf_updated_on: 2016-03-09 #}
 {# wf_published_on: 2015-12-21 #}
+{# wf_blink_components: Security #}
 
 # Understand Security Issues {: .page-title }
 
@@ -79,6 +80,6 @@ served over HTTP.
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https

--- a/src/content/en/tools/lighthouse/audits/offscreen-images.md
+++ b/src/content/en/tools/lighthouse/audits/offscreen-images.md
@@ -33,7 +33,7 @@ images only when the user has scrolled halfway down the page. See [Intersect
 all the things!][IATT] for more on this approach.
 
 [IATT]: /web/updates/2016/04/intersectionobserver#intersect_all_the_things
-[IO]: https://developers.google.com/web/updates/2016/04/intersectionobserver
+[IO]: /web/updates/2016/04/intersectionobserver
 
 If you do use an IntersectionObserver, make sure to include the
 [polyfill][polyfill], because native browser support is limited.

--- a/src/content/en/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/en/tools/lighthouse/audits/old-flexbox.md
@@ -19,7 +19,7 @@ UCBrowser. See [googlechrome/lighthouse#1710][uc].
 
 [uc]: https://github.com/GoogleChrome/lighthouse/issues/1710#issuecomment-294470505
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## Recommendations {: #recommendations }
 

--- a/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/en/tools/lighthouse/audits/passive-event-listeners.md
@@ -19,7 +19,7 @@ an overview.
 See the [Explainer][explainer] in the passive event listener specification
 for a technical deep-dive.
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## Recommendations {: #recommendations }

--- a/src/content/en/tools/workbox/overview.md
+++ b/src/content/en/tools/workbox/overview.md
@@ -4,6 +4,7 @@ description: Workbox Examples.
 
 {# wf_published_on: 2017-10-04 #}
 {# wf_updated_on: 2017-11-10 #}
+{# wf_blink_components: Blink>ServiceWorker #}
 
 # Overview {: .page-title }
 
@@ -21,7 +22,7 @@ Modern offline web apps are possible thanks to [**service workers**][sw].
 Service workers are background workers, written in JavaScript, that can
 locally store all of the resources needed to run your site offline.
 
-[sw]: https://developers.google.com/web/fundamentals/getting-started/primers/service-workers
+[sw]: /web/fundamentals/getting-started/primers/service-workers
 
 You can think of a service worker as a [proxy server][proxy] that's running in
 the background of your users' devices. Your site makes a request for a
@@ -44,7 +45,7 @@ than going to the network for the document, Workbox just serves it from the
 cache.
 
 [cache]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
-[http]: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching
+[http]: /web/fundamentals/performance/optimizing-content-efficiency/http-caching
 
 The logic for determining whether to serve a resource from the cache or to
 fetch a fresh version is called the **caching strategy** for that resource.

--- a/src/content/en/updates/2016/05/houdini.md
+++ b/src/content/en/updates/2016/05/houdini.md
@@ -4,6 +4,7 @@ description: Houdini is a collection of APIs that expose the CSS engine’s inte
 
 {# wf_updated_on: 2017-03-23 #}
 {# wf_published_on: 2016-05-19 #}
+{# wf_blink_components: N/A #}
 {# wf_tags: houdini,css #}
 {# wf_featured_image: /web/updates/images/2016/05/houdini/compworklet_small.png #}
 
@@ -401,7 +402,7 @@ If you want to get involved, there’s always the [Houdini mailing list].
 [CompWorklet Polyfill]: https://github.com/googlechrome/houdini-samples
 [Web Components]: http://webcomponents.org/
 [parallax scrolling]: https://en.wikipedia.org/wiki/Parallax_scrolling
-[CSS Custom Properties]: https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care
+[CSS Custom Properties]: /web/updates/2016/02/css-variables-why-should-you-care
 [Houdini Demo]: https://googlechrome.github.io/houdini-samples/animation-worklet/twitter-header/
 [Paint Worklet demo]: http://googlechrome.github.io/houdini-samples/paint-worklet/ripple/
 [Paint Worklet source]: https://github.com/GoogleChrome/houdini-samples/tree/master/paint-worklet/ripple

--- a/src/content/en/updates/2016/06/performance-observer.md
+++ b/src/content/en/updates/2016/06/performance-observer.md
@@ -4,6 +4,7 @@ description: New in Chrome 52, the Performance Observer interface provides more 
 
 {# wf_updated_on: 2016-06-08 #}
 {# wf_published_on: 2016-06-08 #}
+{# wf_blink_components: N/A #}
 {# wf_tags: performance,events,chrome52,javascript #}
 {# wf_featured_snippet: The W3C Performance Timeline specification defines an interface for browsers to provide programmatic access to low level timing data. This opens the door to some interesting use cases like custom performance analysis, third party tools and more. #}
 {# wf_featured_image: /web/updates/images/generic/timer.png #}
@@ -121,7 +122,7 @@ As you can see, this API is quite simple and it offers the ability to gather
 filtered, high resolution, real time performance data without polling, which
 should open the door to more efficient performance tooling for web apps.
 
-[PWAs]: https://developers.google.com/web/progressive-web-apps/
+[PWAs]: /web/progressive-web-apps/
 [spec]: http://w3c.github.io/performance-timeline/#bib-NAVIGATION-TIMING-2
 [navigation]: http://caniuse.com/#search=navigation%20timing
 [resource]: http://caniuse.com/#search=resource%20timing

--- a/src/content/en/updates/2016/07/infinite-scroller.md
+++ b/src/content/en/updates/2016/07/infinite-scroller.md
@@ -4,6 +4,7 @@ description: Infinite scrollers are a common UI pattern. Here we explore how to 
 
 {# wf_updated_on: 2017-11-07 #}
 {# wf_published_on: 2016-07-01 #}
+{# wf_blink_components: Blink>Scroll #}
 {# wf_tags: javascript,css #}
 {# wf_featured_image: /web/updates/images/2016/07/infinite-scroller/featured.png #}
 
@@ -354,9 +355,9 @@ npm or as a separate repo. The primary use is educational.
 
 [Infscroller Demo]: http://googlechromelabs.github.io/ui-element-samples/infinite-scroller/
 [Infscroller Code]: https://github.com/GoogleChromeLabs/ui-element-samples/tree/gh-pages/infinite-scroller
-[Containment]: https://developers.google.com/web/updates/2016/06/css-containment
-[IntersectionObserver]: https://developers.google.com/web/updates/2016/04/intersectionobserver
-[Compositor Worklet]: https://developers.google.com/web/updates/2016/05/houdini
+[Containment]: /web/updates/2016/06/css-containment
+[IntersectionObserver]: /web/updates/2016/04/intersectionobserver
+[Compositor Worklet]: /web/updates/2016/05/houdini
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2016/10/resizeobserver.md
+++ b/src/content/en/updates/2016/10/resizeobserver.md
@@ -6,6 +6,7 @@ description: ResizeObserver lets you know when an element has changed its size.
 {# wf_published_on: 2016-10-07 #}
 {# wf_tags: chrome54 #}
 {# wf_featured_image: /web/updates/images/generic/visibility.png #}
+{# wf_blink_components: N/A #}
 
 # ResizeObserver: It’s Like document.onresize for Elements {: .page-title }
 
@@ -168,6 +169,6 @@ you have questions.
 
 {% include "comment-widget.html" %}
 
-[MutationObserver]: https://developers.google.com/web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers
-[PerformanceObserver]: https://developers.google.com/web/updates/2016/06/performance-observer
-[IntersectionObserver]: https://developers.google.com/web/updates/2016/04/intersectionobserver
+[MutationObserver]: /web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers
+[PerformanceObserver]: /web/updates/2016/06/performance-observer
+[IntersectionObserver]: /web/updates/2016/04/intersectionobserver


### PR DESCRIPTION
What's changed, or what was fixed?
- Removed https://developers.google.com/ from URLs
- Add wf_blink_components to pass Travis-CI tests

**Fixes:** #5436

**Target Live Date:** N/A

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
