### PR TITLE
[devtools] remove "video will be out soon" note from WNDT64

### DIFF
--- a/src/content/en/updates/2017/11/devtools-release-notes.md
+++ b/src/content/en/updates/2017/11/devtools-release-notes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Performance Monitor, Console Sidebar, and Console groupings.
 
-{# wf_updated_on: 2018-02-01 #}
+{# wf_updated_on: 2018-02-05 #}
 {# wf_published_on: 2017-11-28 #}
 {# wf_tags: chrome64,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -14,9 +14,6 @@ description: Performance Monitor, Console Sidebar, and Console groupings.
 # What's New In DevTools (Chrome 64) {: .page-title }
 
 {% include "web/_shared/contributors/kaycebasques.html" %}
-
-Note: The video version of these release notes will be published around
-late-January 2018.
 
 Welcome back! New features coming to DevTools in Chrome 64 include:
 


### PR DESCRIPTION
What's changed, or what was fixed?
- removes the note about the video being out in late Jan. The vid is already embedded in the post

**Fixes:** N/A

**Target Live Date:** 2018-02-06

- [x] This has been reviewed and approved by @kaycebasques (myself)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
