### PR TITLE
[devtools] add vid to "debugging js" tutorial

### DIFF
--- a/src/content/en/tools/chrome-devtools/javascript/index.md
+++ b/src/content/en/tools/chrome-devtools/javascript/index.md
@@ -3,7 +3,7 @@ book_path: /web/tools/_book.yaml
 description: Learn how to use Chrome DevTools to find and fix JavaScript bugs.
 
 {# wf_blink_components: Platform>DevTools #}
-{# wf_updated_on: 2017-12-06 #}
+{# wf_updated_on: 2018-01-05 #}
 {# wf_published_on: 2017-01-04 #}
 
 {% include "web/tools/chrome-devtools/_shared/styles.html" %}
@@ -13,6 +13,14 @@ description: Learn how to use Chrome DevTools to find and fix JavaScript bugs.
 {% include "web/_shared/contributors/kaycebasques.html" %}
 
 This tutorial teaches you the basic workflow for debugging any JavaScript issue in DevTools.
+Read on, or watch the video version of this tutorial, below.
+
+<div class="video-wrapper-full-width">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="H0XScE08hy8"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
+
 
 ## Step 1: Reproduce the bug {: #reproduce }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- see title

**Fixes:** N/A

**Target Live Date:** 2018-01-08

- [ ] This has been reviewed and approved by ¯\_(ツ)_/¯
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** ¯\_(ツ)_/¯
