### PR TITLE
update links to Google Pay API Payment Request tutorial

### DIFF
--- a/src/content/en/fundamentals/payments/_toc.yaml
+++ b/src/content/en/fundamentals/payments/_toc.yaml
@@ -8,5 +8,5 @@ toc:
   - title: Payment Request UX considerations
     path: /web/fundamentals/payments/payment-request-ux-considerations
   - title: Set up Google Pay API
-    path: /payments/web/paymentrequest/tutorial
+    path: /pay/api/web/paymentrequest/tutorial
     status: external

--- a/src/content/en/fundamentals/payments/android-pay.md
+++ b/src/content/en/fundamentals/payments/android-pay.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Android Pay enables simple and secure purchases online and eliminates the need for users to remember and manually enter their payment information. Integrate Android Pay to reach millions of Android users, drive higher conversion, and give users a true one-touch checkout experience.
 
 {# wf_blink_components: Blink>Payments #}
-{# wf_updated_on: 2018-01-10 #}
+{# wf_updated_on: 2018-02-20 #}
 {# wf_published_on: 2016-09-07 #}
 
 # Integrating Android Pay into Payment Request {: .page-title }
@@ -11,9 +11,9 @@ description: Android Pay enables simple and secure purchases online and eliminat
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/sieke.html" %}
 
-Warning: Android Pay is now Pay with Google and provides access to payment
+Warning: Android Pay is now Google Pay and provides access to payment
 tokens on the device and credit and debit cards from a user's Google account. To
-learn more about Pay with Google, read [Google Pay API](/payments/) docs.
+learn more about Google Pay, read the [Google Pay API](/pay/api/) docs.
 
 Android Pay enables simple and secure purchases online and eliminates the
 need for users to remember and manually enter their payment information.

--- a/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: How to implement and take full advantage of the Payment Request API.
 
 {# wf_published_on: 2017-04-21 #}
-{# wf_updated_on: 2018-01-08 #}
+{# wf_updated_on: 2018-02-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Deep Dive into the Payment Request API {: .page-title }
@@ -176,7 +176,7 @@ an existing card will be selected for them.
 
 Note: To get access to all forms of payment available with Google, developers
 will need to implement the Pay with Google method. Refer to the
-[Google Pay API](/payments/web/paymentrequest/tutorial) docs for more information.
+[Google Pay API](/pay/api/web/paymentrequest/tutorial) docs for more information.
 
 <div class="attempt-center">
   <figure>
@@ -344,7 +344,7 @@ const payWithGooglePaymentMethod = {
 </div>
 
 We won't go into details of how to add Pay with Google in this article, [we have
-a dedicated document to that](/payments/web/paymentrequest/tutorial).
+a dedicated document to that](/pay/api/web/paymentrequest/tutorial "Google Pay API Payment Request tutorial").
 
 
 #### Edge Cases
@@ -370,7 +370,7 @@ payment option. This has occurred because the example supports both Pay with
 Google and basic cards. If you define Pay with Google as your **only** payment
 method and the browser supports it, the browser can (and Chrome does, at the
 time of writing) skip the payment request UI altogether after the `show()`
-method is called. Users will be taken straight to the Pay with Google app to
+method is called. Users will be taken straight to Google Play services to
 complete the payment.
 
 ### Defining Payment Details

--- a/src/content/en/fundamentals/payments/index.md
+++ b/src/content/en/fundamentals/payments/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Payment Request API is for fast, easy payments on the web.
 
 {# wf_published_on: 2016-07-25 #}
-{# wf_updated_on: 2017-12-27 #}
+{# wf_updated_on: 2018-02-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Introducing the Payment Request API {: .page-title }
@@ -92,7 +92,7 @@ the site.
 
 Note: Pay with Google is one of payment methods you can use to get cards from a
 user's Google account and payment tokens on the device. To learn more, read [the
-Google Pay API docs](/payments/web/paymentrequest/tutorial).
+Google Pay API docs](/pay/api/web/paymentrequest/tutorial).
 
 <div class="attempt-right">
   <figure>


### PR DESCRIPTION
Update link to Google Pay API Payment Request tutorial:
https://developers.google.com/pay/api/web/paymentrequest/tutorial

Google Pay API docs have moved. References to "Pay with Google" in Payment Request documentation is correct until M65, when Google Pay branding replaces.

**CC:** @petele @agektmr
