### PR TITLE
Add test for illegal chars in filesnames

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1241,6 +1241,14 @@ function testFile(filename, opts) {
     let testPromise;
     let filenameObj = path.parse(filename.toLowerCase());
 
+    // Check the filename for illegal characters
+    if (filename.indexOf(' ') >= 0 ||
+        filename.indexOf('%') >= 0 ||
+        filename.indexOf('?') >= 0) {
+          msg = 'Illegal character(s) in filename.';
+          logError(filename, null, msg);
+    }
+
     // Check if the file is an extension we skip
     if (EXTENSIONS_TO_SKIP.indexOf(filenameObj.ext) >= 0) {
       if (global.WF.options.verbose) {

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1244,6 +1244,10 @@ function testFile(filename, opts) {
     // Check the filename for illegal characters
     if (filename.indexOf(' ') >= 0 ||
         filename.indexOf('%') >= 0 ||
+        filename.indexOf('(') >= 0 ||
+        filename.indexOf(')') >= 0 ||
+        filename.indexOf('[') >= 0 ||
+        filename.indexOf(']') >= 0 ||
         filename.indexOf('?') >= 0) {
           msg = 'Illegal character(s) in filename.';
           logError(filename, null, msg);


### PR DESCRIPTION
What's changed, or what was fixed?
- Adds tests for spaces and other illegal characters in filenames

**Fixes:** Deployment blocker in #5370 (space in filename)

**Target Live Date:** 2018-01-03

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele, @addyosmani 
