### PR TITLE
Add translation out of date widget to some pt-br docs

### DIFF
--- a/src/content/pt-br/fundamentals/app-install-banners/index.md
+++ b/src/content/pt-br/fundamentals/app-install-banners/index.md
@@ -7,6 +7,8 @@ description: Existem dois tipos de banners de instalação de aplicativo: os web
 
 # Banners de instalação de aplicativo web {: .page-title }
 
+{% include "web/_shared/translation-out-of-date.html" %}
+
 {% include "web/_shared/contributors/mattgaunt.html" %}
 {% include "web/_shared/contributors/paulkinlan.html" %}
 
@@ -19,7 +21,7 @@ description: Existem dois tipos de banners de instalação de aplicativo: os web
 Há dois tipos de banner de instalação de aplicativo: os **web** e
 os [**nativos**](native-app-install). Eles permitem que os usuários adicionem seu aplicativo web ou nativo às telas iniciais de forma rápida e fácil sem sair do navegador.
 
-É muito fácil adicionar banners de instalação de aplicativo: o Chrome faz todo o trabalho duro 
+É muito fácil adicionar banners de instalação de aplicativo: o Chrome faz todo o trabalho duro
 para você. Você precisa incluir o arquivo de manifesto do aplicativo web no site
 com detalhes sobre o aplicativo.
 
@@ -86,20 +88,20 @@ banner de instalação de aplicativo e até mesmo cancelá-lo ou deferi-lo para 
 
 ### Um usuário instalou o aplicativo?
 
-O evento `beforeinstallprompt` retorna uma promessa chamada `userChoice` 
-que resolve quando o usuário executa uma ação em relação à solicitação.  A promessa 
+O evento `beforeinstallprompt` retorna uma promessa chamada `userChoice`
+que resolve quando o usuário executa uma ação em relação à solicitação.  A promessa
 retorna um objeto com um valor de `dismissed` no atributo `outcome`
 ou `accepted` se o usuário adicionou a página à tela inicial.
 
     window.addEventListener('beforeinstallprompt', function(e) {
       // beforeinstallprompt Event fired
-      
-      // e.userChoice will return a Promise. 
+
+      // e.userChoice will return a Promise.
       // For more details read: https://developers.google.com/web/fundamentals/getting-started/primers/promises
       e.userChoice.then(function(choiceResult) {
-        
+
         console.log(choiceResult.outcome);
-        
+
         if(choiceResult.outcome == 'dismissed') {
           console.log('User cancelled home screen install');
         }
@@ -108,63 +110,63 @@ ou `accepted` se o usuário adicionou a página à tela inicial.
         }
       });
     });
-    
 
-Essa é uma boa ferramenta para entender como seus usuários interagem com a solicitação 
+
+Essa é uma boa ferramenta para entender como seus usuários interagem com a solicitação
 de instalação de aplicativo.
 
 
 ### Retardando ou cancelando a solicitação
 
-O Chrome gerencia quando acionar a solicitação, mas, para alguns sites, isso pode não 
-ser o ideal. Você pode deferir a solicitação para um momento posterior no uso do aplicativo ou 
-mesmo cancelá-la. 
+O Chrome gerencia quando acionar a solicitação, mas, para alguns sites, isso pode não
+ser o ideal. Você pode deferir a solicitação para um momento posterior no uso do aplicativo ou
+mesmo cancelá-la.
 
-Quando o Chrome decide solicitar o usuário a instalar o aplicativo, você 
-pode evitar a ação padrão e armazenar o evento para um momento posterior. Então, quando 
-o usuário tiver uma interação positiva com seu site, você poderá acionar novamente 
-a solicitação chamando `prompt()` no evento armazenado. 
+Quando o Chrome decide solicitar o usuário a instalar o aplicativo, você
+pode evitar a ação padrão e armazenar o evento para um momento posterior. Então, quando
+o usuário tiver uma interação positiva com seu site, você poderá acionar novamente
+a solicitação chamando `prompt()` no evento armazenado.
 
-This causes Chrome to show the banner and all the Promise attributes 
-such as `userChoice` will be available to bind to so that you can understand 
+This causes Chrome to show the banner and all the Promise attributes
+such as `userChoice` will be available to bind to so that you can understand
 what action the user took.
-    
+
     var deferredPrompt;
-    
+
     window.addEventListener('beforeinstallprompt', function(e) {
       console.log('beforeinstallprompt Event fired');
       e.preventDefault();
-      
+
       // Stash the event so it can be triggered later.
       deferredPrompt = e;
-      
+
       return false;
     });
