### PR TITLE
More Workbox docs fixes

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/single/globPatterns.html
+++ b/src/content/en/tools/workbox/_shared/config/single/globPatterns.html
@@ -5,7 +5,9 @@
   <td>
     <p>
       <em>Optional <code>Array</code> of <code>String</code>, defaulting to
-        <code>['**/*.{js,css,html}']</code></em>
+        either <code>['**/*.{js,css,html}']</code>
+        (for <code>workbox-build</code> and <code>workbox-cli</code>) or <code>[]</code>
+        (for <code>workbox-webpack-plugin</code>)</em>
     </p>
     <p>
       Files matching against any of these patterns will be included in the precache manifest.
@@ -13,6 +15,13 @@
     <p>
       For more information, see the
       <a href="https://github.com/isaacs/node-glob#glob-primer" class="external">glob primer</a>.
+    </p>
+    <p>
+      <strong>Note:</strong> Setting <code>globPatterns</code> is often unnecessary when using the
+      <code>workbox-webpack-plugin</code>, which will automatically precache files that are part of
+      the webpack build pipeline by default. When using the webpack plugin, only set it when you
+      need to cache
+      <a href="/web/tools/workbox/modules/workbox-webpack-plugin#cache_additional_non-webpack_assets">non-webpack assets</a>.
     </p>
     <p>
       <strong>Example:</strong>

--- a/src/content/en/tools/workbox/guides/_toc.yaml
+++ b/src/content/en/tools/workbox/guides/_toc.yaml
@@ -34,7 +34,7 @@ toc:
   - title: "Gulp or Node"
     path: /web/tools/workbox/guides/generate-service-worker/workbox-build
   - title: "Webpack"
-    path: /web/tools/workbox/guides/generate-service-workers/webpack
+    path: /web/tools/workbox/guides/generate-service-worker/webpack
 - title: "Codelabs"
   style: accordion
   section:

--- a/src/content/en/tools/workbox/guides/generate-service-worker/webpack.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/webpack.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to generate a complete service worker with the Workbox Webpack Plugin.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-03-19 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Generate a Service Worker with Webpack {: .page-title }
@@ -28,7 +28,7 @@ module.exports = {
   plugins: [
     // Other plugins...
 
-    WorkboxPlugin.GenerateSW()
+    new WorkboxPlugin.GenerateSW()
   ]
 };
 ```
@@ -66,7 +66,7 @@ module.exports = {
   plugins: [
     // Other plugins...
 
-    WorkboxPlugin.GenerateSW({
+    new WorkboxPlugin.GenerateSW({
       // Exclude images from the precache
       exclude: [/\.(?:png|jpg|jpeg|svg)$/],
 

--- a/src/content/en/tools/workbox/guides/migrations/migrate-from-v2.md
+++ b/src/content/en/tools/workbox/guides/migrations/migrate-from-v2.md
@@ -447,7 +447,7 @@ between modes explicit, vs. the v2 behavior where behavior changed based on the 
 - By default, assets in the webpack compilation pipeline will be precached, and it is no longer
 necessary to configure `globPatterns`. The only reason to continue using `globPatterns` is if you
 need to precache assets that are
-[not included](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#cache_additional_non-webpack_assets)
+[not included](/web/tools/workbox/modules/workbox-webpack-plugin#cache_additional_non-webpack_assets)
 in your webpack build. In general, when migrating to the v3 plugin, you should start by removing all
 of your previous `glob`-based configuration, and only re-add it if you specifically need it.
 

--- a/src/content/en/tools/workbox/guides/migrations/migrate-from-v2.md
+++ b/src/content/en/tools/workbox/guides/migrations/migrate-from-v2.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to migrating from Workbox v2 to v3.
 
-{# wf_updated_on: 2018-03-14 #}
+{# wf_updated_on: 2018-03-19 #}
 {# wf_published_on: 2018-03-08 #}
 {# wf_blink_components: N/A #}
 
@@ -443,6 +443,13 @@ updated API surface.
 
 - The API now exposes two classes, `GenerateSW` and `InjectManifest`. This makes the toggling
 between modes explicit, vs. the v2 behavior where behavior changed based on the presence of `swSrc`.
+
+- By default, assets in the webpack compilation pipeline will be precached, and it is no longer
+necessary to configure `globPatterns`. The only reason to continue using `globPatterns` is if you
+need to precache assets that are
+[not included](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#cache_additional_non-webpack_assets)
+in your webpack build. In general, when migrating to the v3 plugin, you should start by removing all
+of your previous `glob`-based configuration, and only re-add it if you specifically need it.
 
 ## Getting help
 

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -165,6 +165,6 @@ in-memory file system is used.
 
 ## Extra Info
 
-Guidance on using the plugins within the context of a larger webpack build can
-be found in the "[Progressive Web Application](https://webpack.js.org/guides/progressive-web-application/)" section of the
-webpack documentation.
+Guidance on using the plugins within the context of a larger webpack build can be found in the
+"[Progressive Web Application](https://webpack.js.org/guides/progressive-web-application/)" section
+of the webpack documentation.

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-webpack-plugin.
 
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-03-19 #}
 {# wf_published_on: 2017-12-15 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -45,7 +45,7 @@ module.exports = {
   // Other webpack config...
   plugins: [
     // Other plugins...
-    GenerateSW()
+    new GenerateSW()
   ]
 };
 ```
@@ -68,7 +68,7 @@ module.exports = {
   // Other webpack config...
   plugins: [
     // Other plugins...
-    GenerateSW({
+    new GenerateSW({
       option: 'value',
     })
   ]
@@ -101,7 +101,7 @@ module.exports = {
   // Other webpack config...
   plugins: [
     // Other plugins...
-    InjectManifest({
+    new InjectManifest({
       swSrc: './src/sw.js',
     })
   ]
@@ -125,7 +125,7 @@ module.exports = {
   // Other webpack config...
   plugins: [
     // Other plugins...
-    InjectManifest({option: 'value'})
+    new InjectManifest({option: 'value'})
   ]
 };
 ```


### PR DESCRIPTION
This fixes a few typos/issues with the Workbox focs.

I also expanded a bit in the migration guide for the webpack plugin to address a common issue that seems to be cropping up, related to the use of `globPatterns` in v3.

**Fixes:**
https://github.com/GoogleChrome/workbox/issues/1378
https://github.com/GoogleChrome/workbox/issues/1379

**Target Live Date:** 2018-03-21

- [ ] This has been reviewed and approved by (@gauntface)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
