### PR TITLE
[devtools] add get started section to homepage & polish the ToC

### DIFF
--- a/src/content/en/tools/chrome-devtools/_toc.yaml
+++ b/src/content/en/tools/chrome-devtools/_toc.yaml
@@ -1,62 +1,13 @@
 toc:
 - title: Overview
   path: /web/tools/chrome-devtools/
-- title: Debug Progressive Web Apps
-  path: /web/tools/chrome-devtools/progressive-web-apps
-- title: Understand Security Issues
-  path: /web/tools/chrome-devtools/security
-- title: Run Snippets of Code From Any Page
-  path: /web/tools/chrome-devtools/snippets
-- title: Keyboard Shortcuts Reference
-  path: /web/tools/chrome-devtools/shortcuts
-- title: UI Reference
-  path: /web/tools/chrome-devtools/ui
-- title: Sources Panel Overview
-  path: /web/tools/chrome-devtools/sources
-- title: Inspect and Edit Pages
-  section:
-  - title: Overview
-    path: /web/tools/chrome-devtools/inspect-styles/
-  - title: Inspect Animations
-    path: /web/tools/chrome-devtools/inspect-styles/animations
-  - title: Edit the DOM
-    path: /web/tools/chrome-devtools/inspect-styles/edit-dom
-  - title: Edit Styles
-    path: /web/tools/chrome-devtools/inspect-styles/edit-styles
-    status: deprecated
 - title: View and Change CSS
   section:
   - title: Get Started with Viewing and Changing CSS
     path: /web/tools/chrome-devtools/css/
   - title: CSS Reference
     path: /web/tools/chrome-devtools/css/reference
-- title: Inspect and Manage Storage, Caches, and Resources
-  section:
-  - title: Inspect and Manage Storage, Databases, and Caches
-    path: /web/tools/chrome-devtools/manage-data/local-storage
-  - title: Inspect and Delete Cookies
-    path: /web/tools/chrome-devtools/manage-data/cookies
-  - title: Inspect Resources
-    path: /web/tools/chrome-devtools/manage-data/page-resources
-- title: Simulate Mobile Devices with Device Mode
-  section:
-  - title: Overview
-    path: /web/tools/chrome-devtools/device-mode/
-  - title: Test Responsive and Device-Specific Viewports
-    path: /web/tools/chrome-devtools/device-mode/emulate-mobile-viewports
-  - title: Emulate Geolocation and Accelerometer Sensors
-    path: /web/tools/chrome-devtools/device-mode/device-input-and-sensors
-  - title: Emulate and Test Other Browsers
-    path: /web/tools/chrome-devtools/device-mode/testing-other-browsers
-- title: Remote Debugging Android Devices
-  section:
-  - title: Get Started
-    path: /web/tools/chrome-devtools/remote-debugging/
-  - title: Access Local Servers
-    path: /web/tools/chrome-devtools/remote-debugging/local-server
-  - title: Remote Debugging WebViews
-    path: /web/tools/chrome-devtools/remote-debugging/webviews
-- title: Inspect and Debug JavaScript
+- title: View and Change JavaScript
   section:
   - title: Get Started
     path: /web/tools/chrome-devtools/javascript/
@@ -75,7 +26,33 @@ toc:
   - title: Watch Variables in Sources
     path: /web/tools/chrome-devtools/javascript/watch-variables
     status: deprecated
-- title: Using the Console
+- title: UI References and Overviews
+  section:
+  - title: UI Reference
+    path: /web/tools/chrome-devtools/ui
+  - title: Sources Panel Overview
+    path: /web/tools/chrome-devtools/sources
+  - title: Keyboard Shortcuts Reference
+    path: /web/tools/chrome-devtools/shortcuts
+- title: Simulate Mobile Devices with Device Mode
+  section:
+  - title: Overview
+    path: /web/tools/chrome-devtools/device-mode/
+  - title: Test Responsive and Device-Specific Viewports
+    path: /web/tools/chrome-devtools/device-mode/emulate-mobile-viewports
+  - title: Emulate Geolocation and Accelerometer Sensors
+    path: /web/tools/chrome-devtools/device-mode/device-input-and-sensors
+  - title: Emulate and Test Other Browsers
+    path: /web/tools/chrome-devtools/device-mode/testing-other-browsers
+- title: Remote-Debug Android Devices
+  section:
+  - title: Get Started
+    path: /web/tools/chrome-devtools/remote-debugging/
+  - title: Access Local Servers
+    path: /web/tools/chrome-devtools/remote-debugging/local-server
+  - title: Remote Debugging WebViews
+    path: /web/tools/chrome-devtools/remote-debugging/webviews
+- title: Log Messages and Execute JavaScript in the Console
   section:
   - title: Overview
     path: /web/tools/chrome-devtools/console/
