### PR TITLE
[lighthouse] add "meta description" reference

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -46,6 +46,8 @@ toc:
   path: /web/tools/lighthouse/audits/critical-request-chains
 - title: Displays Images With Incorrect Aspect Ratio
   path: /web/tools/lighthouse/audits/aspect-ratio
+- title: Document Does Not Have A Meta Description
+  path: /web/tools/lighthouse/audits/description
 - title: Element aria-* Attributes Are Allowed For This Role
   path: /web/tools/lighthouse/audits/aria-allowed-attributes
 - title: Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent

--- a/src/content/en/tools/lighthouse/audits/description.md
+++ b/src/content/en/tools/lighthouse/audits/description.md
@@ -2,8 +2,8 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Document Does Not Have A Meta Description" Lighthouse audit.
 
-{# wf_updated_on: 2018-02-14 #}
-{# wf_published_on: 2018-02-14 #}
+{# wf_updated_on: 2018-02-16 #}
+{# wf_published_on: 2018-02-16 #}
 {# wf_blink_components: Platform>DevTools #}
 
 # Document Does Not Have A Meta Description  {: .page-title }
@@ -17,7 +17,7 @@ can make your results more relevant to search users and can increase your search
 
 * Add a description tag to the `<head>` of each of your pages.
 
-    <pre>
+    <pre class="prettyprint">
     &lt;meta name="Description" content="Put your description here."&gt;
     </pre>
 
@@ -26,7 +26,7 @@ can make your results more relevant to search users and can increase your search
 * Include clearly-tagged facts in the descriptions. The descriptions don't have to be in
   sentence format. They can contain structured data.
 
-    <pre>
+    <pre class="prettyprint">
     &lt;meta name="Description" content="Author: A.N. Author, 
         Illustrator: P. Picture, Category: Books, Price: $17.99, 
         Length: 784 pages"&gt;
@@ -37,7 +37,7 @@ can make your results more relevant to search users and can increase your search
 
 See [Create good meta descriptions][help]{:.external} for more guidance.
 
-[help]: https://support.google.com/webmasters/answer/35624?hl=en#1
+[help]: https://support.google.com/webmasters/answer/35624#1
 
 ## More information {: #more-info }
 

--- a/src/content/en/tools/lighthouse/audits/description.md
+++ b/src/content/en/tools/lighthouse/audits/description.md
@@ -1,0 +1,49 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Document Does Not Have A Meta Description" Lighthouse audit.
+
+{# wf_updated_on: 2018-02-14 #}
+{# wf_published_on: 2018-02-14 #}
+{# wf_blink_components: Platform>DevTools #}
+
+# Document Does Not Have A Meta Description  {: .page-title }
+
+## Overview {: #overview }
+
+Descriptions can be displayed in Google's search results. High-quality, unique descriptions
+can make your results more relevant to search users and can increase your search traffic.
+
+## Recommendations {: #recommendations }
+
+* Add a description tag to the `<head>` of each of your pages.
+
+    <pre>
+    &lt;meta name="Description" content="Put your description here."&gt;
+    </pre>
+
+* Make sure that every page has a description.
+* Use different descriptions for different pages.
+* Include clearly-tagged facts in the descriptions. The descriptions don't have to be in
+  sentence format. They can contain structured data.
+
+    <pre>
+    &lt;meta name="Description" content="Author: A.N. Author, 
+        Illustrator: P. Picture, Category: Books, Price: $17.99, 
+        Length: 784 pages"&gt;
+    </pre>
+
+* Use quality descriptions. High-quality descriptions can be displayed in Google's search
+  results, and can go a long way to improving your search traffic.
+
+See [Create good meta descriptions][help]{:.external} for more guidance.
+
+[help]: https://support.google.com/webmasters/answer/35624?hl=en#1
+
+## More information {: #more-info }
+
+This audit fails if your page doesn't have a description, or if the `content` attribute of the
+description is empty. Lighthouse doesn't evaluate the quality of your description.
+
+[Audit source][src]{:.external}
+
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/seo/meta-description.js


### PR DESCRIPTION
What's changed, or what was fixed?
- add reference for the "meta description" audit

**Fixes:** N/A

**Target Live Date:** 2018-02-15

- [x] This has been reviewed and approved by @rviscomi 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
