### PR TITLE
Fixes a typo in one of Workbox's guides

### DIFF
--- a/src/content/en/tools/workbox/guides/handle-third-party-requests.md
+++ b/src/content/en/tools/workbox/guides/handle-third-party-requests.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to handle third party requests with Workbox.
 
-{# wf_updated_on: 2018-02-01 #}
+{# wf_updated_on: 2018-03-05 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -61,7 +61,7 @@ The user will be in a broken state.
 
 However, it’s not a bad thing to want to try and add some fault tolerance to
 these requests so Workbox will allow opaque responses to be cached with the
-`networkFirst` and `stalteWhileRevalidate` strategies. Since these strategies
+`networkFirst` and `staleWhileRevalidate` strategies. Since these strategies
 regularly update the cached response it’s much safer to cache them as
 hopefully a bad request will be short lived and used rarely.
 


### PR DESCRIPTION
**Fixes:** https://github.com/GoogleChrome/workbox/issues/1345

**Target Live Date:** 2018-03-08

- [ ] This has been reviewed and approved by (@gauntface )
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
