### PR TITLE
Update security.md

### DIFF
--- a/src/content/en/tools/chrome-devtools/security.md
+++ b/src/content/en/tools/chrome-devtools/security.md
@@ -17,7 +17,6 @@ to debug security issues and ensure that you have properly implemented
 HTTPS on your websites.
 
 
-### TL;DR {: .hide-from-toc }
 - Use the Security Overview to instantly find out whether the current page is secure or non-secure.
 - Inspect individual origins to view connection and certificate details (for secure origins) or to find out exactly which requests are unprotected (for non-secure origins).
 


### PR DESCRIPTION
Delete h3 'TL;DR' after first paragraph.
Already hidden from TOC.  No clear intention, reads fine without it.
Alternatively: change 'TL;DR' text to 'For example:'

**Fixes:** #issue - trivial typo, no issue created

**Target Live Date:** YYYY-MM-DD

- [x ] I previewed the change on my Win DevTools.
- [x ] I have added the appropriate `type-something` label - here and on patch

**CC:** @petele
