### PR TITLE
Fix incorrect title on Japanese Keyword Hack doc

### DIFF
--- a/src/content/en/fundamentals/security/hacked/fixing_the_japanese_keyword_hack.md
+++ b/src/content/en/fundamentals/security/hacked/fixing_the_japanese_keyword_hack.md
@@ -1,11 +1,11 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-01-08 #}
+{# wf_updated_on: 2018-02-12 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
-# Fixing the gibberish hack {: .page-title }
+# Fixing the Japanese keyword hack {: .page-title }
 
 Note: Unsure whether or not your site is hacked? Start by reading our
 [how to check if your site is hacked](how_do_I_know_if_site_hacked) guide.


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed title

**Target Live Date:** ASAP

