### PR TITLE
Remove caveat about importWorkboxFrom: 'local' and InjectManifest

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/single/importWorkboxFrom.html
+++ b/src/content/en/tools/workbox/_shared/config/single/importWorkboxFrom.html
@@ -20,8 +20,6 @@
           versioned directory alongside your generated service worker, and configure the service
           worker to use those local copies. This option is provided for developers who would prefer
           to host everything  themselves and not rely on the Google Cloud Storage CDN.
-          <br/>
-          <strong>Note:</strong> This option is not supported in the `InjectManifest` webpack plugin.
         </li>
         <li>
           <code>'disabled'</code> will opt-out automatic behavior. It's up to you to host a local copy


### PR DESCRIPTION
New functionality was added to Workbox in https://github.com/GoogleChrome/workbox/pull/1290

This PR updates the Workbox docs to reflect the change.