### PR TITLE
Ensure includes are html files

### DIFF
--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -676,6 +676,10 @@ function testMarkdown(filename, contents, options) {
         msg = '`{% include %}` tag found, but couldn\'t find related include';
         logError(filename, position, `${msg}: ${inclFile}`);
       }
+      if (!inclFile.endsWith('.html') && !inclFile.endsWith('.js')) {
+        msg = '`{% include %}` tag found, file must be an HTML file';
+        logError(filename, position, `${msg}: ${inclFile}`);
+      }
     });
 
     // Verify all {% includecode %} elements work properly


### PR DESCRIPTION
What's changed, or what was fixed?
- Ensures that `{% include %}` tags are .html files

**Target Live Date:** ASAP

- [x] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