@@ -113,7 +90,7 @@ toc:
   - title: Diagnose Forced Synchronous Layouts
     path: /web/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts
     status: deprecated
-- title: Measure Network Performance
+- title: Analyze Network Performance
   section:
   - title: Get Started
     path: /web/tools/chrome-devtools/network-performance/
@@ -124,7 +101,7 @@ toc:
   - title: Resource Loading
     path: /web/tools/chrome-devtools/network-performance/resource-loading
     status: deprecated
-- title: Fix Memory Problems
+- title: Analyze Memory Problems
   section:
   - title: Overview
     path: /web/tools/chrome-devtools/memory-problems/
@@ -134,7 +111,32 @@ toc:
     path: /web/tools/chrome-devtools/memory-problems/heap-snapshots
   - title: Use the Allocation Profiler
     path: /web/tools/chrome-devtools/memory-problems/allocation-profiler
-- title: Extend the Chrome DevTools
+- title: Debug Progressive Web Apps
+  path: /web/tools/chrome-devtools/progressive-web-apps
+- title: Analyze Security Problems
+  path: /web/tools/chrome-devtools/security
+- title: Run Snippets of JavaScript From Any Page
+  path: /web/tools/chrome-devtools/snippets
+- title: View and Change HTML
+  section:
+  - title: Overview
+    path: /web/tools/chrome-devtools/inspect-styles/
+  - title: Inspect Animations
+    path: /web/tools/chrome-devtools/inspect-styles/animations
+  - title: Edit the DOM
+    path: /web/tools/chrome-devtools/inspect-styles/edit-dom
+  - title: Edit Styles
+    path: /web/tools/chrome-devtools/inspect-styles/edit-styles
+    status: deprecated
+- title: View and Change Storage and Resources
+  section:
+  - title: Inspect and Manage Storage, Databases, and Caches
+    path: /web/tools/chrome-devtools/manage-data/local-storage
+  - title: Inspect and Delete Cookies
+    path: /web/tools/chrome-devtools/manage-data/cookies
+  - title: Inspect Resources
+    path: /web/tools/chrome-devtools/manage-data/page-resources
+- title: Extend DevTools
   section:
   - title: Integrating with DevTools and Chrome
     path: https://developer.chrome.com/devtools/docs/integrating
@@ -145,3 +147,4 @@ toc:
   - title: Debugger Protocol
     path: https://developer.chrome.com/devtools/docs/debugger-protocol
     status: external
+