-    
+
     btnSave.addEventListener('click', function() {
       if(deferredPrompt !== undefined) {
         // The user has had a postive interaction with our app and Chrome
         // has tried to prompt previously, so let's show the prompt.
         deferredPrompt.prompt();
-      
+
         // Follow what the user has done with the prompt.
         deferredPrompt.userChoice.then(function(choiceResult) {
-      
+
           console.log(choiceResult.outcome);
-          
+
           if(choiceResult.outcome == 'dismissed') {
             console.log('User cancelled home screen install');
           }
           else {
             console.log('User added to home screen');
           }
-          
+
           // We no longer need the prompt.  Clear it up.
           deferredPrompt = null;
         });
       }
     });
-    
+
 
 Como alternativa, você pode cancelar a solicitação ao impedir a ação padrão.
 
@@ -173,7 +175,7 @@ Como alternativa, você pode cancelar a solicitação ao impedir a ação padrã
       e.preventDefault();
       return false;
     });
-    
+
 ## Banner de instalação de aplicativo nativo
 
 <div class="attempt-right">
@@ -212,7 +214,7 @@ plataformas de `play` (do Google Play) e o ID do aplicativo.
       "id": "com.google.samples.apps.iosched"
       }
     ]
-    
+
 
 Se só quiser oferecer ao usuário a possibilidade de instalar o seu
 aplicativo Android e não exibir o banner de instalação de aplicativo web, adicione

--- a/src/content/pt-br/fundamentals/payments/android-pay.md
+++ b/src/content/pt-br/fundamentals/payments/android-pay.md
@@ -7,6 +7,8 @@ description: O Android Pay oferece segurança e simplicidade para as compras on-
 
 # Como integrar o Android Pay ao Payment Request {: .page-title }
 
+{% include "web/_shared/translation-out-of-date.html" %}
+
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/sieke.html" %}
 

--- a/src/content/pt-br/fundamentals/payments/index.md
+++ b/src/content/pt-br/fundamentals/payments/index.md
@@ -7,6 +7,8 @@ description: A Payment Request API oferece pagamentos rápidos e fáceis na web.
 
 # Guia de integração da Payment Request API {: .page-title }
 
+{% include "web/_shared/translation-out-of-date.html" %}
+
 {% include "web/_shared/contributors/agektmr.html" %}
 {% include "web/_shared/contributors/dgash.html" %}
 {% include "web/_shared/contributors/zkoch.html" %}

--- a/src/content/pt-br/fundamentals/performance/rail.md
+++ b/src/content/pt-br/fundamentals/performance/rail.md
@@ -7,6 +7,8 @@ description: O RAIL é um modelo de desempenho centrado no usuário. Todo app da
 
 # Medição do desempenho com o modelo RAIL {: .page-title }
 
+{% include "web/_shared/translation-out-of-date.html" %}
+
 {% include "web/_shared/contributors/megginkearney.html" %}
 
 O RAIL é um modelo de desempenho centrado no usuário. Todo aplicativo web tem estes quatro aspectos distintos no seu ciclo de vida, e o desempenho se relaciona com eles de maneiras muito diferentes:
@@ -93,10 +95,10 @@ Seu objetivo é produzir 60 quadros por segundo, e todo quadro tem que passar pe
 
 ![Etapas para se renderizar um quadro](images/render-frame.png)
 
-De um ponto de vista puramente matemático, todo quadro tem um "orçamento" de cerca de 
+De um ponto de vista puramente matemático, todo quadro tem um "orçamento" de cerca de
 16 ms (1000 ms/60 quadros por segundo = 16,66 ms por quadro). Porém, como
 os navegadores precisam de algum tempo para exibir o novo quadro na tela, **o seu código
-deve finalizar a execução em até 10 ms**. 
+deve finalizar a execução em até 10 ms**.
 
 Em pontos de alta pressão, como as animações, a chave é não fazer nada
 onde for possível e absolutamente o mínimo onde não for possível não fazer nada. Sempre que der, use a
@@ -110,7 +112,7 @@ Para saber mais, acesse
 
 Use o tempo de ociosidade para concluir trabalhos adiados. Por exemplo, mantenha um mínimo de dados pré-carregados para que o aplicativo carregue rapidamente, e use o tempo de ociosidade para carregar os demais dados.
 
-Os trabalhos adiados devem ser agrupados em blocos de cerca de 50 ms. Caso um usuário comece a interagir, a prioridade é responder a isso. 
+Os trabalhos adiados devem ser agrupados em blocos de cerca de 50 ms. Caso um usuário comece a interagir, a prioridade é responder a isso.
 
 Para tornar possível uma <resposta de 100 ms,
 o aplicativo deve devolver o controle ao encadeamento principal a cada <50 ms,
