### PR TITLE
Makes all reference-docs have page classes loaded in yaml

### DIFF
--- a/src/content/en/tools/workbox/next/_reference-docs.yaml
+++ b/src/content/en/tools/workbox/next/_reference-docs.yaml
@@ -35,4 +35,6 @@ toc:
 
 - heading: Reference
 - title: "View Full API"
-  path: /web/tools/workbox/reference-docs/prerelease/index-all
+  style: accordion
+  section:
+  - include: /web/tools/workbox/reference-docs/prerelease/_toc.yaml


### PR DESCRIPTION
This includes the jsdoc templates toc.yaml file which means *all* pages created by jsdocs will be loaded.

This means pages like the following will still show the header and menu: https://developers.google.com/web/tools/workbox/reference-docs/prerelease/workbox.precaching.PrecacheController
  