### PR TITLE
Remove errant character that breaks RSS feed output

### DIFF
--- a/src/content/en/updates/2018/01/paintapi.md
+++ b/src/content/en/updates/2018/01/paintapi.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Houdini’s CSS Paint API allows you to programmatically draw CSS images.
 
-{# wf_updated_on: 2018-01-18 #}
+{# wf_updated_on: 2018-02-12 #}
 {# wf_published_on: 2018-01-18 #}
 {# wf_tags: css,style,houdini,javascript,chrome65 #}
 {# wf_featured_image: /web/updates/images/2018/01/paintapi/houdinidiamond.png #}
@@ -270,8 +270,5 @@ collection](https://lab.iamvdo.me/houdini/).
 
 Note: Breakpoints are currently not supported in CSS Paint API, but will be
 enabled in a later release of Chrome.
-
-
-
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Remove errant `FF` in file that broke RSS feed
- item 2

**Fixes:** #5780 

**Target Live Date:** ASAP
