### PR TITLE
Add pointer to one-tap sign-up API docs

### DIFF
--- a/src/content/en/updates/2016/04/credential-management-api.md
+++ b/src/content/en/updates/2016/04/credential-management-api.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: To provide a sophisticated user experience, it's important to help users authenticate themselves to your website. But creating, remembering and typing passwords tends to be cumbersome for end users, especially on mobile
 
-{# wf_updated_on: 2016-11-08 #}
+{# wf_updated_on: 2018-01-12 #}
 {# wf_published_on: 2016-04-18 #}
 {# wf_tags: credentials,sign-in,chrome51 #}
 {# wf_featured_image: /web/updates/images/generic/security.png #}
@@ -24,6 +24,12 @@ The latest version of Chrome (51) supports the **[Credential Management
 API](http://w3c.github.io/webappsec-credential-management/)**. It's a
 standards-track proposal at the W3C that gives developers programmatic access to
 a browser's credential manager and helps users sign in more easily.
+
+Note: The new [one tap sign-up and automatic sign-in API](/identity/one-tap/web/overview),
+built on the Credential Management API, combines Google sign-in and
+password-based sign-in into one API call, and adds support for one-tap account
+creation. Consider using this new API instead of directly using the Credential
+Management API.
 
 ## What is the Credential Management API?
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Add pointer to one-tap sign-up API docs, which is recmmended over directly using the CM API when possible

**Fixes:** #issue

**Target Live Date:** 2018-01-12

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
