### PR TITLE
[lighthouse] add "keep server response times low" reference

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -3,9 +3,7 @@ toc:
   path: /web/tools/lighthouse/
 - title: Scoring Guide
   path: /web/tools/lighthouse/scoring
-
 - heading: Audit Reference
-
 - title: Address Bar Matches Brand Colors
   path: /web/tools/lighthouse/audits/address-bar
 - title: Avoids Application Cache
@@ -70,6 +68,8 @@ toc:
   path: /web/tools/lighthouse/audits/has-viewport-meta-tag
 - title: Includes Front-End JavaScript Libraries With Known Security Vulnerabilities
   path: /web/tools/lighthouse/audits/vulnerabilities
+- title: Keep Server Response Times Low
+  path: /web/tools/lighthouse/audits/ttfb
 - title: Manifest Contains Icons at Least 192px
   path:  /web/tools/lighthouse/audits/manifest-contains-192px-icon
 - title: Manifest Contains background_color

--- a/src/content/en/tools/lighthouse/audits/ttfb.md
+++ b/src/content/en/tools/lighthouse/audits/ttfb.md
@@ -38,6 +38,9 @@ to improve:
 
 ## More information {: #more-info }
 
+This audit fails when the browser waits more than 600ms for the server to respond to the
+main document request.
+
 This audit is also referred to as "Time To First Byte", which represents the time that it takes
 for a user's browser to receive the first byte of page content.
 

--- a/src/content/en/tools/lighthouse/audits/ttfb.md
+++ b/src/content/en/tools/lighthouse/audits/ttfb.md
@@ -1,0 +1,46 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Keep Server Response Times Low" Lighthouse audit.
+
+{# wf_updated_on: 2017-12-22 #}
+{# wf_published_on: 2017-12-22 #}
+{# wf_blink_components: N/A #}
+
+# Keep Server Response Times Low  {: .page-title }
+
+## Overview {: #overview }
+
+Users dislike when pages take a long time to load. Slow server response times are one possible
+cause for long page loads.
+
+When users navigate to a URL in their web browser, the browser makes a network request to
+fetch that content. Your server receives the request and returns the page content. The server
+may need to do a lot of work in order to return a page with all of the content that users
+want. For example, if users are looking at their order history, the server needs
+to fetch each user's history from a database, and then insert that content into the page.
+Optimizing the server to do work like this as quickly as possible is one way to reduce the time
+that users spend waiting for pages to load.
+
+## Recommendations {: #recommendations }
+
+The first step to improving server response times is to identify the core conceptual tasks
+that your server must complete in order to return page content, and then measure how long each
+of these tasks takes. Once you've identified the longest tasks, search for ways to speed them
+up.
+
+There are many possible causes of slow server responses, and therefore many possible ways
+to improve:
+
+* Optimize the server's application logic to prepare pages faster. If you use a server
+  framework, the framework may have recommendations on how to do this.
+* Optimize how your server queries databases, or migrate to faster database systems.
+* Upgrade your server hardware to have more memory or CPU.
+
+## More information {: #more-info }
+
+This audit is also referred to as "Time To First Byte", which represents the time that it takes
+for a user's browser to receive the first byte of page content.
+
+[Audit source][src]{:.external}
+
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/time-to-first-byte.js

--- a/src/content/en/tools/lighthouse/audits/ttfb.md
+++ b/src/content/en/tools/lighthouse/audits/ttfb.md
@@ -2,8 +2,8 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Keep Server Response Times Low" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-22 #}
-{# wf_published_on: 2017-12-22 #}
+{# wf_updated_on: 2018-01-03 #}
+{# wf_published_on: 2018-01-03 #}
 {# wf_blink_components: N/A #}
 
 # Keep Server Response Times Low  {: .page-title }


### PR DESCRIPTION
What's changed, or what was fixed?
- see title

**Fixes:** N/A

**Target Live Date:** 2017-12-31

- [x] This has been reviewed and approved by @patrickhulce 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.