### PR TITLE
Nit: got rid of stray 'is'

### DIFF
--- a/src/content/en/updates/2017/12/disabling-hardware-noise-suppression.md
+++ b/src/content/en/updates/2017/12/disabling-hardware-noise-suppression.md
@@ -16,8 +16,8 @@ description: Experimentally disabling hardware noise suppression in Chrome 64.
 In Chrome 64 we're trying a new behavior for getUserMedia audio streams that
 have the `echoCancellation` constraint enabled. What's new is that such streams
 will temporarily disable hardware noise suppression for the duration of the
-stream. We anticipate this will make the echo canceller perform better. As this
-is functionality is experimental, it needs to be explicitly turned on; [see
+stream. We anticipate this will make the echo canceller perform better. As this 
+functionality is experimental, it needs to be explicitly turned on; [see
 below](#heading-experiment).
 
 At this point, this behavior is only supported for certain input devices and


### PR DESCRIPTION
What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
