### PR TITLE
Link getImageData() correctly

### DIFF
--- a/src/content/en/updates/2018/03/emscripting-a-c-library.md
+++ b/src/content/en/updates/2018/03/emscripting-a-c-library.md
@@ -224,7 +224,7 @@ Looking at the [encoding API of
 libwebp](/speed/webp/docs/api#simple_encoding_api),
 it expects an array of bytes in RGB, RGBA, BGR or BGRA. Luckily, the Canvas API
 has
-`[getImageData()](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData)`,
+[getImageData()](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData),
 that gives us an
 [Uint8ClampedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray)
 containing the image data in RGBA:


### PR DESCRIPTION
Vas is das markdown boog?

some extra `...` got in the mix to mess up the HTML goodness.

**CC:** @petele
