### PR TITLE
More schema.org metadata for contributors

### DIFF
--- a/gulp-tasks/wfContributors.js
+++ b/gulp-tasks/wfContributors.js
@@ -88,14 +88,11 @@ function buildIndividualPages(contributors) {
     if (!(key in filesByAuthor)) {
       return;
     }
+    const contributor = contributors[key];
     filesByAuthor[key].sort(wfHelper.publishedComparator);
-    const name = contributors[key].name;
-    let title = 'Latest contributions from ' + name.given;
-    if (name.family) {
-      title += ' ' + name.family;
-    }
     const context = {
-      title: title,
+      id: key,
+      contributor: contributor,
       articles: filesByAuthor[key],
     };
     const dest = DEST_ARTICLE_LIST.replace('{{key}}', key);

--- a/src/templates/contributors/article-list.md
+++ b/src/templates/contributors/article-list.md
@@ -5,14 +5,50 @@ book_path: /web/resources/_book.yaml
 {# wf_updated_on: 1900-01-01 #}
 {# wf_published_on: 1900-01-01 #}
 
-# {{{ title }}} {: .page-title }
+<style>
+  .wf-icon-width {width: 32px;}
+  .wf-homepage {
+    background-color: #CFD8DC;
+    border-radius: 50%;
+    color: black;
+    height: 32px;
+    padding-top: 4px;
+    text-align: center;
+    vertical-align: top !important;
+  }
+</style>
+
+# Articles by {{{ contributor.name.given }}} {{{ contributor.name.family }}} {: .page-title }
+
+{{#if contributor.description.en}}{{contributor.description.en}}
+{{~else}}{{contributor.name.given}} is a contributor to Web<b>Fundamentals</b>{{/if}}
+
+{{#if contributor.homepage}}<a href="{{contributor.homepage}}">
+  <i class="material-icons wf-icon-width wf-homepage">http</i>
+</a>
+{{/if}}
+{{#if contributor.github}}<a href="https://github.com/{{contributor.github}}">
+  <img class="wf-icon-width" src="/site-assets/logo-github.svg">
+</a>
+{{/if}}
+{{#if contributor.twitter}}<a href="https://twitter.com/{{contributor.twitter}}">
+  <img class="wf-icon-width" src="/site-assets/logo-twitter.svg">
+</a>
+{{/if}}
+{{#if contributor.google}}<a href="https://plus.google.com/{{contributor.google}}">
+  <img class="wf-icon-width" src="/site-assets/logo-google-plus.svg">
+</a>
+{{/if}}
+
 
 {{#each articles}}
 
 ## [{{ title }}]({{url}})
 {{#if image}}
 <div class="attempt-right">
+  <a href="{{url}}">
     <img src="{{image}}">
+  </a>
 </div>
 {{/if}}
 {{{description}}}

--- a/src/templates/contributors/include.html
+++ b/src/templates/contributors/include.html
@@ -6,7 +6,7 @@
 .wf-byline .wf-byline-social {font-size: smaller;}
 </style>
 
-<section class="wf-byline" itemscope itemtype="http://schema.org/Person">
+<section class="wf-byline" itemprop="author" itemscope itemtype="http://schema.org/Person">
   <div class="attempt-left">
     <figure>
       <img itemprop="image" src="/web/images/contributors/{{photo}}.jpg" alt="{{name.given}} {{name.family}}">
@@ -16,7 +16,7 @@
     <div class="wf-byline-name">
       <strong>By</strong>
       <span itemprop="name">
-        <a href="/web/resources/contributors#{{id}}">
+        <a href="/web/resources/contributors/{{id}}">
           <span itemprop="givenName">{{name.given}}</span>
           <span itemprop="familyName">{{name.family}}</span>
         </a>


### PR DESCRIPTION
What's changed, or what was fixed?
- Adds `itemprop="author"` to include for contributors
- Changes link to actual user
- Updates listing page to include users homepage & other urls
- See #5547  

Tests
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

