### PR TITLE
Redirect from hacked/docs to hacked

### DIFF
--- a/src/content/en/fundamentals/security/_redirects.yaml
+++ b/src/content/en/fundamentals/security/_redirects.yaml
@@ -8,3 +8,6 @@ redirects:
 
 - from: /web/fundamentals/security/prevent-mixed-content/
   to: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
+
+- from: /web/fundamentals/security/hacked/docs/...
+  to: /web/fundamentals/security/hacked/...


### PR DESCRIPTION
What's changed, or what was fixed?
-Adds redirect from /web/fundamentals/security/hacked/docs/... to hacked/

**Target Live Date:** 2017-12-22

- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
