### PR TITLE
Add addtional schema.org metadata to contributors template

### DIFF
--- a/src/templates/contributors/index.md
+++ b/src/templates/contributors/index.md
@@ -47,7 +47,7 @@ book_path: /web/resources/_book.yaml
 
 <div class="contributor-container">
   {{#each contributors}}
-  <div class="contributor" id="{{id}}" itemprop="author" itemscope itemtype="https://schema.org/Person">
+  <div class="contributor" id="{{id}}" itemprop="author" itemscope itemtype="http://schema.org/Person">
     <img class="person" itemprop="image" src="/web/images/contributors/{{photo}}.jpg" alt="{{name.given}} {{name.family}}">
     <section class="wf-byline-meta">
       <h3 itemprop="name">

--- a/src/templates/contributors/index.md
+++ b/src/templates/contributors/index.md
@@ -47,7 +47,7 @@ book_path: /web/resources/_book.yaml
 
 <div class="contributor-container">
   {{#each contributors}}
-  <div class="contributor" id="{{id}}" itemscope itemtype="http://schema.org/Person">
+  <div class="contributor" id="{{id}}" itemprop="author" itemscope itemtype="https://schema.org/Person">
     <img class="person" itemprop="image" src="/web/images/contributors/{{photo}}.jpg" alt="{{name.given}} {{name.family}}">
     <section class="wf-byline-meta">
       <h3 itemprop="name">

--- a/src/templates/contributors/index.md
+++ b/src/templates/contributors/index.md
@@ -51,7 +51,7 @@ book_path: /web/resources/_book.yaml
     <img class="person" itemprop="image" src="/web/images/contributors/{{photo}}.jpg" alt="{{name.given}} {{name.family}}">
     <section class="wf-byline-meta">
       <h3 itemprop="name">
-        {{#if homepage}}<a itemprop="url" href="{{homepage}}">{{/if~}}
+        {{#if homepage}}<a itemprop="url" href="{{homepage}}" rel="author">{{/if~}}
         <span itemprop="givenName">{{name.given}}</span> <span itemprop="familyName">{{name.family}}</span>
         {{~#if homepage}}</a>{{/if}}
       </h3>


### PR DESCRIPTION
What's changed, or what was fixed?
- adds additional metadata to contributor include.

**Target Live Date:** whenever

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