@@ -166,7 +168,7 @@ Para avaliar o seu site com base nas métricas do RAIL, use a [ferramenta "Timel
       <td data-th="User Test">O usuário carrega a página e vê o conteúdo do caminho crítico.</td>
     </tr>
   </tbody>
-</table> 
+</table>
 
 
 

--- a/src/content/pt-br/fundamentals/web-app-manifest/index.md
+++ b/src/content/pt-br/fundamentals/web-app-manifest/index.md
@@ -7,16 +7,18 @@ description: O manifesto de um aplicativo web é um arquivo JSON que permite con
 
 # O manifesto do aplicativo web {: .page-title }
 
+{% include "web/_shared/translation-out-of-date.html" %}
+
 {% include "web/_shared/contributors/mattgaunt.html" %}
 {% include "web/_shared/contributors/paulkinlan.html" %}
 
 O [manifesto dos aplicativos web](https://developer.mozilla.org/en-US/docs/Web/Manifest) é um arquivo JSON que permite controlar como o aplicativo web ou site é exibido para o usuário em áreas que normalmente se espera ver aplicativos nativos (por exemplo, a tela inicial de um dispositivo), como definir o que o usuário pode inicializar e o visual durante a inicialização.
 
-Manifestos de app da Web fornecem a capacidade de salvar um site marcado como favorito na tela inicial de um dispositivo. Quando um site é iniciado dessa maneira: 
+Manifestos de app da Web fornecem a capacidade de salvar um site marcado como favorito na tela inicial de um dispositivo. Quando um site é iniciado dessa maneira:
 
 * Ele tem um ícone e um nome exclusivos para que os usuários possam distingui-los de outros sites.
 * Mostra algo ao usuário enquanto os recursos são baixados ou restaurados do cache.
-* Fornece características de exibição padrão ao navegador para evitar transição muito brusca quando os recursos do site ficam disponíveis. 
+* Fornece características de exibição padrão ao navegador para evitar transição muito brusca quando os recursos do site ficam disponíveis.
 
 Ele faz tudo isso com um mecanismo simples de metadados em um arquivo de texto. Esse é o manifesto de app da Web.
 
@@ -25,7 +27,7 @@ Observação: apesar de ser possível usar um manifesto de app da Web em qualque
 ### TL;DR {: .hide-from-toc }
 - Criar um manifesto e vinculá-lo à sua página são processos bem simples.
 - Controlar o que o usuário vê ao inicializar a partir da tela inicial.
-- Isso envolve coisas como uma tela de apresentação, cores do tema e até o URL que foi aberto. 
+- Isso envolve coisas como uma tela de apresentação, cores do tema e até o URL que foi aberto.
 
 ## Crie o manifesto
 
@@ -57,13 +59,13 @@ Você pode chamar o manifesto como quiser. A maioria das pessoas usa o nome `man
       ],
       "start_url": "index.html?launcher=true"
     }
-    
 
-Não deixe de incluir o seguinte: 
 
-* Um `short_name` para usar como o texto na tela inicial para os usuários.  
-* Um `name` para usar no banner de instalação de aplicativo web.  
-  
+Não deixe de incluir o seguinte:
+
+* Um `short_name` para usar como o texto na tela inicial para os usuários.
+* Um `name` para usar no banner de instalação de aplicativo web.
+
 
 ## Informe o navegador da presença do seu manifesto
 
@@ -72,18 +74,18 @@ uma tag `link` a todas as páginas que envolve o seu aplicativo web da seguinte 
 
 
     <link rel="manifest" href="/manifest.json">
-  
+
 ## Defina um URL inicial
 
 Se você não fornecer um `start_url`, a página atual será usada, o que
 provavelmente não é o que seus usuários querem. Mas esse não é o único motivo para
 incluir esse elemento. Como agora você pode definir como o seu aplicativo é inicializado, adicione um
-parâmetro de string de consulta ao `start_url` que indique como ele foi inicializado. 
+parâmetro de string de consulta ao `start_url` que indique como ele foi inicializado.
 
     "start_url": "/?utm_source=homescreen"
 
 Isso pode funcionar como você quiser. O valor que estamos usando tem a vantagem de ser relevante para o Google Analytics.
- 
+
 
 ## Personalize os ícones
 
@@ -113,7 +115,7 @@ Isso pode funcionar como você quiser. O valor que estamos usando tem a vantagem
         "type": "image/png",
         "sizes": "192x192"
       }],
-    
+
 
 Observação: ao salvar um ícone na tela inicial, o Chrome primeiro procura ícones que correspondam à densidade da tela e que sejam dimensionados de acordo com a densidade de 48 dp. Se não encontrar nenhum, ele procura o ícone que mais se aproxima das características do dispositivo. Se, por qualquer motivo, você quiser escolher um ícone específico para uma determinada densidade de pixels, pode usar o membro <code>density</code> opcional, que assume um número. Se você não declara a densidade, assume-se o padrão 1,0. Isso significa: "use esse ícone para densidades de tela de 1,0 ou mais", o que, em geral, é o que se deseja.
 
@@ -132,18 +134,18 @@ nos bastidores:
 3. Seu site é carregado pela rede (ou pelo cache, se tiver um service worker).
 
 Enquanto isso acontece, a tela fica branca e parece estar paralisada.
-Isso fica muito aparente quando se carrega a página da web pela rede, em que 
+Isso fica muito aparente quando se carrega a página da web pela rede, em que
 se leva mais de um ou dois segundos para que as páginas fiquem visíveis na página inicial.
 
-Para oferecer uma experiência melhor ao usuário, substitua a tela branca por um título, cores e imagens. 
+Para oferecer uma experiência melhor ao usuário, substitua a tela branca por um título, cores e imagens.
 
 ### Defina uma imagem e um título
 
-Se você acompanhou tudo desde o início, já deve ter definido uma imagem e um título. O Chrome infere a imagem e o título de membros específicos do manifesto. O que importa é saber os detalhes específicos. 
+Se você acompanhou tudo desde o início, já deve ter definido uma imagem e um título. O Chrome infere a imagem e o título de membros específicos do manifesto. O que importa é saber os detalhes específicos.
 
 A imagem de uma tela de apresentação é delineada a partir da matriz `icons`. O Chrome escolhe a imagem mais próxima de 128 dp para o dispositivo. O título é simplesmente retirado do membro `name`.
 
-### Defina a cor do fundo 
+### Defina a cor do fundo
 
 Especifique a cor do fundo usando a propriedade `background_color`
 , cujo nome é bastante apropriado. O Chrome usa essa cor no exato momento em que o aplicativo web é inicializado,
@@ -153,7 +155,7 @@ Para definir a cor do fundo, aplique o seguinte ao seu manifesto:
 
 
     "background_color": "#2196F3",
-    
+
 
 Agora, não aparecerá uma tela branca enquanto seu aplicativo é inicializado a partir da tela inicial.
 
@@ -182,13 +184,13 @@ Você pode fazer seu aplicativo web esconder a interface do navegador definindo 
 
 
     "display": "standalone"
-    
+
 
 Se acha que os usuários prefeririam ver a página como um site normal no navegador, basta definir o tipo `display` como `browser`:
 
 
     "display": "browser"
-    
+
 <div style="clear:both;"></div>
 
 ### Especifique a orientação inicial da página
@@ -198,15 +200,15 @@ Se acha que os usuários prefeririam ver a página como um site normal no navega
   <figcaption>Opções de orientação do manifesto de app da Web</figcaption>
 </figure>
 
-Você pode impor uma orientação específica, o que é vantajoso para aplicativos 
-que funcionam em apenas uma orientação, como jogos, por exemplo. Use essa opção 
+Você pode impor uma orientação específica, o que é vantajoso para aplicativos
+que funcionam em apenas uma orientação, como jogos, por exemplo. Use essa opção
 de forma seletiva. Os usuários preferem selecionar a orientação
 
 
     "orientation": "landscape"
 
 <div style="clear:both;"></div>
-    
+
 
 ## Forneça uma cor de tema para todo o site
 
@@ -217,9 +219,9 @@ de forma seletiva. Os usuários preferem selecionar a orientação
 
 O Chrome introduziu o conceito de uma cor de tema para seu site em 2014. A cor de tema
 é uma dica da sua página da Web que informa o navegador qual cor usar para os
-[elementos da IU, como a barra de endereços](/web/fundamentals/design-and-ux/browser-customization/).  
+[elementos da IU, como a barra de endereços](/web/fundamentals/design-and-ux/browser-customization/).
 
-Sem um manifesto, você precisará definir a cor de tema em cada página e, se 
+Sem um manifesto, você precisará definir a cor de tema em cada página e, se
 tiver um site grande ou legado, não é viável fazer muitas alterações que englobem todo o site.
 
 <div style="clear:both;"></div>
@@ -230,7 +232,7 @@ pela tela inicial, todas as páginas do domínio terão a mesma cor de tema auto
 
 
     "theme_color": "#2196F3"
-    
+
 
 <figure>
   <img src="images/manifest-display-options.png" alt="cor do fundo">


### PR DESCRIPTION
What's changed, or what was fixed?
- adds `translation-out-of-date.html` widget to some pt-br docs

[WF_IGNORE:SKIP_TYPOS]
