### PR TITLE
Add warnings to old translated articles of CM API

### DIFF
--- a/src/content/ja/fundamentals/security/credential-management/index.md
+++ b/src/content/ja/fundamentals/security/credential-management/index.md
@@ -9,6 +9,8 @@ book_path: /web/fundamentals/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
 
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+
 [Credential Management API](https://www.w3.org/TR/credential-management/) は標準ベースのブラウザ API であり、複数の端末でのシームレスなログインを実現するためにサイトとブラウザ間にプログラム インターフェースを提供し、ログインフローを簡潔にします。
 
 

--- a/src/content/ja/fundamentals/security/credential-management/index.md
+++ b/src/content/ja/fundamentals/security/credential-management/index.md
@@ -9,7 +9,7 @@ book_path: /web/fundamentals/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
 
-Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](/web/updates/2017/06/credential-management-updates)ご確認ください。
 
 [Credential Management API](https://www.w3.org/TR/credential-management/) は標準ベースのブラウザ API であり、複数の端末でのシームレスなログインを実現するためにサイトとブラウザ間にプログラム インターフェースを提供し、ログインフローを簡潔にします。
 

--- a/src/content/ja/fundamentals/security/credential-management/retrieve-credentials.md
+++ b/src/content/ja/fundamentals/security/credential-management/retrieve-credentials.md
@@ -9,7 +9,7 @@ book_path: /web/fundamentals/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
 
-Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](/web/updates/2017/06/credential-management-updates)ご確認ください。
 
 ユーザーのログインを実行するには、ブラウザのパスワード マネージャーから認証情報を取得し、その情報を使用してログイン処理を行う必要があります。
 

--- a/src/content/ja/fundamentals/security/credential-management/retrieve-credentials.md
+++ b/src/content/ja/fundamentals/security/credential-management/retrieve-credentials.md
@@ -9,6 +9,8 @@ book_path: /web/fundamentals/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
 
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+
 ユーザーのログインを実行するには、ブラウザのパスワード マネージャーから認証情報を取得し、その情報を使用してログイン処理を行う必要があります。
 
 
@@ -338,7 +340,7 @@ Google Sign-In では、ID トークンが認証の証明になり、この ID �
 
 
 
-##  ログアウト{: #sign-out }
+##  ログアウト {: #sign-out }
 
 ユーザーがウェブサイトからログアウトした場合、ユーザーが次にウェブサイトにアクセスしたときに、自動的にログインしないようにする必要があります。
 自動ログオンをオフにするには、[`navigator.credentials.requireUserMediation()`](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/requireUserMediation) を呼び出します。

--- a/src/content/ja/fundamentals/security/credential-management/store-credentials.md
+++ b/src/content/ja/fundamentals/security/credential-management/store-credentials.md
@@ -9,6 +9,8 @@ book_path: /web/fundamentals/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
 
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+
 `navigator.credentials.store()` API を使用すると、ユーザーの認証情報を簡単に保存およびアップデートできます。
 
 

--- a/src/content/ja/fundamentals/security/credential-management/store-credentials.md
+++ b/src/content/ja/fundamentals/security/credential-management/store-credentials.md
@@ -9,7 +9,7 @@ book_path: /web/fundamentals/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/megginkearney.html" %}
 
-Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。[英語版](?hl=en)をご確認頂くか、変更点を[こちらから](/web/updates/2017/06/credential-management-updates)ご確認ください。
 
 `navigator.credentials.store()` API を使用すると、ユーザーの認証情報を簡単に保存およびアップデートできます。
 

--- a/src/content/ja/updates/2016/04/credential-management-api.md
+++ b/src/content/ja/updates/2016/04/credential-management-api.md
@@ -9,7 +9,7 @@ description: 洗練されたユーザ体験を提供するために、あなた�
 
 {%include "web/_shared/contributors/agektmr.html" %}
 
-Warning: 本翻訳記事公開後仕様が大幅に変更されています。変更点は[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。変更点は[こちらから](/web/updates/2017/06/credential-management-updates)ご確認ください。
 
 洗練されたユーザ体験を提供するために、ウェブサイト上でユーザ認証を手助けすることは非常に重要なことです。
 認証されたユーザは、専用のプロフィール、デバイス間やオフライン状態で処理された情報の同期など

--- a/src/content/ja/updates/2016/04/credential-management-api.md
+++ b/src/content/ja/updates/2016/04/credential-management-api.md
@@ -7,10 +7,9 @@ description: 洗練されたユーザ体験を提供するために、あなた�
 
 # Credential Management API を使ったサインインフローの効率化 {: .page-title }
 
+{%include "web/_shared/contributors/agektmr.html" %}
 
-Translated By:
-{% include "web/_shared/contributors/yoichiro.html" %}
-
+Warning: 本翻訳記事公開後仕様が大幅に変更されています。変更点は[こちらから](https://developers.google.com/web/updates/2017/06/credential-management-updates)ご確認ください。
 
 洗練されたユーザ体験を提供するために、ウェブサイト上でユーザ認証を手助けすることは非常に重要なことです。
 認証されたユーザは、専用のプロフィール、デバイス間やオフライン状態で処理された情報の同期など
@@ -362,5 +361,8 @@ mediation モードを有効にすることができます。
 * [デモ](https://credential-management-sample.appspot.com)
 * [デモのソースコード](https://github.com/GoogleChrome/credential-management-sample)
 * [コードラボ "Enabling auto sign-in with Credential Management API"](https://g.co/codelabs/cmapi)
+
+Translated By:
+{% include "web/_shared/contributors/yoichiro.html" %}
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Adds warnings that these Japanese translated articles are out of date.

**Target Live Date:** YYYY-MM-DD

- [x] This has been reviewed and approved by (myself)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
