### PR TITLE
Payments: rename Google Payment API to Google Pay API

### DIFF
--- a/src/content/en/fundamentals/payments/_toc.yaml
+++ b/src/content/en/fundamentals/payments/_toc.yaml
@@ -7,6 +7,6 @@ toc:
     path: /web/fundamentals/payments/deep-dive-into-payment-request
   - title: Payment Request UX considerations
     path: /web/fundamentals/payments/payment-request-ux-considerations
-  - title: Set up Google Payment API
+  - title: Set up Google Pay API
     path: /payments/web/paymentrequest/tutorial
     status: external

--- a/src/content/en/fundamentals/payments/android-pay.md
+++ b/src/content/en/fundamentals/payments/android-pay.md
@@ -12,7 +12,7 @@ description: Android Pay enables simple and secure purchases online and eliminat
 
 Warning: Android Pay is now Pay with Google and provides access to payment
 tokens on the device and credit and debit cards from a user's Google account. To
-learn more about Pay with Google, read [Google Payment API](/payments/) docs.
+learn more about Pay with Google, read [Google Pay API](/payments/) docs.
 
 Android Pay enables simple and secure purchases online and eliminates the
 need for users to remember and manually enter their payment information.

--- a/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
@@ -176,7 +176,7 @@ an existing card will be selected for them.
 
 Note: To get access to all forms of payment available with Google, developers
 will need to implement the Pay with Google method. Refer to the
-[Google Payment API](/payments/web/paymentrequest/tutorial) docs for more information.
+[Google Pay API](/payments/web/paymentrequest/tutorial) docs for more information.
 
 <div class="attempt-center">
   <figure>

--- a/src/content/en/fundamentals/payments/index.md
+++ b/src/content/en/fundamentals/payments/index.md
@@ -92,7 +92,7 @@ the site.
 
 Note: Pay with Google is one of payment methods you can use to get cards from a
 user's Google account and payment tokens on the device. To learn more, read [the
-Google Payment API docs](/payments/web/paymentrequest/tutorial).
+Google Pay API docs](/payments/web/paymentrequest/tutorial).
 
 <div class="attempt-right">
   <figure>


### PR DESCRIPTION
Google Payment API is now known as the Google Pay API. Updates text to match.

**CC:** @petele @agektmr 