### PR TITLE
Add wf_blink_components header to Android Pay page

### DIFF
--- a/src/content/en/fundamentals/payments/android-pay.md
+++ b/src/content/en/fundamentals/payments/android-pay.md
@@ -2,7 +2,8 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Android Pay enables simple and secure purchases online and eliminates the need for users to remember and manually enter their payment information. Integrate Android Pay to reach millions of Android users, drive higher conversion, and give users a true one-touch checkout experience.
 
-{# wf_updated_on: 2017-11-07 #}
+{# wf_blink_components: Blink>Payments #}
+{# wf_updated_on: 2018-01-10 #}
 {# wf_published_on: 2016-09-07 #}
 
 # Integrating Android Pay into Payment Request {: .page-title }


### PR DESCRIPTION
What's changed, or what was fixed?
- Add wf_blink_components header

**Fixes:** N/A

**Target Live Date:** N/A

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
