### PR TITLE
Fix for loading third-party JS in TOC

### DIFF
--- a/src/content/en/fundamentals/performance/_toc.yaml
+++ b/src/content/en/fundamentals/performance/_toc.yaml
@@ -51,6 +51,10 @@ toc:
           step_group: perf-oce
         - title: JavaScript Start-up Optimization
           path: /web/fundamentals/performance/optimizing-content-efficiency/javascript-startup-optimization
+          step_group: perf-oce
+        - title: Loading Third-Party JavaScript
+          path: /web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript
+          step_group: perf-oce
         - title: Web Font Optimization
           path: /web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization
           step_group: perf-oce


### PR DESCRIPTION
What's changed, or what was fixed?

As part of #5837, I neglected to include the step group and correct TOC entry for the "Loading third-party JavaScript" article. This change adds the article to the TOC correctly.

**Target Live Date:** 2018-03-01

- [ ] This has been reviewed and approved by (addyo, minor change)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label. (I think this is content..might be infra)
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
