### PR TITLE
Gracefully handle missing TOC

### DIFF
--- a/devsiteHelper.py
+++ b/devsiteHelper.py
@@ -179,8 +179,18 @@ def expandBook(book, lang='en'):
     results = []
     for item in book:
       if 'include' in item:
-        newItems = yaml.load(readFile(item['include'], lang))
-        results = results + expandBook(newItems['toc'], lang)
+        tocFileContents = readFile(item['include'], lang)
+        if tocFileContents is None:
+          logging.error('Error in expandBook, unable to read %s', item['include'])
+          items = [{
+            "title": '** ERROR: TOC not found. **',
+            "path": '#',
+            "status": 'deprecated'
+          }]
+          results = results + expandBook(items, lang)
+        else:
+          newItems = yaml.load(tocFileContents)
+          results = results + expandBook(newItems['toc'], lang)
       else:
         results.append(expandBook(item, lang))
     return results

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -306,6 +306,13 @@ gulp.task('build:updates', function() {
   wfTemplateHelper.renderTemplate(template, context, outFile);
 });
 
+/**
+ * Builds all the things!
+ */
+gulp.task('post-install', function(cb) {
+  runSequence('puppeteer:build', 'build', cb);
+});
+
 
 /**
  * Builds all the things!

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "precommit": "gulp update-updated_on",
     "prepush": "npm test",
     "prestart": "gulp build",
-    "postinstall": "gulp build"
+    "postinstall": "gulp post-install"
   }
 }


### PR DESCRIPTION
What's changed, or what was fixed?
- If an include in a TOC isn't found, render the rest of the content
- Show an error in the python server for what's not available
- Change the missing include bit to a warning

**Fixes:** #5723 

**Target Live Date:** ASAP

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @kaycebasques 
