### PR TITLE
Auto update wf_updated_on field

### DIFF
--- a/gulp-tasks/wfUpdatedOn.js
+++ b/gulp-tasks/wfUpdatedOn.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Gulp Task for updating wf_updated_on.
+ *
+ * @author Matt Gaunt
+ */
+
+'use strict';
+
+const gulp = require('gulp');
+const fse = require('fs-extra');
+const moment = require('moment');
+const wfHelper = require('./wfHelper');
+const wfRegEx = require('./wfRegEx');
+
+/**
+ * Gets the list of changed files
+ * @return {Promise<Array<String>>} Returns array of changed Files.
+ */
+async function getChangedFiles() {
+  const cmd = 'git --no-pager diff --name-only ' +
+    '$(git merge-base origin/master HEAD)';
+  const results = await wfHelper.promisedExec(cmd, '.');
+  return results.split('\n');
+}
+
+gulp.task('update-updated_on', async () => {
+  if (process.env.TRAVIS) {
+    // Do nothing on Travis.
+    return;
+  }
+
+  let filesUpdated = false;
+  const changedFiles = await getChangedFiles();
+
+  for (const changedFile of changedFiles) {
+    if (changedFile.indexOf('src/content') == -1) {
+      // File isn't a content file, skip it.
+      continue;
+    }
+    try {
+      await fse.access(changedFile);
+    } catch (err) {
+      // File removed
+      continue;
+    }
+
+    const fileContents = (await fse.readFile(changedFile)).toString();
+    const matched = wfRegEx.RE_UPDATED_ON.exec(fileContents);
+    if (!matched) {
+      // Updated on not in the file - nothing to do.
+      continue;
+    }
+
+    const originalUpdatedOn = matched[0];
+    const originalTimestamp = matched[1];
+    const newTimeStamp = moment().format(`YYYY-MM-DD`);
+    if (originalTimestamp === newTimeStamp) {
+      continue;
+    }
+
+    const newUpdatedOn = originalUpdatedOn
+      .replace(originalTimestamp, newTimeStamp);
+    const newContents = fileContents.replace(originalUpdatedOn, newUpdatedOn);
+    await fse.writeFile(changedFile, newContents);
+    filesUpdated = true;
+  }
+  if (filesUpdated) {
+    throw new Error('Updated wf_updated_on for some files, try commit again.');
+  }
+});

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "clean": "gulp clean",
     "start": "./start-appengine.sh",
     "test": "gulp test",
+    "precommit": "gulp update-updated_on",
     "prepush": "npm test",
     "prestart": "gulp build",
     "postinstall": "gulp build"

--- a/src/content/en/feedback/file-a-bug.md
+++ b/src/content/en/feedback/file-a-bug.md
@@ -3,6 +3,7 @@ book_path: /web/feedback/_book.yaml
 
 {# wf_updated_on: 2018-01-22 #}
 {# wf_published_on: 2016-10-24 #}
+{# wf_blink_components: N/A #}
 
 # How to File a Good Bug {: .page-title }
 

--- a/src/content/en/feedback/file-a-bug.md
+++ b/src/content/en/feedback/file-a-bug.md
@@ -1,7 +1,7 @@
 project_path: /web/feedback/_project.yaml
 book_path: /web/feedback/_book.yaml
 
-{# wf_updated_on: 2016-10-24 #}
+{# wf_updated_on: 2018-01-22 #}
 {# wf_published_on: 2016-10-24 #}
 
 # How to File a Good Bug {: .page-title }
@@ -20,10 +20,9 @@ might help you translate an abstract problem into a specific broken API. It
 might also give you a workaround for the short term.
 
 Once you have an idea of what the bug is, search for it on the
-[browser bug searcher](/web/feedback/).
-If you find an existing bug that describes the problem, it’s much more useful
-to add your support by starring, favoriting, or commenting on that bug.
-If not, it's time to file a bug.
+[browser bug searcher](/web/feedback/). If you find an existing bug that
+describes the problem, it’s much more useful to add your support by starring,
+favoriting, or commenting on that bug. If not, it's time to file a bug.
 
 ## What's the correct behavior?
 
@@ -41,9 +40,9 @@ odd one out. Try to test on the latest versions of Chrome, Firefox, Safari and
 Edge, possibly using a tool like [BrowserStack](https://www.browserstack.com/).
 
 If possible, check that the page isn't intentionally behaving differently due to
- user agent sniffing. Try setting the user agent string to another browser in
- Dev Tools > Menu > More Tools > Network conditions. Note: don’t forget to set
- it back to Select automatically.
+user agent sniffing. Try setting the user agent string to another browser in
+Dev Tools > Menu > More Tools > Network conditions. Note: don’t forget to set
+it back to Select automatically.
 
 
 ### Is it a regression?
@@ -51,10 +50,11 @@ If possible, check that the page isn't intentionally behaving differently due to
 Did this work as expected in the past, but broke in a recent browser release?
 Such "regressions" can be acted upon much quicker, especially if you supply a
 version number where it worked and a version where it failed. Tools like
-[BrowserStack](https://www.browserstack.com/) can make it easy to check old browser versions.
+[BrowserStack](https://www.browserstack.com/) can make it easy to check old
+browser versions.
 
 If an issue is a regression and can be reproduced, the root cause can usually be
- found and fixed quickly.
+found and fixed quickly.
 
 ## Create a minimized test case
 
@@ -69,19 +69,20 @@ the odds of your bug getting fixed.
 Here are a few tips for minimizing a test case:
 
 * Download the web page, add `<base href="http://original.url">` and verify that
-the bug exists locally. This may require a live HTTPS server if the URL uses
-HTTPS.
+  the bug exists locally. This may require a live HTTPS server if the URL uses
+  HTTPS.
 * Test the local files on the latest builds of as many browsers as you can.
 * Try to condense everything into 1 file.
 * Remove code (starting with things you know to be unnecessary) until the bug
-goes away.
+  goes away.
 * Use version control so that you can save your work and undo things that go
-wrong.
+  wrong.
 
 
 ### Hosting a minified test case
 
-If you're looking for a good place to host your minified test case, there are several good places available:
+If you're looking for a good place to host your minified test case, there are
+several good places available:
 
 * [JSBin](https://jsbin.com)
 * [JSFiddle](https://jsfiddle.net)


### PR DESCRIPTION
**Replaced by #5699**

What's changed, or what was fixed?
- Pre-commit hook that will update `wf_updated_on` if it wasn't already updated.

**Fixes:** #5541 

- [ ] This has been reviewed and approved by (@gauntface)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