--- a/src/content/en/tools/chrome-devtools/index.md
+++ b/src/content/en/tools/chrome-devtools/index.md
@@ -4,6 +4,7 @@ description: Get started with Google Chrome's built-in web developer tools.
 
 {# wf_updated_on: 2018-02-23 #}
 {# wf_published_on: 2016-03-28 #}
+{# wf_blink_components: Platform>DevTools #}
 
 # Chrome DevTools {: .page-title }
 

--- a/src/content/en/tools/chrome-devtools/index.md
+++ b/src/content/en/tools/chrome-devtools/index.md
@@ -2,27 +2,60 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Get started with Google Chrome's built-in web developer tools.
 
-{# wf_updated_on: 2017-06-16 #}
+{# wf_updated_on: 2018-02-23 #}
 {# wf_published_on: 2016-03-28 #}
 
 # Chrome DevTools {: .page-title }
 
-Chrome DevTools is a set of authoring, debugging, and profiling tools built
-into Google Chrome.
+<div class="video-wrapper">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="G_P6rpRSr4g"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
-Note: Many of the DevTools docs are based on [Chrome Canary][canary], which
-provides the latest Chrome features.
+Chrome DevTools is a set of web developer tools built directly into the Google Chrome browser.
+DevTools can help you diagnose problems quickly, which ultimately helps you build better
+websites, faster.
 
-[canary]: https://www.google.com/intl/en/chrome/browser/canary.html
+With DevTools you can view and change any page, even the Google homepage, as the video
+demonstrates.
 
-## Open DevTools {: #open }
+## Get started {: #get-started }
 
-* Select **More Tools** > **Developer Tools** from Chrome's Main Menu.
-* Right-click a page element and select **Inspect**.
-* Press <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>I</kbd> (Mac) or
-  <kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> (Windows, Linux).
+Here are the recommended starting points for some of the most common ways that DevTools
+can help you build websites faster:
+
+* [Viewing and changing a page's styles](/web/tools/chrome-devtools/css/). Every developer goes
+  through this experience: you code some CSS, and then you view your page and... the styles
+  aren't being applied. Or, they look way different than you expect. This tutorial shows you how
+  to use DevTools to see how the browser is actually applying styles to HTML elements. It also
+  shows you how to change styles from DevTools, which applies the changes immediately without
+  needing to reload the page.
+* [Debugging JavaScript](/web/tools/chrome-devtools/javascript/). The first way that most
+  developers learn how to debug is to sprinkle `console.log()` commands throughout their code,
+  in order to infer where the code is going wrong. This tutorial shows you how to set breakpoints
+  in DevTools, which lets you pause in the middle of a page's execution and step through the
+  code one line at a time. While you're paused, you can inspect (and even change) the current
+  values of variables at that point in time. You may find that this workflow helps you
+  debug issues much faster than the `console.log()` method.
+* [Analyzing runtime performance](/web/tools/chrome-devtools/evaluate-performance/). If your
+  page is slow or janky, you can use DevTools to record everything that happens on the page,
+  and then analyze the results to learn how to optimize the page's performance.
+
+Browse the DevTools docs to learn about all the other things that DevTools can do for you.
+The docs are organized by common tasks.
+
+See [Join the DevTools community](#community) to learn about all the ways that you can
+get help with how to use DevTools, or help others. If you ever have ideas on how to improve these
+docs or the DevTools product itself, the DevTools team would love to hear your feedback!
 
 ## Discover DevTools {: #discover-devtools }
+
+The DevTools UI can be a little overwhelming... there's so many tabs! But, if you take some
+time to get familiar with each tab to understand what's possible, you may discover that DevTools
+can seriously boost your productivity.
+
+Note: In the DevTools docs, the top-level tabs are called panels.
 
 ### Device Mode {: #device-mode }
 
@@ -88,7 +121,7 @@ Optimize page load performance and debug request issues.
 
 <div style="clear:both;"></div>
 
-### Performance panel (previously Timeline panel) {: #performance }
+### Performance panel {: #performance }
 
 Note: In Chrome 58 the Timeline panel was renamed to the Performance panel.
 
@@ -106,7 +139,7 @@ various events that happen during the lifecycle of a site.
 
 <div style="clear:both;"></div>
 
-### Memory panel (previously Profiles panel) {: #memory }
+### Memory panel {: #memory }
 
 Note: In Chrome 58 the Profiles panel was renamed to the Memory panel.
 
@@ -142,7 +175,7 @@ Debug mixed content issues, certificate problems, and more.
 
 <div style="clear:both;"></div>
 
-## Get Involved (Bugs and Feature Requests) {: #community }
+## Join the DevTools community {: #community }
 
 <style>
   .cdt-but {


### PR DESCRIPTION
What's changed, or what was fixed?
- add get started section to devtools homepage and clarify devtools' value proposition
- polish the ToC

**Fixes:** N/A

**Target Live Date:** 2018-02-23

- [x] This has been reviewed and approved by @kaycebasques (myself)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
