### PR TITLE
broadcastUpdate.Plugin channelName new syntax applied in Migration from v2 guide

### DIFF
--- a/src/content/en/tools/workbox/guides/migrations/migrate-from-v2.md
+++ b/src/content/en/tools/workbox/guides/migrations/migrate-from-v2.md
@@ -237,9 +237,7 @@ has a v3 equivalent of:
 
 ```js
 workbox.precaching.addPlugins([
-    new workbox.broadcastUpdate.Plugin({
-      channelName: 'precache-updates',
-    })
+    new workbox.broadcastUpdate.Plugin('precache-updates')
 ]);
 
 workbox.precaching.precacheAndRoute([...], {


### PR DESCRIPTION
What's changed, or what was fixed?
- broadcastUpdate.Plugin channelName new syntax applied

**CC:** @jeffposnick 
