### PR TITLE
Fix imprecision about IDBKeyRange API

### DIFF
--- a/src/content/en/ilt/pwa/working-with-indexeddb.md
+++ b/src/content/en/ilt/pwa/working-with-indexeddb.md
@@ -494,7 +494,7 @@ The `bound` method is used to specify both an upper and lower limit, and takes t
 IDBKeyRange.bound(lowerIndexKey, upperIndexKey);
 ```
 
-The range for these functions is inclusive by default, but can be specified as exclusive by passing `false` in the second argument (or the third in the case of `bound`). An inclusive range includes the data at the limits of the range. An exclusive range does not.
+The range for these functions is inclusive by default, but can be specified as exclusive by passing `true` as the second argument (or the third and fourth in the case of `bound`, for the lower and upper limits respectively). An inclusive range includes the data at the limits of the range. An exclusive range does not.
 
 Let's look at an example. For this demo, we have created an index on the "price" property in the "store" object store. We have also added a small form with two inputs for the upper and lower limits of the range. Imagine we are passing in the lower and upper bounds to the function as floating point numbers representing prices:
 


### PR DESCRIPTION
To specify exclusion we need to pass `true` as the second argument,
since that argument indicates whether the bound is open, and defaults to `false`.
Also, `IDBKeyRange.bound` takes 4 arguments, not 3, since we need to
specify both whether the lower bound is open and whether the upper bound
is open.

**R:** @petele
