### PR TITLE
WebFu IA tweak - Getting Started at the top

### DIFF
--- a/src/content/en/fundamentals/_book.yaml
+++ b/src/content/en/fundamentals/_book.yaml
@@ -6,8 +6,14 @@ upper_tabs:
       other:
       - name: Guides
         contents:
-        - title: Overview
-          path: /web/fundamentals/
+        - title: Getting Started
+          style: accordion
+          section:
+          - title: Overview
+            path: /web/fundamentals/
+          - include: /web/fundamentals/_toc-base.yaml
+          - title: Glossary
+            path: /web/fundamentals/glossary
         - include: /web/fundamentals/architecture/_toc.yaml
         - include: /web/fundamentals/design-and-ux/_toc.yaml
         - include: /web/fundamentals/integration/_toc.yaml
@@ -18,10 +24,7 @@ upper_tabs:
           - include: /web/fundamentals/vr/_toc.yaml
         - include: /web/fundamentals/performance/_toc.yaml
         - include: /web/fundamentals/security/_toc.yaml
-        - include: /web/fundamentals/_toc-base.yaml
         - break: True
-        - title: Glossary
-          path: /web/fundamentals/glossary
       - name: Code Labs
         contents:
         - include: /web/fundamentals/codelabs/_toc.yaml

--- a/src/content/en/fundamentals/_toc-base.yaml
+++ b/src/content/en/fundamentals/_toc-base.yaml
@@ -1,12 +1,9 @@
 toc:
-- title: Base Technologies
-  style: accordion
+- title: Core Technologies
   section:
-  - title: HTML & DOM
-    section:
-    - include: /web/fundamentals/web-components/_toc.yaml
+  - include: /web/fundamentals/web-components/_toc.yaml
   - title: JavaScript
-    section:  
+    section:
     - title: Async Functions
       path: /web/fundamentals/primers/async-functions
     - title: Promises


### PR DESCRIPTION
What's changed, or what was fixed?
- Creates 'getting started' section at the very top
- Moves welcome page into getting started
- Renames 'base technologies' to 'core technologies' and moves into GS
- Moves glossary into GS

**Target Live Date:** TBD

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @Meggin @devnook 
