### PR TITLE
Cleans up a few issues with the module docs for the Workbox build tools

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/groups/base-schema.html
+++ b/src/content/en/tools/workbox/_shared/config/groups/base-schema.html
@@ -1,5 +1,3 @@
-{% include "web/tools/workbox/_shared/config/single/swDest.html" %}
-
 {% include "web/tools/workbox/_shared/config/single/globDirectory.html" %}
 
 {% include "web/tools/workbox/_shared/config/single/globFollow.html" %}

--- a/src/content/en/tools/workbox/_shared/config/groups/common-webpack.html
+++ b/src/content/en/tools/workbox/_shared/config/groups/common-webpack.html
@@ -1,3 +1,5 @@
+{% include "web/tools/workbox/_shared/config/webpack-single/swDest.html" %}
+
 {% include "web/tools/workbox/_shared/config/single/importWorkboxFrom.html" %}
 
 {% include "web/tools/workbox/_shared/config/webpack-single/chunks.html" %}

--- a/src/content/en/tools/workbox/_shared/config/single/swSrc.html
+++ b/src/content/en/tools/workbox/_shared/config/single/swSrc.html
@@ -12,12 +12,12 @@
     </p>
     <p><strong>In Node</strong></p>
     <p>
-      The file should include a call to a
+      Your service worker file should include a call to a
       <a href="/web/tools/workbox/reference-docs/prerelease/workbox.precaching"></a><code>workbox.precaching</code>
       method that makes use of the injected precache manifest.
     </p>
     <p><strong>In Webpack</strong></p>
-    <p>Your sw file should ycan reference the <code>self.__precacheManifest</code> variable to obtain a list of
+    <p>Your service worker file should reference the <code>self.__precacheManifest</code> variable to obtain a list of
     <a href="/web/tools/workbox/reference-docs/prerelease/module-workbox-build#.ManifestEntry"><code>ManifestEntry</code>s</a>
     obtained as part of the compilation: <code>workbox.precaching.precacheAndRoute(self.__precacheManifest)</code></p>
     <p>

--- a/src/content/en/tools/workbox/modules/_toc.yaml
+++ b/src/content/en/tools/workbox/modules/_toc.yaml
@@ -28,7 +28,7 @@ toc:
 - heading: Node Modules
 - title: Workbox CLI
   path: /web/tools/workbox/modules/workbox-cli
-# - title: workbox-build
-#  path: /web/tools/workbox/modules/workbox-build
+- title: workbox-build
+  path: /web/tools/workbox/modules/workbox-build
 - title: workbox-webpack-plugin
   path: /web/tools/workbox/modules/workbox-webpack-plugin

--- a/src/content/en/tools/workbox/modules/workbox-build.md
+++ b/src/content/en/tools/workbox/modules/workbox-build.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-build.
 
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-03-15 #}
 {# wf_published_on: 2018-01-31 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -54,6 +54,7 @@ configuration.
 
 <table class="responsive">
   <tbody>
+{% include "web/tools/workbox/_shared/config/single/swDest.html" %}
 {% include "web/tools/workbox/_shared/config/groups/common-generate-schema.html" %}
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
@@ -85,6 +86,7 @@ it into your existing service worker file.
 
 <table class="responsive">
   <tbody>
+{% include "web/tools/workbox/_shared/config/single/swDest.html" %}
 {% include "web/tools/workbox/_shared/config/groups/common-inject-schema.html" %}
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>

--- a/src/content/en/tools/workbox/modules/workbox-cli.md
+++ b/src/content/en/tools/workbox/modules/workbox-cli.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-cli.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-03-15 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox CLI  {: .page-title }
@@ -203,6 +203,7 @@ The remaining options are used by both commands.
     <tr>
       <th colspan="2">Used by both `generateSW` and `injectManifest`.</th>
     </tr>
+{% include "web/tools/workbox/_shared/config/single/swDest.html" %}
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>


### PR DESCRIPTION
What's changed, or what was fixed?
- There was a custom definition for `swDest` for the webpack plugins, but it was not included in the webpack docs. This breaks things out so that the webpack and the non-webpack docs each have the correct `swDest` definition.
- There were a few typos that I found in the `swSrc` description.
- The entry for the `workbox-build` module was erroneously commented out in the TOC.

**Fixes:** This is related to https://github.com/GoogleChrome/workbox/issues/1363

**Target Live Date:** 2018-03-16

- [ ] This has been reviewed and approved by (@gauntface)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
