### PR TITLE
Adds better redirects to payment articles

### DIFF
--- a/src/content/en/fundamentals/_redirects.yaml
+++ b/src/content/en/fundamentals/_redirects.yaml
@@ -111,8 +111,11 @@ redirects:
 - from: /web/fundamentals/native-hardware/capturing-images/
   to: /web/fundamentals/media/capturing-images/
 
-- from: /web/fundamentals/primers/payment-request/
-  to: /web/fundamentals/payments/
+- from: /web/fundamentals/primers/payment-request/...
+  to: /web/fundamentals/payments/...
+
+- from: /web/fundamentals/payments/android-pay
+  to: /pay/api/web/paymentrequest/tutorial
 
 - from: /web/fundamentals/feed.xml
   to: /web/fundamentals/rss.xml


### PR DESCRIPTION
What's changed, or what was fixed?
- Redirects to payment articles got better

One thing, I couldn't confirm redirect to `/pay/api/web/paymentrequest/tutorial` works thinking it might be developing environment issue. Let me know if this was a pure mistake.

**CC:** @petele
