### PR TITLE
Adds 2018 to the book.yaml for updates

### DIFF
--- a/src/content/en/updates/_book.yaml
+++ b/src/content/en/updates/_book.yaml
@@ -13,6 +13,7 @@ upper_tabs:
         path: /web/updates/
     - name: By Year
       contents:
+      - include: /web/updates/2018/_toc.yaml
       - include: /web/updates/2017/_toc.yaml
       - include: /web/updates/2016/_toc.yaml
       - include: /web/updates/2015/_toc.yaml


### PR DESCRIPTION
What's changed, or what was fixed?
- Adds the 2018 toc to the `_book.yaml`


**Fixes:** TOC not showing up in 2018 docs

**Target Live Date:** 2018-01-09

- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
