### PR TITLE
Removed https://developers.google.com/

### DIFF
--- a/src/content/es/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/es/fundamentals/performance/prpl-pattern/index.md
@@ -246,7 +246,7 @@ PRPL puede ayudar a brindar el mínimo código funcional necesario para hacer qu
 usuarios aterrizan sea interactiva, abordando este desafío.
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 

--- a/src/content/es/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/es/tools/chrome-devtools/memory-problems/index.md
@@ -150,7 +150,7 @@ comenzar (el “comienzo” en este caso es el punto después de la recolección
 forzada de elementos no usados). En el mundo real, si vieras este patrón de aumento
 del tamaño del montón JS o de los nodos, posiblemente indicaría una fuga de memoria.
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/es/tools/chrome-devtools/security.md
+++ b/src/content/es/tools/chrome-devtools/security.md
@@ -81,9 +81,9 @@ proporcionadas a través de HTTP.
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/es/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/es/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ La especificación de 2009 para Flexbox es obsoleta y es 2,3 veces más lenta
 que la última especificación. Consulta [El diseño de Flexbox no es lento][slow] para obtener más
 información.
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## Cómo aprobar la auditoría {: #how }
 

--- a/src/content/es/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/es/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ obtener información general.
 Consulta el [Explainer][explainer] de la especificación del gestor de eventos pasivos
 para obtener información técnica detallada.
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## Cómo aprobar la auditoría {: #how }

--- a/src/content/id/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/id/fundamentals/performance/prpl-pattern/index.md
@@ -247,7 +247,7 @@ PRPL dapat membantu mengirim kode fungsi minimal yang dibutuhkan untuk membuat r
 Anda mendapat pada interaktif, dengan mengatasi tantangan ini.
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 

--- a/src/content/id/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/id/tools/chrome-devtools/memory-problems/index.md
@@ -150,7 +150,7 @@ dari saat dimulai ("dimulai" disini adalah titik setelah pengumpulan sampah
 secara paksa). Dalam kondisi nyata, jika Anda melihat pola meningkatnya
 ukuran heap JS atau ukuran simpul, ini berarti ada kemungkinan kebocoran memori.
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/id/tools/chrome-devtools/security.md
+++ b/src/content/id/tools/chrome-devtools/security.md
@@ -81,9 +81,9 @@ disajikan melalui HTTP.
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/id/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/id/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ Spesifikasi flexbox lama tahun 2009 tidak digunakan lagi dan 2,3x lebih lambat
 dari spesifikasi terbaru. Lihat [Layout Flexbox Tidak Lambat][slow] untuk mengetahui
 selengkapnya.
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## Cara untuk lulus audit {: #how }
 

--- a/src/content/id/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/id/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ ringkasannya.
 Lihat [Explainer][explainer] dalam spesifikasi event listener pasif untuk
 penyelaman teknis yang lebih mendalam.
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## Cara untuk lulus audit {: #how }

--- a/src/content/it/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/it/fundamentals/performance/prpl-pattern/index.md
@@ -262,7 +262,7 @@ rendere il percorso che i tuoi utenti percorrono interattivo, affrontando
 questa sfida.
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 Translated by

--- a/src/content/ja/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/ja/fundamentals/performance/prpl-pattern/index.md
@@ -229,7 +229,7 @@ PRPL では、ユーザーが選択したルートをインタラクティブに
 
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 

