### PR TITLE
Workbox "Getting Started" updates for v3

### DIFF
--- a/src/content/en/tools/workbox/get-started/_shared/create.md
+++ b/src/content/en/tools/workbox/get-started/_shared/create.md
@@ -13,11 +13,6 @@ logic, you need to write custom service worker code, and then inject the Workbox
 the service worker at build-time.
 
 1. Re-focus the tab containing your project source code.
-1. Open `package.json`.
-1. Click **Add Package**, type `workbox-sw`, then click on the matching package to install
-   that library.
-1. Write down the version number of `workbox-sw` that gets installed. You'll
-   need it later.
 1. Add the following line of code to the `init()` function in `app.js`.
 
     <pre class="prettyprint">function init() {
@@ -44,8 +39,7 @@ the service worker at build-time.
 1. Click **New File**, enter `src/sw.js`, then press <kbd>Enter</kbd>.
 1. Add the following code to `src/sw.js`.
 
-    <pre class="prettyprint">// TODO: Replace Xs.
-    importScripts('https://storage.googleapis.com/workbox-cdn/releases/X.X.X/workbox-sw.js');
+    <pre class="prettyprint">importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
     
     // Note: Ignore the error that Glitch raises about workbox being undefined.
     workbox.skipWaiting();
@@ -69,6 +63,3 @@ the service worker at build-time.
     <aside class="important">**Important**: `workbox.precaching.precacheAndRoute([])` is a
     placeholder keyword. At build-time, Workbox injects the list of files to cache into the
     array.</aside>
-
-1. Replace each `X` in `importScripts('.../X.X.X/workbox-sw.js')` with
-   the version number of `workbox-sw` in `package.json` that you noted earlier.

--- a/src/content/en/tools/workbox/get-started/_shared/create.md
+++ b/src/content/en/tools/workbox/get-started/_shared/create.md
@@ -45,16 +45,14 @@ the service worker at build-time.
 1. Add the following code to `src/sw.js`.
 
     <pre class="prettyprint">// TODO: Replace Xs.
-    importScripts('/node_modules/workbox-sw/build/importScripts/workbox-sw.prod.vX.X.X.js');
-
-    // Note: Ignore the error that Glitch raises about WorkboxSW being undefined.
-    const workbox = new WorkboxSW({
-      skipWaiting: true,
-      clientsClaim: true
-    });
-
-    workbox.router.registerRoute(
-      new RegExp('^https://hacker-news.firebaseio.com'),
+    importScripts('https://storage.googleapis.com/workbox-cdn/releases/X.X.X/workbox-sw.js');
+    
+    // Note: Ignore the error that Glitch raises about workbox being undefined.
+    workbox.skipWaiting();
+    workbox.clientsClaim();
+    
+    workbox.routing.registerRoute(
+      new RegExp('https://hacker-news.firebaseio.com'),
       workbox.strategies.staleWhileRevalidate()
     );
 
@@ -66,10 +64,11 @@ the service worker at build-time.
       event.waitUntil(self.registration.showNotification(title, options));
     });
 
-    workbox.precache([]);</pre>
+    workbox.precaching.precacheAndRoute([]);</pre>
 
-    <aside class="important">**Important**: `workbox.precache([])` is a placeholder keyword.
-    At build-time, Workbox injects the list of files to cache into the array.</aside>
+    <aside class="important">**Important**: `workbox.precaching.precacheAndRoute([])` is a
+    placeholder keyword. At build-time, Workbox injects the list of files to cache into the
+    array.</aside>
 
-1. Replace each `X` in `importScripts('.../workbox-sw.prod.vX.X.X.js')` with
+1. Replace each `X` in `importScripts('.../X.X.X/workbox-sw.js')` with
    the version number of `workbox-sw` in `package.json` that you noted earlier.

--- a/src/content/en/tools/workbox/get-started/_shared/end.md
+++ b/src/content/en/tools/workbox/get-started/_shared/end.md
@@ -24,8 +24,8 @@ The app is now all set to handle push notifications. Try it now:
 
 ### Optional: How service worker injection works {: #optional-injection }
 
-At the bottom of your custom service worker, you call `workbox.precache([])`. This is a
-placeholder. At build-time, the Workbox plugin replaces the empty array with the list
+At the bottom of your custom service worker, you call `workbox.precaching.precacheAndRoute([]);`.
+This is a placeholder. At build-time, the Workbox plugin replaces the empty array with the list
 of resources to precache. Your Workbox build configuration still determines what resources
 get precached.
 

