### PR TITLE
`oldVersion` is not a method of UpgradeDB object

### DIFF
--- a/src/content/en/ilt/pwa/working-with-indexeddb.md
+++ b/src/content/en/ilt/pwa/working-with-indexeddb.md
@@ -547,7 +547,7 @@ Note: The browser throws an error if we try to create object stores or indexes t
 
 
 
-The UpgradeDB object gets a special `oldVersion` method that returns the version number of the database existing in the browser. We can pass this version number into a `switch` statement to execute blocks of code inside the upgrade callback based on the existing database version number. Let's look at an example:
+The UpgradeDB object has a special `oldVersion` property, which indicates the version number of the database existing in the browser. We can pass this version number into a `switch` statement to execute blocks of code inside the upgrade callback based on the existing database version number. Let's look at an example:
 
 ```
 var dbPromise = idb.open('test-db7', 2, function(upgradeDb) {

--- a/src/content/en/ilt/pwa/working-with-indexeddb.md
+++ b/src/content/en/ilt/pwa/working-with-indexeddb.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2017-12-21 #}
 {# wf_published_on: 2016-01-01 #}
 
 


### PR DESCRIPTION
What's changed, or what was fixed?

`oldVersion` is simply a property with a number value.

**R:** @petele
