### PR TITLE
[devtools] add more x-refs to WNDT64

### DIFF
--- a/src/content/en/updates/2017/11/devtools-release-notes.md
+++ b/src/content/en/updates/2017/11/devtools-release-notes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Performance Monitor, Console Sidebar, and Console groupings.
 
-{# wf_updated_on: 2018-01-29 #}
+{# wf_updated_on: 2018-02-01 #}
 {# wf_published_on: 2017-11-28 #}
 {# wf_tags: chrome64,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -40,15 +40,22 @@ may have changed. Chrome auto-updates to a new major version about every 6 weeks
 
 ## Performance Monitor {: #perf-monitor }
 
-Use the Performance Monitor to get a real-time view of various aspects of a page's performance,
-including:
+Use the **Performance Monitor** to get a real-time view of various aspects of a page's load
+or runtime performance, including:
 
 * CPU usage.
 * JavaScript heap size.
 * The total number of DOM nodes, JavaScript event listeners, documents, and frames on the page.
 * Layouts and style recalculations per second.
 
-To use the Performance Monitor:
+If users are reporting that your app feels slow or janky, check the **Performance Monitor** for
+clues.
+
+<aside class="success"><b>Why load perf matters</b>: BookMyShow achieved an 80% increase
+in conversions when they built a Progressive Web App that focused on speed.
+<a href="/web/showcase/2017/bookmyshow">Learn more</a>.</aside>
+
+To use the **Performance Monitor**:
 
 1. Open the [Command Menu](/web/tools/chrome-devtools/ui#command-menu).
 1. Start typing `Performance` then select `Show Performance Monitor`.
@@ -63,6 +70,22 @@ To use the Performance Monitor:
 
 1. Click a metric to show or hide it. In Figure 1 the **CPU Usage**, **JS heap size**, and
    **JS event listeners** charts are shown.
+
+Related features:
+
+* **Performance** panel. Walk through a critical user journey and record everything that
+  happens on the page, including JavaScript activity, network requests, CPU usage, and much more.
+  Can also be used to analyze load performance. 
+  [Learn more][runtime].
+* **Audits** panel. Run a suite of automated load and runtime performance tests against any URL.
+  [Learn more][audits].
+
+If you're just starting out with analyzing performance, the recommended path is to first use
+the **Audits** panel, and then investigate further using the **Performance** panel or
+**Performance** monitor.
+
+[runtime]: /web/tools/chrome-devtools/evaluate-performance/
+[audits]: /web/tools/lighthouse/#devtools
 
 ## Console Sidebar {: #console-sidebar }
 
@@ -79,6 +102,14 @@ On large sites, the Console can quickly get flooded with irrelevant messages. Us
 
 The Console Sidebar is hidden by default. Click **Show Console Sidebar** ![Show Console
 Sidebar](/web/updates/images/2017/11/show-console-sidebar.png){:.cdt-inl} to show it.
+
+Related features:
+
+* **Filter** text box. Enter some text and the **Console** only shows messages that include
+  that text. Also supports regex patterns, [negative filters][neg], and [URL filters][url].
+
+[neg]: /web/updates/2017/08/devtools-release-notes#negative-filters
+[url]: /web/updates/2017/08/devtools-release-notes#url-filters
 
 ## Group similar Console messages {: #group-similar }
 
@@ -105,10 +136,17 @@ Click on a group to expand it and see each instance of the message.
 
 Uncheck the **Group Similar** checkbox to disable this feature.
 
+Related features:
+
+* You can group your own Console messages with [`console.group()`][group].
+
+[group]: /web/tools/chrome-devtools/console/console-reference#group
+
 ## Local Overrides {: #overrides }
 
 Whoops! We originally scheduled this feature to launch in Chrome 64, but pulled it close to
-the deadline in order to smooth out some rough edges.
+the deadline in order to smooth out some rough edges. Apparently, the What's New UI didn't
+update in time.
 
 This feature is shipping in Chrome 65, which will land approximately 6 weeks after Chrome 64.
 Check out [Local Overrides][LO] to learn more.
@@ -125,7 +163,7 @@ DevTools, please [open an issue](https://crbug.com/new).
 
 [ML]: https://groups.google.com/forum/#!forum/google-chrome-developer-tools
 
-## Previous release notes {: #links }
+## Links to previous release notes {: #links }
 
 See the [devtools-whatsnew][tag] tag for links to all previous DevTools
 release notes.


### PR DESCRIPTION
What's changed, or what was fixed?
- adds more x-refs to WNDT64

**Fixes:** N/A

**Target Live Date:** 2018-02-01

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