--- a/src/content/ja/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/ja/tools/chrome-devtools/memory-problems/index.md
@@ -130,7 +130,7 @@ Chrome と DevTools を使用して、メモリリーク、メモリの肥大化
 JS ヒープのグラフ（青のグラフ）は単純ではありません。ベスト プラクティスを踏まえると、最初の落ち込みは実際にガベージ コレクションが強制的に行われたことを示します（ガベージ コレクションは、**ガベージ コレクションの実行**ボタンをクリックして行います）。記録が進んでいくと、JS ヒープサイズが急上昇しているのが分かります。これは不自然ではなく、想定できます。JavaScript コードでは、ボタンがクリックされるたびに DOM ノードが作成され、100 万文字から成る文字列を作成するときに多くの処理を行います。重要なのは、開始時よりも終了時の方が JS ヒープが高くなっている点です（「開始時」とはガベージ コレクションを強制的に行った直後を指します）。実際に JS ヒープサイズまたはノードサイズが増加していくパターンを見つけた場合は、メモリリークの可能性を考えます。
 
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/ja/tools/chrome-devtools/security.md
+++ b/src/content/ja/tools/chrome-devtools/security.md
@@ -79,9 +79,9 @@ description: サイト上のすべてのリソースが HTTPS で保護されて
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/ja/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/ja/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ description: Lighthouse の監査項目「サイトで古い CSS Flexbox を使�
 詳細については、[Flexbox Layout Isn't Slow][slow] をご覧ください。
 
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ##  監査に合格する方法 {: #how }
 

--- a/src/content/ja/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/ja/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ description: Lighthouse の監査項目「Passive Event Listener を使用して
 技術的な詳細については、Passive Event Listener の仕様の [Explainer][explainer] をご確認ください。
 
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ##  監査に合格する方法 {: #how }

--- a/src/content/ja/updates/2016/05/houdini.md
+++ b/src/content/ja/updates/2016/05/houdini.md
@@ -279,7 +279,7 @@ Houdini のドラフトのリストには、まだ多くの仕様があります
 [CompWorklet Polyfill]: https://github.com/googlechrome/houdini-samples
 [Web Components]: http://webcomponents.org/
 [parallax scrolling]: https://en.wikipedia.org/wiki/Parallax_scrolling
-[CSS Custom Properties]: https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care
+[CSS Custom Properties]: /web/updates/2016/02/css-variables-why-should-you-care
 [Houdini Demo]: https://googlechrome.github.io/houdini-samples/compositor-worklet/twitter-header
 [Paint Worklet demo]: http://googlechrome.github.io/houdini-samples/paint-worklet/ripple/
 [Paint Worklet source]: https://github.com/GoogleChrome/houdini-samples/tree/master/paint-worklet/ripple

--- a/src/content/ko/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/ko/fundamentals/performance/prpl-pattern/index.md
@@ -247,7 +247,7 @@ PRPL은 사용자가 상호작용할 수 있는 경로를 만드는 데 필요�
 코드를 제공하여 이러한 문제를 해결할 수 있도록 지원합니다.
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 

--- a/src/content/ko/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/ko/tools/chrome-devtools/memory-problems/index.md
@@ -150,7 +150,7 @@ Timeline 패널을 조사의 또 다른 출발점으로 사용할 수도
 가비지 수집 이후 시점). 실제로는 JS 힙 크기 또는 노드 크기가 이렇게 증가하는 패턴이
 나타나면 메모리 누수를 의미할 가능성이 있습니다.
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/ko/tools/chrome-devtools/security.md
+++ b/src/content/ko/tools/chrome-devtools/security.md
@@ -81,9 +81,9 @@ HTTP를 통해 제공된 것인지 확인할 수 있습니다.
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/ko/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/ko/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ Flexbox의 오래된 2009년 사양은 지원이 중단되었고 최신 사양�
 속도가 느립니다. 자세한 내용은 [Flexbox 레이아웃은 느리지 않습니다][slow]를
 참조하세요.
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## 감사를 통과하는 방법 {: #how }
 

--- a/src/content/ko/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/ko/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ description: '스크롤 성능 개선을 위해 패시브 이벤트 리스너를
 심층적 기술 정보는 패시브 이벤트 리스너 사양의 [Explainer][explainer]를 참조하세요.
 
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## 감사를 통과하는 방법 {: #how }

--- a/src/content/pt-br/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/pt-br/fundamentals/performance/prpl-pattern/index.md
@@ -247,7 +247,7 @@ Superando esse desafio, o PRPL pode ajudar a fornecer o código funcional mínim
 os usuários caem interativa
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 