--- a/src/content/en/tools/workbox/get-started/_shared/register.md
+++ b/src/content/en/tools/workbox/get-started/_shared/register.md
@@ -76,7 +76,7 @@ Your app now sort-of works offline. Try it now:
 
 The service worker code is generated based on your Workbox configuration.
 
-* `importScripts('workbox-sw.prod.vX.X.X.js')` imports Workbox's service
+* `importScripts('.../X.X.X/workbox-sw.js')` imports Workbox's service
   worker library. You can inspect this file from the **Sources** panel of
   DevTools.
 
@@ -88,9 +88,8 @@ The service worker code is generated based on your Workbox configuration.
       </figcaption>
     </figure>
 
-* The `fileManifest` array lists all of the resources that Workbox is
-  precaching. This list is determined by the `globDirectory`
-  and `globPatterns` properties in your Workbox configuration.
+* The `self.__precacheManifest` array lists all of the resources that Workbox is
+  precaching.
 * Each resource has a `revision` property. This is how Workbox determines
   when to update a resource. Each time you build your app, Workbox generates
   a hash based on the contents of the resource. If the contents change, then

--- a/src/content/en/tools/workbox/get-started/_shared/register.md
+++ b/src/content/en/tools/workbox/get-started/_shared/register.md
@@ -76,8 +76,8 @@ Your app now sort-of works offline. Try it now:
 
 The service worker code is generated based on your Workbox configuration.
 
-* `importScripts('.../X.X.X/workbox-sw.js')` imports Workbox's service
-  worker library. You can inspect this file from the **Sources** panel of
+* `importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');`
+  imports Workbox's service worker library. You can inspect this file from the **Sources** panel of
   DevTools.
 
     <figure>

