### PR TITLE
[devtools] add video to WNDT64

### DIFF
--- a/src/content/en/updates/2017/11/devtools-release-notes.md
+++ b/src/content/en/updates/2017/11/devtools-release-notes.md
@@ -2,11 +2,12 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Performance Monitor, Console Sidebar, and Console groupings.
 
-{# wf_updated_on: 2017-11-30 #}
+{# wf_updated_on: 2018-01-18 #}
 {# wf_published_on: 2017-11-28 #}
 {# wf_tags: chrome64,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
 {# wf_featured_snippet: Performance Monitor, Console Sidebar, and Console groupings. #}
+{# wf_blink_components: Platform>DevTools #}
 
 {% include "web/tools/chrome-devtools/_shared/styles.html" %}
 
@@ -24,6 +25,14 @@ Welcome back! New features coming to DevTools in Chrome 64 include:
   important to you.
 * [Group similar Console messages](#group-similar). The Console now groups similar messages
   together by default.
+
+Read on, or watch the video version of these release notes below.
+
+<div class="video-wrapper-full-width">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="90wNAn05Cf4"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
 Note: Check what version of Chrome you're running at `chrome://version`. If you're running
 an earlier version, these features won't exist. If you're running a later version, these features


### PR DESCRIPTION
What's changed, or what was fixed?
- add fancy vid to fancy post
- fancy fancy

**Fixes:** N/A

**Target Live Date:** 2018-01-25

- [ ] This has been reviewed and approved by ¯\_(ツ)_/¯
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
