### PR TITLE
[devtools] add note about canary in WNDT64

### DIFF
--- a/src/content/en/updates/2017/11/devtools-release-notes.md
+++ b/src/content/en/updates/2017/11/devtools-release-notes.md
@@ -143,12 +143,14 @@ Related features:
 
 Whoops! We originally scheduled this feature to launch in Chrome 64, but pulled it close to
 the deadline in order to smooth out some rough edges. Apparently, the What's New UI didn't
-update in time.
+update in time. Sorry!
 
 This feature is shipping in Chrome 65, which will land approximately 6 weeks after Chrome 64.
-Check out [Local Overrides][LO] to learn more.
+Check out [Local Overrides][LO] to learn more. If you're on Windows or Mac, you can try
+Chrome 65 now by downloading [Chrome Canary][canary]{:.external}.
 
 [LO]: /web/updates/2018/01/devtools#overrides
+[canary]: https://www.google.com/chrome/browser/canary.html
 
 ## Feedback {: #feedback }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- explain how readers can use the local overrides feature right now via canary

**Fixes:** N/A

**Target Live Date:** 2018-02-08 (today)

- [x] This has been reviewed and approved by @kaycebasques (me)
- [x] I have run `gulp test` locally and all tests pass. (travis build passed)
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly. (verified on [staging](https://pr-5763-dot-web-central.appspot.com/web/updates/2017/11/devtools-release-notes#overrides))

**CC:** @petele
