### PR TITLE
Fixed some broken images

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/automating-image-optimization/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/automating-image-optimization/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Image formats!
 
-{# wf_updated_on: 2018-02-21#}
+{# wf_updated_on: 2018-03-02#}
 {# wf_published_on: 2017-11-16 #}
 {# wf_blink_components: Blink>Image,Internals>Images,Internals>Images>Codecs #}
 

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/automating-image-optimization/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/automating-image-optimization/index.md
@@ -170,7 +170,7 @@ panel](/web/updates/2017/05/devtools-release-notes#lighthouse) in the Chrome
 DevTools:
 
 
-<img class="lazyload small" data-src="images/hbo.jpg" alt="Lighthouse audit for
+<img src="images/hbo.jpg" alt="Lighthouse audit for
         HBO.com, displaying image optimization recommendations" /> Lighthouse
         can audit for Web Performance, Best Practices and Progressive Web App
         features.
@@ -834,7 +834,7 @@ Butteraugli scores, before choosing something that fits the best balance of
 file- size and level.
 
 
-<img class="lazyload small" data-src="images/Modern-Image15.jpg"
+<img src="images/Modern-Image15.jpg"
         alt="butteraugli being run from the command line" /> All in all, it took
         me about 30m to setup Butteraugli locally after installing Bazel and
         getting a build of the C++ sources to correctly compile on my Mac. Using


### PR DESCRIPTION
What's changed, or what was fixed?

There doesn't appear to be any JavaScript on the page that lazy loads images with the `lazyload` class. And given that there are many images on the page, and only two use this class, it may be because this article was moved, and two `img` elements were not updated.
Also, the `small` class on the same two images doesn't seem to have any style associated with it, and it is not used on any other image on the page.
Therefore, the `lazyload` and `small` classes were removed from the two images, and `src` is now used instead of `data-src` to specify the image URL.

**CC:** @addyosmani, @petele
