### PR TITLE
srcElement doesn't work in firefox

### DIFF
--- a/gae/scripts/devsite.js
+++ b/gae/scripts/devsite.js
@@ -38,7 +38,7 @@
 
   /* Expand/Collapses the Primary Left Hand Nav */
   function toggleNav(event) {
-    var srcElement = event.srcElement;
+    var srcElement = event.srcElement || event.target;
     var srcParent = srcElement.parentElement;
     // Ensure's we're in the outer most <span>
     if (srcElement.localName === 'span' && srcParent.localName === 'span') {


### PR DESCRIPTION
Toggling doesn't work in Firefox because the `srcElement` doesn't exist on the event. Falling back to target fixes this.

cc @petele 