### PR TITLE
Allows {% include %} to start midline

### DIFF
--- a/gulp-tasks/wfRegEx.js
+++ b/gulp-tasks/wfRegEx.js
@@ -36,9 +36,9 @@ const RE_PODCAST_DURATION = /^{#\s?wf_podcast_duration: (.*?)\s?#}\s?\n/m;
 const RE_PODCAST_SUBTITLE = /^{#\s?wf_podcast_subtitle: (.*?)\s?#}\s?\n/m;
 const RE_PODCAST_SIZE = /^{#\s?wf_podcast_fileSize: (.*?)\s?#}\s?\n/m;
 
-const RE_INCLUDE_MD = /^<<(.*?)>>/gm;
+const RE_INCLUDE_MD = /<<(.*?)>>/gm;
 const RE_INCLUDE_FILE = /["|'](.*)["|']/;
-const RE_INCLUDES = /^{%\s?include (["|']?)(.+?)(["|']?)\s?%}/gm;
+const RE_INCLUDES = /{%\s?include (["|']?)(.+?)(["|']?)\s?%}/gm;
 
 const RE_INCLUDE_CODE = /{% includecode .*?%}/gm;
 const RE_INCLUDE_CODE_PATH = /content_path=["']?(.*?)["' ]/;

--- a/src/content/zh-tw/tools/workbox/overview.md
+++ b/src/content/zh-tw/tools/workbox/overview.md
@@ -1,5 +1,5 @@
-project_path: /web/tools/_project.yaml 
-book_path: /web/tools/_book.yaml 
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
 description: Workbox的例子。
 
 {# wf_published_on: 2017-10-04 #}
@@ -88,4 +88,4 @@ workbox.precache([
 
 還是不明白什麼是Workbox? 我們希望能聽到您的意見。請在[此文檔的repo開啟新的issue](https://github.com/GoogleChrome/workbox-microsite/issues/new?title=%5BOverview%5D)並告訴我們您的意見。
 
-Translated by {% include "web/_shared/contributors/henrylim.html %}
+Translated by {% include "web/_shared/contributors/henrylim.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- `{% include %}` tags started mid-line weren't tested, this fixes that
- Update one file that was badly quoted and not caught earlier.
