### PR TITLE
Move travis node version to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: '4'
+node_js: '8'
 dist: trusty
 sudo: false
 git:


### PR DESCRIPTION
What's changed, or what was fixed?
- change node version used by Travis to 8+
