### PR TITLE
PaymentRequest: update link to Google Payment API payment method doc

### DIFF
--- a/src/content/en/fundamentals/payments/_toc.yaml
+++ b/src/content/en/fundamentals/payments/_toc.yaml
@@ -8,5 +8,5 @@ toc:
   - title: Payment Request UX considerations
     path: /web/fundamentals/payments/payment-request-ux-considerations
   - title: Set up Google Payment API
-    path: /payments/mobile-web-setup
+    path: /payments/web/paymentrequest/tutorial
     status: external

--- a/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
@@ -174,9 +174,8 @@ If the user has no cards set up they'll be prompted to add details, otherwise
 an existing card will be selected for them.
 
 Note: To get access to all forms of payment available with Google, developers
-will need to implement the Pay with Google method. Refer to [Payment Method:
-Multiple Payment Methods](#payment_method_multiple_payment_methods) section then
-the [Google Payment API](/payments/) docs for more information.
+will need to implement the Pay with Google method. Refer to the
+[Google Payment API](/payments/web/paymentrequest/tutorial) docs for more information.
 
 <div class="attempt-center">
   <figure>
@@ -344,7 +343,7 @@ const payWithGooglePaymentMethod = {
 </div>
 
 We won't go into details of how to add Pay with Google in this article, [we have
-a dedicated document to that](/payments/mobile-web-setup).
+a dedicated document to that](/payments/web/paymentrequest/tutorial).
 
 
 #### Edge Cases
@@ -504,7 +503,7 @@ items. You should use this for high level entries instead of an itemized list,
 for example subtotal, discount, tax and shipping cost.
 
 <div class="warning">
-It's worth repeating that the the <code>PaymentRequest</code> API does not perform any
+It's worth repeating that the <code>PaymentRequest</code> API does not perform any
 arithmetic. If you look at the above example, all the items values do not add up
 to the total. This is because we've set the total to have a value of zero.
 <strong>It is the responsibility of your web app to calculate the correct total.</strong>

--- a/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
@@ -3,7 +3,8 @@ book_path: /web/fundamentals/_book.yaml
 description: How to implement and take full advantage of the Payment Request API.
 
 {# wf_published_on: 2017-04-21 #}
-{# wf_updated_on: 2017-11-07 #}
+{# wf_updated_on: 2017-12-27 #}
+{# wf_blink_components: Blink>Payments #}
 
 # Deep Dive into the Payment Request API {: .page-title }
 

--- a/src/content/en/fundamentals/payments/index.md
+++ b/src/content/en/fundamentals/payments/index.md
@@ -3,7 +3,8 @@ book_path: /web/fundamentals/_book.yaml
 description: Payment Request API is for fast, easy payments on the web.
 
 {# wf_published_on: 2016-07-25 #}
-{# wf_updated_on: 2017-11-07 #}
+{# wf_updated_on: 2017-12-27 #}
+{# wf_blink_components: Blink>Payments #}
 
 # Introducing the Payment Request API {: .page-title }
 

--- a/src/content/en/fundamentals/payments/index.md
+++ b/src/content/en/fundamentals/payments/index.md
@@ -91,7 +91,7 @@ the site.
 
 Note: Pay with Google is one of payment methods you can use to get cards from a
 user's Google account and payment tokens on the device. To learn more, read [the
-Google Payment API docs](/payments/mobile-web-setup).
+Google Payment API docs](/payments/web/paymentrequest/tutorial).
 
 <div class="attempt-right">
   <figure>


### PR DESCRIPTION
[Google Payment API documentation related to PaymentRequest](https://developers.google.com/payments/web/paymentrequest/tutorial) has moved. Update PaymentRequest documentation referencing the previous `google.com/pay` payment method docs to new path containing a tutorial for sites implementing Google Payment API as one of multiple payment methods.

**CC:** @agektmr 