### PR TITLE
[lighthouse] organize ToC by category

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -3,142 +3,156 @@ toc:
   path: /web/tools/lighthouse/
 - title: Scoring Guide
   path: /web/tools/lighthouse/scoring
-- heading: Audit Reference
-- title: Address Bar Matches Brand Colors
-  path: /web/tools/lighthouse/audits/address-bar
-- title: Avoids Application Cache
-  path: /web/tools/lighthouse/audits/appcache
-- title: Avoids console.time()
-  path: /web/tools/lighthouse/audits/console-time
-- title: Avoids Date.now()
-  path: /web/tools/lighthouse/audits/date-now
-- title: Avoids Deprecated APIs
-  path: /web/tools/lighthouse/audits/deprecated-apis
-- title: Avoids document.write()
-  path: /web/tools/lighthouse/audits/document-write
-- title: Avoids Enormous Network Payloads
-  path: /web/tools/lighthouse/audits/network-payloads
-- title: Avoids Mutation Events In Its Own Scripts
-  path: /web/tools/lighthouse/audits/mutation-events
-- title: Avoids Old CSS Flexbox
-  path: /web/tools/lighthouse/audits/old-flexbox
-- title: Avoids Requesting The Geolocation Permission On Page Load
-  path: /web/tools/lighthouse/audits/geolocation-on-load
-- title: Avoids Requesting The Notification Permission On Page Load
-  path: /web/tools/lighthouse/audits/notifications-on-load
-- title: Avoids Web SQL
-  path: /web/tools/lighthouse/audits/web-sql
-- title: Background and Foreground Colors Have Sufficient Contrast Ratio
-  path: /web/tools/lighthouse/audits/contrast-ratio
-- title: Buttons Have An Accessible Name
-  path: /web/tools/lighthouse/audits/button-name
-- title: Cache Contains start_url From Manifest
-  path: /web/tools/lighthouse/audits/cache-contains-start_url
-- title: Configured For A Custom Splash Screen
-  path: /web/tools/lighthouse/audits/custom-splash-screen
-- title: Consistently Interactive
-  path: /web/tools/lighthouse/audits/consistently-interactive
-- title: Contains Some Content When Its Scripts Are Not Available
-  path: /web/tools/lighthouse/audits/no-js
-- title: Content Sized Correctly for Viewport
-  path: /web/tools/lighthouse/audits/content-sized-correctly-for-viewport
-- title: Critical Request Chains
-  path: /web/tools/lighthouse/audits/critical-request-chains
-- title: Displays Images With Incorrect Aspect Ratio
-  path: /web/tools/lighthouse/audits/aspect-ratio
-- title: Document Does Not Have A Meta Description
-  path: /web/tools/lighthouse/audits/description
-- title: Document Doesn't Use Legible Font Sizes
-  path: /web/tools/lighthouse/audits/font-sizes
-- title: Element aria-* Attributes Are Allowed For This Role
-  path: /web/tools/lighthouse/audits/aria-allowed-attributes
-- title: Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent
-  path: /web/tools/lighthouse/audits/valid-aria-attributes
-- title: Element aria-* Attributes Have Valid Values
-  path: /web/tools/lighthouse/audits/valid-aria-values
-- title: Elements With ARIA Roles Have The Required aria-* Attributes
-  path: /web/tools/lighthouse/audits/required-aria-attributes
-- title: Enable Text Compression
-  path: /web/tools/lighthouse/audits/text-compression
-- title: Estimated Input Latency
-  path: /web/tools/lighthouse/audits/estimated-input-latency
-- title: Every Form Element Has A Label
-  path: /web/tools/lighthouse/audits/form-labels
-- title: Every Image Has An alt Attribute
-  path: /web/tools/lighthouse/audits/alt-attribute
-- title: First Interactive
-  path: /web/tools/lighthouse/audits/first-interactive
-- title: First Meaningful Paint
-  path: /web/tools/lighthouse/audits/first-meaningful-paint
-- title: Has A Viewport Meta Tag With width Or initial-scale
-  path: /web/tools/lighthouse/audits/has-viewport-meta-tag
-- title: Includes Front-End JavaScript Libraries With Known Security Vulnerabilities
-  path: /web/tools/lighthouse/audits/vulnerabilities
-- title: JavaScript Bootup Time Is Too High
-  path: /web/tools/lighthouse/audits/bootup
-- title: Keep Server Response Times Low
-  path: /web/tools/lighthouse/audits/ttfb
-- title: Links Do Not Have Descriptive Text
-  path: /web/tools/lighthouse/audits/descriptive-link-text
-- title: Manifest Contains Icons at Least 192px
-  path:  /web/tools/lighthouse/audits/manifest-contains-192px-icon
-- title: Manifest Contains background_color
-  path: /web/tools/lighthouse/audits/manifest-contains-background_color
-- title: Manifest Contains name
-  path: /web/tools/lighthouse/audits/manifest-contains-name
-- title: Manifest Contains short_name
-  path: /web/tools/lighthouse/audits/manifest-contains-short_name
-- title: Manifest Contains Start URL
-  path: /web/tools/lighthouse/audits/manifest-contains-start_url
-- title: Manifest Exists
-  path: /web/tools/lighthouse/audits/manifest-exists
-- title: Manifest's display Property Is Set
-  path: /web/tools/lighthouse/audits/manifest-has-display-set
-- title: Manifest's short_Name Won't Be Truncated When Displayed On Homescreen
-  path: /web/tools/lighthouse/audits/manifest-short_name-is-not-truncated
-- title: No Element Has A tabindex Attribute Greater Than 0
-  path: /web/tools/lighthouse/audits/tabindex
-- title: Offscreen Images
-  path: /web/tools/lighthouse/audits/offscreen-images
-- title: Opens External Anchors Using rel="noopener"
-  path: /web/tools/lighthouse/audits/noopener
-- title: Optimize Images
-  path: /web/tools/lighthouse/audits/optimize-images
-- title: Oversized Images
-  path: /web/tools/lighthouse/audits/oversized-images
-- title: Page has unsuccessful HTTP status code
-  path: /web/tools/lighthouse/audits/successful-http-code
-- title: Page Load Is Fast Enough On 3G
-  path: /web/tools/lighthouse/audits/fast-3g
-- title: Perceptual Speed Index
-  path: /web/tools/lighthouse/audits/speed-index
-- title: Prevents Users From Pasting Into Password Fields
-  path: /web/tools/lighthouse/audits/password-pasting
-- title: Redirects HTTP Traffic To HTTPS
-  path: /web/tools/lighthouse/audits/http-redirects-to-https
-- title: Registers A Service Worker
-  path: /web/tools/lighthouse/audits/registered-service-worker
-- title: Render-Blocking Resources
-  path: /web/tools/lighthouse/audits/blocking-resources
-- title: Responds With A 200 When Offline
-  path: /web/tools/lighthouse/audits/http-200-when-offline
-- title: Serve Images As WebP
-  path: /web/tools/lighthouse/audits/webp
-- title: Some Insecure Resources Can Be Upgraded To HTTPS
-  path: /web/tools/lighthouse/audits/mixed-content
-- title: Time to Interactive
-  path: /web/tools/lighthouse/audits/time-to-interactive
-- title: Unoptimized Images
-  path: /web/tools/lighthouse/audits/unoptimized-images
-- title: Uses An Excessive DOM Size
-  path: /web/tools/lighthouse/audits/dom-size
-- title: User Can Be Prompted To Install The Web App
-  path: /web/tools/lighthouse/audits/install-prompt
-- title: User Timing Marks and Measures
-  path: /web/tools/lighthouse/audits/user-timing
-- title: Uses HTTP/2 For Its Own Resources
-  path: /web/tools/lighthouse/audits/http2
-- title: Uses HTTPS
-  path: /web/tools/lighthouse/audits/https
-- title: Uses Passive Event Listeners To Improve Scrolling Performance
-  path: /web/tools/lighthouse/audits/passive-event-listeners
+- heading: Audit References
+- title: Performance
+  section:
+  - title: Consistently Interactive
+    path: /web/tools/lighthouse/audits/consistently-interactive
+  - title: Critical Request Chains
+    path: /web/tools/lighthouse/audits/critical-request-chains
+  - title: Enable Text Compression
+    path: /web/tools/lighthouse/audits/text-compression
+  - title: Estimated Input Latency
+    path: /web/tools/lighthouse/audits/estimated-input-latency
+  - title: First Interactive
+    path: /web/tools/lighthouse/audits/first-interactive
+  - title: First Meaningful Paint
+    path: /web/tools/lighthouse/audits/first-meaningful-paint
+  - title: Has Enormous Network Payloads
+    path: /web/tools/lighthouse/audits/network-payloads
+  - title: JavaScript Bootup Time Is Too High
+    path: /web/tools/lighthouse/audits/bootup
+  - title: Keep Server Response Times Low
+    path: /web/tools/lighthouse/audits/ttfb
+  - title: Offscreen Images
+    path: /web/tools/lighthouse/audits/offscreen-images
+  - title: Optimize Images
+    path: /web/tools/lighthouse/audits/optimize-images
+  - title: Oversized Images
+    path: /web/tools/lighthouse/audits/oversized-images
+  - title: Perceptual Speed Index
+    path: /web/tools/lighthouse/audits/speed-index
+  - title: Reduce Render-Blocking Scripts
+    path: /web/tools/lighthouse/audits/blocking-resources
+  - title: Reduce Render-Blocking Stylesheets
+    path: /web/tools/lighthouse/audits/blocking-resources
+  - title: Serve Images In Next-Gen Formats
+    path: /web/tools/lighthouse/audits/webp
+  - title: Time to Interactive
+    path: /web/tools/lighthouse/audits/time-to-interactive
+  - title: Unoptimized Images
+    path: /web/tools/lighthouse/audits/unoptimized-images
+  - title: User Timing Marks and Measures
+    path: /web/tools/lighthouse/audits/user-timing
+  - title: Uses An Excessive DOM Size
+    path: /web/tools/lighthouse/audits/dom-size
+- title: Progressive Web App
+  section:
+  - title: Address Bar Matches Brand Colors
+    path: /web/tools/lighthouse/audits/address-bar
+  - title: Cache Contains start_url From Manifest
+    path: /web/tools/lighthouse/audits/cache-contains-start_url
+  - title: Configured For A Custom Splash Screen
+    path: /web/tools/lighthouse/audits/custom-splash-screen
+  - title: Contains Some Content When Its Scripts Are Not Available
+    path: /web/tools/lighthouse/audits/no-js
+  - title: Content Sized Correctly for Viewport
+    path: /web/tools/lighthouse/audits/content-sized-correctly-for-viewport
+  - title: Has A Viewport Meta Tag With width Or initial-scale
+    path: /web/tools/lighthouse/audits/has-viewport-meta-tag
+  - title: Manifest Contains Icons at Least 192px
+    path:  /web/tools/lighthouse/audits/manifest-contains-192px-icon
+  - title: Manifest Contains background_color
+    path: /web/tools/lighthouse/audits/manifest-contains-background_color
+  - title: Manifest Contains name
+    path: /web/tools/lighthouse/audits/manifest-contains-name
+  - title: Manifest Contains short_name
+    path: /web/tools/lighthouse/audits/manifest-contains-short_name
+  - title: Manifest Contains Start URL
+    path: /web/tools/lighthouse/audits/manifest-contains-start_url
+  - title: Manifest Exists
+    path: /web/tools/lighthouse/audits/manifest-exists
+  - title: Manifest's display Property Is Set
+    path: /web/tools/lighthouse/audits/manifest-has-display-set
+  - title: Page Load Is Fast Enough On 3G
+    path: /web/tools/lighthouse/audits/fast-3g
+  - title: Redirects HTTP Traffic To HTTPS
+    path: /web/tools/lighthouse/audits/http-redirects-to-https
+  - title: Registers A Service Worker
+    path: /web/tools/lighthouse/audits/registered-service-worker
+  - title: Responds With A 200 When Offline
+    path: /web/tools/lighthouse/audits/http-200-when-offline
+  - title: User Can Be Prompted To Install The Web App
+    path: /web/tools/lighthouse/audits/install-prompt
+  - title: Uses HTTPS
+    path: /web/tools/lighthouse/audits/https
+- title: Accessibility
+  section:
+  - title: Background and Foreground Colors Have Sufficient Contrast Ratio
+    path: /web/tools/lighthouse/audits/contrast-ratio
+  - title: Buttons Have An Accessible Name
+    path: /web/tools/lighthouse/audits/button-name
+  - title: Element aria-* Attributes Are Allowed For This Role
+    path: /web/tools/lighthouse/audits/aria-allowed-attributes
+  - title: Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent
+    path: /web/tools/lighthouse/audits/valid-aria-attributes
+  - title: Element aria-* Attributes Have Valid Values
+    path: /web/tools/lighthouse/audits/valid-aria-values
+  - title: Elements With ARIA Roles Have The Required aria-* Attributes
+    path: /web/tools/lighthouse/audits/required-aria-attributes
+  - title: Every Form Element Has A Label
+    path: /web/tools/lighthouse/audits/form-labels
+  - title: Every Image Has An alt Attribute
+    path: /web/tools/lighthouse/audits/alt-attribute
+  - title: No Element Has A tabindex Attribute Greater Than 0
+    path: /web/tools/lighthouse/audits/tabindex
+- title: Best Practices
+  section:
+  - title: Avoids Application Cache
+    path: /web/tools/lighthouse/audits/appcache
+  - title: Avoids console.time()
+    path: /web/tools/lighthouse/audits/console-time
+  - title: Avoids Date.now()
+    path: /web/tools/lighthouse/audits/date-now
+  - title: Avoids Deprecated APIs
+    path: /web/tools/lighthouse/audits/deprecated-apis
+  - title: Avoids document.write()
+    path: /web/tools/lighthouse/audits/document-write
+  - title: Avoids Mutation Events In Its Own Scripts
+    path: /web/tools/lighthouse/audits/mutation-events
+  - title: Avoids Old CSS Flexbox
+    path: /web/tools/lighthouse/audits/old-flexbox
+  - title: Avoids Requesting The Geolocation Permission On Page Load
+    path: /web/tools/lighthouse/audits/geolocation-on-load
+  - title: Avoids Requesting The Notification Permission On Page Load
+    path: /web/tools/lighthouse/audits/notifications-on-load
+  - title: Avoids Web SQL
+    path: /web/tools/lighthouse/audits/web-sql
+  - title: Displays Images With Incorrect Aspect Ratio
+    path: /web/tools/lighthouse/audits/aspect-ratio
+  - title: Includes Front-End JavaScript Libraries With Known Security Vulnerabilities
+    path: /web/tools/lighthouse/audits/vulnerabilities
+  - title: Manifest's short_Name Won't Be Truncated When Displayed On Homescreen
+    path: /web/tools/lighthouse/audits/manifest-short_name-is-not-truncated
+  - title: Opens External Anchors Using rel="noopener"
+    path: /web/tools/lighthouse/audits/noopener
+  - title: Prevents Users From Pasting Into Password Fields
+    path: /web/tools/lighthouse/audits/password-pasting
+  - title: Some Insecure Resources Can Be Upgraded To HTTPS
+    path: /web/tools/lighthouse/audits/mixed-content
+  - title: Uses HTTPS
+    path: /web/tools/lighthouse/audits/https
+  - title: Uses HTTP/2 For Its Own Resources
+    path: /web/tools/lighthouse/audits/http2
+  - title: Uses Passive Event Listeners To Improve Scrolling Performance
+    path: /web/tools/lighthouse/audits/passive-event-listeners
+- title: SEO
+  section:
+  - title: Document Does Not Have A Meta Description
+    path: /web/tools/lighthouse/audits/description
+  - title: Document Doesn't Use Legible Font Sizes
+    path: /web/tools/lighthouse/audits/font-sizes
+  - title: Links Do Not Have Descriptive Text
+    path: /web/tools/lighthouse/audits/descriptive-link-text
+  - title: Page has unsuccessful HTTP status code
+    path: /web/tools/lighthouse/audits/successful-http-code


### PR DESCRIPTION
What's changed, or what was fixed?
- organizes the LH references under their respective categories

**Fixes:** N/A

**Target Live Date:** 2018-03-02

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