--- a/src/content/en/tools/workbox/get-started/gulp.md
+++ b/src/content/en/tools/workbox/get-started/gulp.md
@@ -4,6 +4,7 @@ description: Learn how to make a gulp-based app work offline by adding Workbox t
 
 {# wf_updated_on: 2018-03-06 #}
 {# wf_published_on: 2017-11-17 #}
+{# wf_blink_components: N/A #}
 
 # Get Started With Workbox For Gulp {: .page-title }
 

--- a/src/content/en/tools/workbox/get-started/gulp.md
+++ b/src/content/en/tools/workbox/get-started/gulp.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Learn how to make a gulp-based app work offline by adding Workbox to it.
 
-{# wf_updated_on: 2017-11-17 #}
+{# wf_updated_on: 2018-03-06 #}
 {# wf_published_on: 2017-11-17 #}
 
 # Get Started With Workbox For Gulp {: .page-title }
@@ -91,25 +91,32 @@ Workbox is installed, but you're not using it in your gulp build process, yet.
     <strong>gulp.task('generate-service-worker', () => {
       return workbox.generateSW({
         globDirectory: dist,
-        globPatterns: ['\*\*\/\*.{html,js}'],
+        globPatterns: [
+          '\*\*/\*.{html,js}'
+        ],
         swDest: \`${dist}/sw.js\`,
         clientsClaim: true,
         skipWaiting: true
-      }).then(() => {
+      }).then(({warnings}) => {
+        // In case there are any warnings from workbox-build, log them.
+        for (const warning of warnings) {
+          console.warn(warning);
+        }
         console.info('Service worker generation completed.');
       }).catch((error) => {
-        console.warn('Service worker generation failed: ' + error);
+        console.warn('Service worker generation failed:', error);
       });
     });</strong>
 
-    gulp.task('default', () => {
+    gulp.task('default', (callback) => {
       ...
     });</pre>
 
-1. Call the Workbox task as the last step in your build process.
+1. Call the Workbox task as the second-to-last task in your build process (just before the
+`callback`).
     
-    <pre class="prettyprint">gulp.task('default', function () {
-      runSequence('clean', 'build', <strong>'generate-service-worker'</strong>);
+    <pre class="prettyprint">gulp.task('default', (callback) => {
+      runSequence('clean', 'build', <strong>'generate-service-worker',</strong> callback);
     });</pre>
 
 ### Optional: How the config works {: #optional-config }
@@ -149,13 +156,11 @@ that they had an internet connection.
     <pre class="prettyprint">gulp.task('generate-service-worker', () => {
       return workbox.generateSW({
         ...
-        <strong>runtimeCaching: [
-          {
-            urlPattern: new RegExp('https://hacker-news\.firebaseio\.com'),
-            handler: 'staleWhileRevalidate'
-          }
-        ]</strong>
-      }).then(() => {
+        <strong>runtimeCaching: [{
+          urlPattern: new RegExp('https://hacker-news.firebaseio.com'),
+          handler: 'staleWhileRevalidate'
+        }]</strong>
+      }).then(({warnings}) => {
         ...</pre>
 
 
@@ -173,10 +178,12 @@ that they had an internet connection.
     <pre class="prettyprint">gulp.task('generate-service-worker', () => {
       return workbox.generateSW({
         globDirectory: dist,
-        globPatterns: ['\*\*\/\*.{html,js}'],
+        globPatterns: [
+          '\*\*/\*.{html,js}'
+        ],
+        swDest: \`${dist}/sw.js\`,
         <strong>swSrc: \`${src}/sw.js\`,</strong>
-        swDest: \`${dist}/sw.js\`
-      }).then(() => {
+      }).then(({warnings}) => {
         ...</pre>
 
 1. Change `generateSW` to `injectManifest`.

--- a/src/content/en/tools/workbox/get-started/npm-script.md
+++ b/src/content/en/tools/workbox/get-started/npm-script.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Learn how to make an npm-script-based app work offline by adding Workbox to it.
 
-{# wf_updated_on: 2018-02-01 #}
+{# wf_updated_on: 2018-03-06 #}
 {# wf_published_on: 2017-12-27 #}
 {# wf_blink_components: N/A #}
 
@@ -75,29 +75,28 @@ refreshes, too.
 
 Workbox is installed, but you're not using it in your build process, yet.
 
-1. Click **New File**, type `workbox-cli-config.js`, then press <kbd>Enter</kbd>. 
-1. Add the following code to `workbox-cli-config.js`.
+1. Click **New File**, type `workbox-config.js`, then press <kbd>Enter</kbd>.
+1. Add the following code to `workbox-config.js`.
 
     <pre class="prettyprint">module.exports = {
-      "globDirectory": "./dist/",
-      "globPatterns": [
-        "\*\*/\*.html",
-        "\*\*/\*.js"
+      globDirectory: './dist/',
+      globPatterns: [
+        '\*\*/\*.{html,js}'
       ],
-      "swDest": "dist/sw.js",
-      "clientsClaim": true,
-      "skipWaiting": true
+      swDest: './dist/sw.js',
+      clientsClaim: true,
+      skipWaiting: true
     };</pre>
 
 1. Open `package.json`.
-1. Update your npm Script to call Workbox as the last step in your build process. The bold
+1. Update your npm `scripts` to call Workbox as the last step in your build process. The bold
    code is what you need to add.
 
      <pre class="prettyprint">{
        ...
        "scripts": {
          ...
-         "build": "npm run clean && npm run copy <strong>&& workbox generate:sw</strong>"
+         "build": "npm run clean && npm run copy <strong>&& workbox generateSW</strong>"
        }
        ...
      }</pre>
@@ -105,13 +104,13 @@ Workbox is installed, but you're not using it in your build process, yet.
 ### Optional: How the config works {: #optional-config }
 
 The `build` script in `package.json` controls how the app is built. The build script calls
-Workbox (`workbox generate:sw`) as the last step.
+Workbox (`workbox generateSW`) as the last step.
 
-The `workbox generate:sw` command automatically searches for a Workbox config file called
-`workbox-cli-config.js` in the current working directory. If it finds one, it uses that config.
+The `workbox generateSW` command automatically searches for a Workbox config file called
+`workbox-config.js` in the current working directory. If it finds one, it uses that config.
 Otherwise, a CLI wizard prompts you to configure how Workbox runs.
 
-The object that you define in `workbox-cli-config.js` configures how Workbox runs.
+The object that you define in `workbox-config.js` configures how Workbox runs.
 
 <<_shared/config.md>>
 
@@ -127,7 +126,7 @@ while offline, they'll be able to see the content from the last time
 that they had an internet connection.
 
 1. Re-focus the tab that shows you the source code of your project.
-1. Open `workbox-cli-config.js` again.
+1. Open `workbox-config.js` again.
 1. Add a `runtimeCaching` property to your Workbox configuration.
    `urlPattern` is a regular expression pattern telling Workbox which
    URLs to store locally. `handler` defines the caching strategy that Workbox
@@ -136,12 +135,10 @@ that they had an internet connection.
 
     <pre class="prettyprint">module.exports = {
       ...
-      <strong>"runtimeCaching":  [
-        {
-          "urlPattern": new RegExp('https://hacker-news.firebaseio.com'),
-          "handler": "staleWhileRevalidate"
-        }
-      ]</strong>
+      <strong>runtimeCaching: [{
+        urlPattern: new RegExp('https://hacker-news.firebaseio.com'),
+        handler: 'staleWhileRevalidate'
+      }]</strong>
     }</pre>
 
 
@@ -151,30 +148,29 @@ that they had an internet connection.
 
 <<_shared/create.md>>
 
-1. Open `workbox-cli-config.js`.
+1. Open `workbox-config.js`.
 1. Remove the `runtimeCaching`, `clientsClaim`, and `skipWaiting` properties.
    These are now handled in your service worker code.
 1. Add the `swSrc` property to instruct Workbox to inject its code into a custom service worker.
-   The complete `workbox-cli-config.js` file now looks like this:
+   The complete `workbox-config.js` file now looks like this:
 
     <pre class="prettyprint">module.exports = {
-      "globDirectory": "./dist/",
-      "globPatterns": [
-        "\*\*/\*.html",
-        "\*\*/\*.js"
+      globDirectory: './dist/',
+      globPatterns: [
+        '\*\*/\*.{html,js}'
       ],
-      "swDest": "dist/sw.js",
-      "swSrc": "src/sw.js"
+      swDest: './dist/sw.js',
+      swSrc: './src/sw.js'
     };</pre>
 
 1. Open `package.json`.
-1. In your build script, change `generate:sw` to `inject:manifest`.
+1. In your build script, change `generateSW` to `injectManifest`.
 
      <pre class="prettyprint">{
        ...
        "scripts": {
          ...
-         "build": "npm run clean && npm run copy && workbox <strong>inject:manifest</strong>"
+         "build": "npm run clean && npm run copy && workbox <strong>injectManifest</strong>"
        }
        ...
      }</pre>

--- a/src/content/en/tools/workbox/get-started/webpack.md
+++ b/src/content/en/tools/workbox/get-started/webpack.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Learn how to make a webpack-based app work offline by adding Workbox to it.
 
-{# wf_updated_on: 2017-11-16 #}
+{# wf_updated_on: 2018-03-06 #}
 {# wf_published_on: 2017-10-31 #}
 
 # Get Started With Workbox For Webpack {: .page-title }
@@ -93,10 +93,8 @@ Workbox is installed, but you're not using it in your webpack build process, yet
         filename: 'index.html',
         title: 'Get Started With Workbox For Webpack'
       }),
-      <strong>new workboxPlugin({
-        globDirectory: dist,
-        globPatterns: ['\*\*/\*.{html,js}'],
-        swDest: path.join(dist, 'sw.js'),
+      <strong>new workboxPlugin.GenerateSW({
+        swDest: 'sw.js',
         clientsClaim: true,
         skipWaiting: true,
       })</strong>
@@ -108,14 +106,22 @@ Workbox is installed, but you're not using it in your webpack build process, yet
 
 * `cleanPlugin` deletes `dist`, which is the path to the output directory.
 * `htmlPlugin` re-generates the HTML output and places it back in `dist`.
-* `workboxPlugin` inspects the contents of `dist` and generates
-  service worker code for caching the output. Since Workbox revisions
+* `workboxPlugin.GenerateSW` knows about the assets bundled by webpack, and generates
+  service worker code for caching those files. Since Workbox revisions
   each file based on its contents, Workbox should always be the last
   plugin you call.
 
-The object that you pass to `workboxPlugin` configures how Workbox runs.
+The object that you pass to `workboxPlugin.GenerateSW` configures how Workbox runs.
 
-<<_shared/config.md>>
+* `swDest` is where Workbox outputs the service worker that it generates. The parent directory for
+  this file will be based on your `output.path` webpack configuration.
+* `clientsClaim` instructs the latest service worker to take control of all
+  clients as soon as it's activated. See [clients.claim][claim].
+* `skipWaiting` instructs the latest service worker to activate as soon as it enters
+  the waiting phase. See [Skip the waiting phase][skip].
+  
+[skip]: /web/fundamentals/primers/service-workers/lifecycle#skip_the_waiting_phase
+[claim]: /web/fundamentals/primers/service-workers/lifecycle#clientsclaim
 
 <<_shared/register.md>>
 
@@ -140,37 +146,92 @@ that they had an internet connection.
    uses for any matching URL. See [The Offline Cookbook][cookbook] for more
    on caching strategies.
 
-    <pre class="prettyprint">new workboxPlugin({
-      globDirectory: dist,
-      globPatterns: ['**/*.{html,js}'],
-      swDest: path.join(dist, 'sw.js'),
+    <pre class="prettyprint">new workboxPlugin.GenerateSW({
+      swDest: 'sw.js',
       clientsClaim: true,
       skipWaiting: true,
-      <strong>runtimeCaching: [
-        {
-          urlPattern: new RegExp('https://hacker-news\.firebaseio\.com'),
-          handler: 'staleWhileRevalidate'
-        }
-      ]</strong>
+      <strong>runtimeCaching: [{
+        urlPattern: new RegExp('https://hacker-news.firebaseio.com'),
+        handler: 'staleWhileRevalidate'
+      }]</strong>
     })</pre>
 
 [cookbook]: /web/fundamentals/instant-and-offline/offline-cookbook/
 
 <<_shared/try-complete.md>>
 
-<<_shared/create.md>>
+## Step 6: Create your own service worker {: #inject }
+
+Up until now, you've been letting Workbox generate your entire service
+worker. If you've got a big project, or you want to customize how you cache
+certain resources, or do custom logic in your service worker,
+then you need to create a custom service worker that calls Workbox instead.
+Think of the service worker code you write as a template. You write your custom logic with
+placeholder keywords that instruct Workbox where to inject its code.
+
+In this section, you add push notification support in your service worker. Since this is custom
+logic, you need to write custom service worker code, and then inject the Workbox code into
+the service worker at build-time.
+
+1. Re-focus the tab containing your project source code.
+1. Add the following line of code to the `init()` function in `app.js`.
+
+    <pre class="prettyprint">function init() {
+      ...
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js').then(registration => {
+            console.log('SW registered: ', registration);
+            <strong>registration.pushManager.subscribe({userVisibleOnly: true});</strong>
+          }).catch(registrationError => {
+            ...
+          });
+        });
+      }
+    }</pre>
+
+    <aside class="warning">**Warning**: For simplicity, this demo asks for permission to
+    send push notifications as soon as the service worker is registered. Best practices
+    strongly recommend against out-of-context permission requests like this in real apps.
+    See [Permission UX][UX].</aside>
+
+[UX]: /web/fundamentals/push-notifications/permission-ux
+
+1. Click **New File**, enter `src/sw.js`, then press <kbd>Enter</kbd>.
+1. Add the following code to `src/sw.js`.
+
+    <pre class="prettyprint">workbox.skipWaiting();
+    workbox.clientsClaim();
+    
+    workbox.routing.registerRoute(
+      new RegExp('https://hacker-news.firebaseio.com'),
+      workbox.strategies.staleWhileRevalidate()
+    );
+
+    self.addEventListener('push', (event) => {
+      const title = 'Get Started With Workbox';
+      const options = {
+        body: event.data.text()
+      };
+      event.waitUntil(self.registration.showNotification(title, options));
+    });
+
+    workbox.precaching.precacheAndRoute(self.__precacheManifest);</pre>
+
+    <aside class="important">**Important**:
+    `workbox.precaching.precacheAndRoute(self.__precacheManifest)` reads a list of URLs to precache
+    from an externally defined variable, `self.__precacheManifest`. At build-time, Workbox injects
+    code needed set `self.__precacheManifest` to the correct list of URLs.</aside>
 
 1. Open `webpack.config.json`.
 1. Remove the `runtimeCaching`, `clientsClaim`, and `skipWaiting` properties from your Workbox
    plugin configuration. These are now handled in your service worker code.
-1. Add the `swSrc` property to your Workbox plugin configuration in `webpack.config.json`
-   to instruct Workbox to inject its code into a custom service worker. 
+1. Change the `GenerateSW` to `InjectManifest` and add the `swSrc` property to instruct Workbox to
+inject its code into a custom service worker.
 
-    <pre class="prettyprint">new workboxPlugin({
-      globDirectory: dist,
-      globPatterns: ['**/*.{html,js}'],
+    <pre class="prettyprint">new workboxPlugin.<strong>InjectManifest</strong>({
       <strong>swSrc: './src/sw.js',</strong>
-      swDest: path.join(dist, 'sw.js')
+      swDest: 'sw.js'
     })</pre>
 
 <<_shared/end.md>>

--- a/src/content/en/tools/workbox/get-started/webpack.md
+++ b/src/content/en/tools/workbox/get-started/webpack.md
@@ -4,6 +4,7 @@ description: Learn how to make a webpack-based app work offline by adding Workbo
 
 {# wf_updated_on: 2018-03-06 #}
 {# wf_published_on: 2017-10-31 #}
+{# wf_blink_components: N/A #}
 
 # Get Started With Workbox For Webpack {: .page-title }
 


### PR DESCRIPTION
This migrates the material in the Workbox getting started guides to use the new v3 syntax.

Adding the DO_NOT_MERGE label for now, as we want to time this following the official launch of Workbox v3.0.0.

**Fixes:** #5766

**Target Live Date:** 2018-03-08

- [ ] This has been reviewed and approved by (@kaycebasques)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @gauntface @addyosmani 
