### PR TITLE
Removes rendundant code

### DIFF
--- a/src/content/en/tools/workbox/guides/common-recipes.md
+++ b/src/content/en/tools/workbox/guides/common-recipes.md
@@ -142,9 +142,6 @@ workbox.routing.registerRoute(
             maxEntries: 50,
             maxAgeSeconds: 5 * 60, // 5 minutes
           }),
-          new workbox.cacheableResponse.Plugin({
-            statuses: [0, 200],
-          }),
         ],
     }),
 );


### PR DESCRIPTION
Fixes: https://github.com/GoogleChrome/workbox/issues/1152

@DavidScales pointed out that network first allows opaque responses so there was no need for the the cacheable response plugin.