### PR TITLE
broadcastUpdate.Plugin channelName new syntax applied

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-broadcast-cache-update.md
+++ b/src/content/en/tools/workbox/modules/workbox-broadcast-cache-update.md
@@ -59,9 +59,7 @@ workbox.routing.registerRoute(
   new RegExp('/api/'),
   workbox.strategies.staleWhileRevalidate({
     plugins: [
-      new workbox.broadcastUpdate.Plugin({
-        channelName: 'api-updates',
-      })
+      new workbox.broadcastUpdate.Plugin('api-updates')
     ]
   })
 );
@@ -121,10 +119,10 @@ workbox.routing.registerRoute(
   new RegExp('/api/'),
   workbox.strategies.staleWhileRevalidate({
     plugins: [
-      new workbox.broadcastUpdate.Plugin({
-        channelName: 'api-updates',
+      new workbox.broadcastUpdate.Plugin(
+        'api-updates',
         headersToCheck: ['X-My-Custom-Header']
-      })
+      )
     ]
   })
 );


### PR DESCRIPTION
What's changed, or what was fixed?
- broadcastUpdate.Plugin channelName new syntax applied

**CC:** @jeffposnick 
