### PR TITLE
Update custom fetch deprecation date

### DIFF
--- a/src/content/en/updates/2017/06/credential-management-updates.md
+++ b/src/content/en/updates/2017/06/credential-management-updates.md
@@ -151,7 +151,7 @@ You can use existing methods to deliver credential information to your server:
 <aside class="warning">
   <strong>Warning:</strong>
   Now that passwords are no longer returned in the <code>PasswordCredential</code> object,
-  the custom <code>fetch()</code> function will stop working in Chrome 62.
+  the custom <code>fetch()</code> function will stop working in Chrome 64 (expected [23 Jan 2018](https://www.chromestatus.com/features/schedule)).
   Developers <strong>must</strong> update their code.
 </aside>
 


### PR DESCRIPTION
What's changed, or what was fixed?

Custom fetch wasn't removed when we thought it was. It's now being removed in Chrome 64.

- [ ] This has been reviewed and approved by @agektmr.
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**R:** @petele