--- a/src/content/pt-br/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/pt-br/fundamentals/performance/prpl-pattern/index.md
@@ -1,8 +1,9 @@
 project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2017-12-19 #}
 {# wf_published_on: 2016-09-28 #}
+{# wf_blink_components: Blink>Network,Blink>Loader #}
 
 # O padrão PRPL {: .page-title }
 

--- a/src/content/pt-br/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/pt-br/tools/chrome-devtools/memory-problems/index.md
@@ -150,7 +150,7 @@ do que começou (com o "início" sendo o ponto após a coleta
 de lixo forçada). No mundo real, se você perceber esse padrão de tamanho crescente
 de pilha de JS ou nó, isso poderá significar um vazamento de memória.
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/pt-br/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/pt-br/tools/chrome-devtools/memory-problems/index.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Saiba como usar o Chrome e o DevTools para encontrar problemas de memória que afetam o desempenho da página, incluindo vazamentos de memória, ocupação excessiva de memória e coletas de lixo frequentes.
 
-{# wf_updated_on: 2015-08-03 #}
+{# wf_updated_on: 2017-12-19 #}
 {# wf_published_on: 2015-04-13 #}
+{# wf_blink_components: Blink>MemoryAllocator #}
 
 # Consertar problemas de memória {: .page-title }
 

--- a/src/content/pt-br/tools/chrome-devtools/security.md
+++ b/src/content/pt-br/tools/chrome-devtools/security.md
@@ -81,9 +81,9 @@ fornecidas por HTTP.
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/pt-br/tools/chrome-devtools/security.md
+++ b/src/content/pt-br/tools/chrome-devtools/security.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Use o Security Panel para garantir que todos os recursos do seu site sejam protegidos por HTTPS.
 
-{# wf_updated_on: 2016-03-09 #}
+{# wf_updated_on: 2017-12-19 #}
 {# wf_published_on: 2015-12-21 #}
+{# wf_blink_components: Security #}
 
 # [Entendendo problemas de segurança] {: .page-title }
 

--- a/src/content/pt-br/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/pt-br/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ A especificação antiga de 2009 para o Flexbox tornou-se obsoleta e é 2,3 veze
 do que a especificação mais recente. Consulte [O layout do Flexbox não é lento][slow] para saber
 mais.
 
-[lento]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[lento]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## Como ser aprovado na auditoria {: #how }
 

--- a/src/content/pt-br/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/pt-br/tools/lighthouse/audits/old-flexbox.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Documentação de referência para a auditoria do Lighthouse “Site não usa o Flexbox CSS antigo”.
 
-{# wf_updated_on: 2016-12-05 #}
+{# wf_updated_on: 2017-12-19 #}
 {# wf_published_on: 2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # Site não usa o Flexbox CSS antigo {: .page-title }
 

--- a/src/content/pt-br/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/pt-br/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ obter uma visão geral.
 Consulte o [Explainer][explainer] na especificação do detector de evento
 para obter detalhes técnicos.
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## Como ser aprovado na auditoria {: #how }

--- a/src/content/pt-br/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/pt-br/tools/lighthouse/audits/passive-event-listeners.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Documentação de referência para a auditoria do Lighthouse “Site usa detectores de evento passivos para melhorar o desempenho de rolagem”.
 
-{# wf_updated_on: 2016-11-30 #}
+{# wf_updated_on: 2017-12-19 #}
 {# wf_published_on: 2016-11-30 #}
+{# wf_blink_components: N/A #}
 
 # Site usa detectores de evento passivos para melhorar o desempenho de rolagem {: .page-title }
 

--- a/src/content/zh-cn/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/zh-cn/fundamentals/performance/prpl-pattern/index.md
@@ -1,8 +1,9 @@
 project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2016-09-28 #}
+{# wf_updated_on: 2017-12-19 #}
 {# wf_published_on: 2016-09-28 #}
+{# wf_blink_components: Blink>Network,Blink>Loader #}
 
 # PRPL 模式 {: .page-title }
 

--- a/src/content/zh-cn/fundamentals/performance/prpl-pattern/index.md
+++ b/src/content/zh-cn/fundamentals/performance/prpl-pattern/index.md
@@ -214,7 +214,7 @@ PRPL 仅需最少的功能代码即可让用户所在的路由变得可交互，
 
 
 [HTTP/2]: /web/fundamentals/performance/http2/
-[Resource hints]: https://developers.google.com/web/updates/2016/03/link-rel-preload
+[Resource hints]: /web/updates/2016/03/link-rel-preload
 [HTTP/2 Push]: /web/fundamentals/performance/http2/#server-push
 
 

--- a/src/content/zh-cn/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/zh-cn/tools/chrome-devtools/memory-problems/index.md
@@ -131,7 +131,7 @@ Timeline 面板可以帮助您直观了解页面在一段时间内的内存使�
 JS 堆图表（蓝色图表）的显示并不直接。为了符合最佳做法，第一次下降实际上是一次强制垃圾回收（通过按 **Collect garbage** 按钮实现）。随着记录的进行，您会看到 JS 堆大小高低交错变化。这种现象是正常的并且在预料之中：每次点击按钮，JavaScript 代码都会创建 DOM 节点，在创建由 100 万个字符组成的字符串期间，代码会完成大量工作。这里的关键是，JS 堆在结束时会比开始时大（这里“开始”是指强制垃圾回收后的时间点）。在实际使用过程中，如果您看到这种 JS 堆大小或节点大小不断增大的模式，则可能存在内存泄漏。
 
 
-[recording]: https://developers.google.com/web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
+[recording]: /web/tools/chrome-devtools/profile/evaluate-performance/timeline-tool#make-a-recording
 
 [cg]: imgs/collect-garbage.png
 

--- a/src/content/zh-cn/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/zh-cn/tools/chrome-devtools/memory-problems/index.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:了解如何使用 Chrome 和 DevTools 查找影响页面性能的内存问题，包括内存泄漏、内存膨胀和频繁的垃圾回收。
 
-{# wf_updated_on:2015-08-03 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2015-04-13 #}
+{# wf_blink_components: Blink>MemoryAllocator #}
 
 # 解决内存问题 {: .page-title }
 

--- a/src/content/zh-cn/tools/chrome-devtools/security.md
+++ b/src/content/zh-cn/tools/chrome-devtools/security.md
@@ -77,9 +77,9 @@ Security 面板可以区分两种非安全页面。
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/zh-cn/tools/chrome-devtools/security.md
+++ b/src/content/zh-cn/tools/chrome-devtools/security.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:使用 Security 面板确保您的网站上的所有资源均通过 HTTPS 进行保护。
 
-{# wf_updated_on:2016-03-09 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2015-12-21 #}
+{# wf_blink_components: Security #}
 
 # 了解安全问题 {: .page-title }
 

--- a/src/content/zh-cn/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/zh-cn/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ description:“网站不使用旧版 CSS Flexbox”Lighthouse 审查的参考文
 请参阅 [Flexbox 布局并不慢][slow]了解更多信息。
 
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## 如何通过此审查{: #how }
 

--- a/src/content/zh-cn/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/zh-cn/tools/lighthouse/audits/old-flexbox.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:“网站不使用旧版 CSS Flexbox”Lighthouse 审查的参考文档。
 
-{# wf_updated_on:2016-12-05 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # 网站不使用旧版 CSS Flexbox {: .page-title }
 

--- a/src/content/zh-cn/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/zh-cn/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ description:“网站使用被动事件侦听器以提升滚动性能”Lighthou
 有关技术详细信息，请参阅被动事件侦听器规范中的[说明][explainer]。
 
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## 如何通过此审查{: #how }

--- a/src/content/zh-cn/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/zh-cn/tools/lighthouse/audits/passive-event-listeners.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:“网站使用被动事件侦听器以提升滚动性能”Lighthouse 审查的参考文档。
 
-{# wf_updated_on:2016-11-30 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2016-11-30 #}
+{# wf_blink_components: N/A #}
 
 # 网站使用被动事件侦听器以提升滚动性能 {: .page-title }
 

--- a/src/content/zh-tw/tools/chrome-devtools/security.md
+++ b/src/content/zh-tw/tools/chrome-devtools/security.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:使用 Security 面板確保您的網站上的所有資源均通過 HTTPS 進行保護。
 
-{# wf_updated_on:2016-03-09 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2015-12-21 #}
+{# wf_blink_components: Security #}
 
 # 瞭解安全問題 {: .page-title }
 

--- a/src/content/zh-tw/tools/chrome-devtools/security.md
+++ b/src/content/zh-tw/tools/chrome-devtools/security.md
@@ -77,9 +77,9 @@ Security 面板可以區分兩種非安全頁面。
 
 
 
-[mixed-content]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+[mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
-[why-https]: https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https
+[why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
 
 
 {# wf_devsite_translation #}

--- a/src/content/zh-tw/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/old-flexbox.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:“網站不使用舊版 CSS Flexbox”Lighthouse 審查的參考文檔。
 
-{# wf_updated_on:2016-12-05 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2016-12-05 #}
+{# wf_blink_components: N/A #}
 
 # 網站不使用舊版 CSS Flexbox {: .page-title }
 

--- a/src/content/zh-tw/tools/lighthouse/audits/old-flexbox.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/old-flexbox.md
@@ -13,7 +13,7 @@ description:“網站不使用舊版 CSS Flexbox”Lighthouse 審查的參考文
 請參閱 [Flexbox 佈局並不慢][slow]瞭解更多信息。
 
 
-[slow]: https://developers.google.com/web/updates/2013/10/Flexbox-layout-isn-t-slow
+[slow]: /web/updates/2013/10/Flexbox-layout-isn-t-slow
 
 ## 如何通過此審查 {: #how }
 

--- a/src/content/zh-tw/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/passive-event-listeners.md
@@ -18,7 +18,7 @@ description:“網站使用被動事件偵聽器以提升滾動性能”Lighthou
 有關技術詳細信息，請參閱被動事件偵聽器規範中的[說明][explainer]。
 
 
-[blog]: https://developers.google.com/web/updates/2016/06/passive-event-listeners
+[blog]: /web/updates/2016/06/passive-event-listeners
 [explainer]: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
 
 ## 如何通過此審查 {: #how }

--- a/src/content/zh-tw/tools/lighthouse/audits/passive-event-listeners.md
+++ b/src/content/zh-tw/tools/lighthouse/audits/passive-event-listeners.md
@@ -2,8 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description:“網站使用被動事件偵聽器以提升滾動性能”Lighthouse 審查的參考文檔。
 
-{# wf_updated_on:2016-11-30 #}
+{# wf_updated_on:2017-12-19 #}
 {# wf_published_on:2016-11-30 #}
+{# wf_blink_components: N/A #}
 
 # 網站使用被動事件偵聽器以提升滾動性能 {: .page-title }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Removed https://developers.google.com/ from URLs
- Add wf_blink_components to pass Travis-CI tests

**Fixes:** Follow  #5533 

**Target Live Date:** N/A

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
