### PR TITLE
Fix bugs in tests for translated files

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -47,7 +47,7 @@ const REMARK_WARNING_ONLY = [
 ];
 const RE_BOM = /^\uFEFF/;
 const RE_SRC_BASE = /src\/content\//;
-const RE_SRC_TRANSLATED_PATH = /^src\/content\/(?!en)..\/.*/;
+const RE_SRC_TRANSLATED_PATH = /^src\/content\/(?!en)\w\w(-\w\w)?\/.*/;
 const RE_DATA_BASE = /src\/data\//;
 const RE_GULP_BASE = /^gulp-tasks\/?/;
 const ESLINT_RC_FILE = '.eslintrc';

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -687,11 +687,21 @@ function testMarkdown(filename, contents, options) {
     matched = wfRegEx.getMatches(wfRegEx.RE_INCLUDE_MD, contents);
     matched.forEach(function(match) {
       let inclFile = path.resolve(path.parse(filename).dir, match[1]);
-      if (doesFileExist(inclFile) !== true) {
-        position = {line: getLineNumber(contents, match.index)};
-        msg = `Markdown include ${match[0]} found, but couldn't find file.`;
-        logError(filename, position, msg);
+      if (doesFileExist(inclFile)) {
+        return;
       }
+      if (isTranslation) {
+        // Check to see if there's an EN version of the include file
+        let enFilename = filename.replace(/src\/content\/.*?\/(.*)/, '$1');
+        enFilename = `src/content/en/${enFilename}`;
+        inclFile = path.resolve(path.parse(enFilename).dir, match[1]);
+        if (doesFileExist(inclFile)) {
+          return;
+        }
+      }
+      position = {line: getLineNumber(contents, match.index)};
+      msg = `Markdown include ${match[0]} found, but couldn't find file.`;
+      logError(filename, position, msg);
     });
 
     // Error on single line comments


### PR DESCRIPTION
What's changed, or what was fixed?
- RegEx used to detect if the file path was under a translation missed xx-xx style langugages
- If an include file isn't available in a localized version, check if the EN version exists

**Fixes:** #5590 

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

  