### PR TITLE
[lightouse] update template & add "font sizes" reference

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -48,6 +48,8 @@ toc:
   path: /web/tools/lighthouse/audits/aspect-ratio
 - title: Document Does Not Have A Meta Description
   path: /web/tools/lighthouse/audits/description
+- title: Document Doesn't Use Legible Font Sizes
+  path: /web/tools/lighthouse/audits/font-sizes
 - title: Element aria-* Attributes Are Allowed For This Role
   path: /web/tools/lighthouse/audits/aria-allowed-attributes
 - title: Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent

--- a/src/content/en/tools/lighthouse/audits/_template.md
+++ b/src/content/en/tools/lighthouse/audits/_template.md
@@ -2,9 +2,9 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-11 #}
-{# wf_published_on: 2017-01-30 #}
-{# wf_blink_components: N/A #}
+{# wf_updated_on: 2018-02-20 #}
+{# wf_published_on: 2018-02-20 #}
+{# wf_blink_components: Platform>DevTools #}
 
 # AUDIT_NAME  {: .page-title }
 
@@ -17,40 +17,3 @@ description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
 [Audit source][src]{:.external}
 
 [src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/AUDIT_NAME
-
-## Feedback {: #feedback }
-
-{% framebox width="auto" height="auto" enable_widgets="true" %}
-<script>
-var label = 'AUDIT_NAME / Helpful';
-var url = 'https://github.com/google/webfundamentals/issues/new?title=[' +
-      label + ']';
-var feedback = {
-  "category": "Lighthouse",
-  "choices": [
-    {
-      "button": {
-        "text": "This Doc Was Helpful"
-      },
-      "response": "Thanks for the feedback.",
-      "analytics": {
-        "label": label
-      }
-    },
-    {
-      "button": {
-        "text": "This Doc Was Not Helpful"
-      },
-      "response": 'Sorry to hear that. Please <a href="' + url +
-          '" target="_blank">open a GitHub issue</a> and tell us how to ' +
-          'make it better.',
-      "analytics": {
-        "label": label,
-        "value": 0
-      }
-    }
-  ]
-};
-</script>
-{% include "web/_shared/multichoice.html" %}
-{% endframebox %}

--- a/src/content/en/tools/lighthouse/audits/font-sizes.md
+++ b/src/content/en/tools/lighthouse/audits/font-sizes.md
@@ -1,0 +1,47 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Document Doesn't Use Legible Font Sizes" Lighthouse audit.
+
+{# wf_updated_on: 2018-02-21 #}
+{# wf_published_on: 2018-02-21 #}
+{# wf_blink_components: Platform>DevTools #}
+
+# Document Doesn't Use Legible Font Sizes  {: .page-title }
+
+## Overview {: #overview }
+
+Font sizes smaller than 12px are often difficult to read on mobile devices, and may require users
+to pinch-to-zoom in order to display the text at a comfortable reading size.
+
+## Recommendations {: #recommendations }
+
+Aim to have a font size of at least 12px on at least 60% of the text on your pages. 
+When a page fails the audit, Lighthouse lists the results in a table with 4 columns:
+
+* **Source**. The source location of the CSS ruleset that is causing the illegible text.
+* **Selector**. The selector of the ruleset.
+* **% of Page Text**. The percentage of text on the page that is affected by the ruleset.
+* **Font Size**. The computed size of the text.
+
+### Text is illegible because of a missing viewport config {: #viewport }
+
+If Lighthouse reports `Text is illegible because of a missing viewport config`, add a
+`<meta name="viewport" content="width=device-width, initial-scale=1">` tag to the `<head>` of
+your document. See [Has A Viewport Meta Tag With Width Or Intial-Scale][viewport].
+
+[viewport]: /web/tools/lighthouse/audits/has-viewport-meta-tag
+
+### Characters per line {: #characters }
+
+Although Lighthouse does not check characters per line, classic readability theory suggests
+that 70 or 80 characters per line provides maximum readability. See [How to choose
+breakpoints][breakpoints] for strategies on ensuring that your text is readable across different
+form factors.
+
+[breakpoints]: /web/fundamentals/design-and-ux/responsive/#how_to_choose_breakpoints
+
+## More information {: #more-info }
+
+[Audit source][src]{:.external}
+
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/seo/font-size.js

--- a/src/content/en/tools/lighthouse/audits/font-sizes.md
+++ b/src/content/en/tools/lighthouse/audits/font-sizes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Document Doesn't Use Legible Font Sizes" Lighthouse audit.
 
-{# wf_updated_on: 2018-02-21 #}
+{# wf_updated_on: 2018-02-22 #}
 {# wf_published_on: 2018-02-21 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -30,15 +30,6 @@ If Lighthouse reports `Text is illegible because of a missing viewport config`, 
 your document. See [Has A Viewport Meta Tag With Width Or Intial-Scale][viewport].
 
 [viewport]: /web/tools/lighthouse/audits/has-viewport-meta-tag
-
-### Characters per line {: #characters }
-
-Although Lighthouse does not check characters per line, classic readability theory suggests
-that 70 or 80 characters per line provides maximum readability. See [How to choose
-breakpoints][breakpoints] for strategies on ensuring that your text is readable across different
-form factors.
-
-[breakpoints]: /web/fundamentals/design-and-ux/responsive/#how_to_choose_breakpoints
 
 ## More information {: #more-info }
 


### PR DESCRIPTION
Hey @rviscomi and @kdzwinel, have a look at the reference for the "font size" audit, plz!

What's changed, or what was fixed?
- update template for LH reference docs
- add reference for "font sizes" audit

**Fixes:** N/A

**Target Live Date:** 2018-02-28

- [x] This has been reviewed and approved by @kdzwinel & @rviscomi 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
