### PR TITLE
Better quoting checks for include tags

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -661,7 +661,7 @@ function testMarkdown(filename, contents, options) {
       const inclFile = include[2];
       const quoteL = include[1];
       const quoteR = include[3];
-      if (quoteL !== quoteR) {
+      if (quoteL !== quoteR || quoteL === '') {
         msg = '`{% include %}` tag is badly quoted';
         logError(filename, position, `${msg}: ${include[0]}`);
       }


### PR DESCRIPTION
What's changed, or what was fixed?
- Verifies include tags are fully quoted.

- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @gauntface 
