### PR TITLE
Fix 404s due to Workbox codelabs migration

### DIFF
--- a/src/content/en/tools/workbox/guides/codelabs/_shared/end.md
+++ b/src/content/en/tools/workbox/guides/codelabs/_shared/end.md
@@ -11,7 +11,7 @@ The app is now all set to handle push notifications. Try it now:
    displays a push notification from the app.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/push.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/push.png"
          alt="Simulating a push notification from DevTools"/>
        <figcaption>
          <b>Figure 11</b>. Simulating a push notification from DevTools

--- a/src/content/en/tools/workbox/guides/codelabs/_shared/register.md
+++ b/src/content/en/tools/workbox/guides/codelabs/_shared/register.md
@@ -26,7 +26,7 @@ your app, yet.
 1. Click the **Service Workers** tab.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/sw-pane.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/sw-pane.png"
          alt="The Service Workers pane"/>
        <figcaption>
          <b>Figure 6</b>. The Service Workers pane
@@ -37,7 +37,7 @@ your app, yet.
    service worker code that Workbox generated. It should look close to this:
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/sources.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/sources.png"
          alt="The generated service worker code"/>
        <figcaption>
          <b>Figure 7</b>. The generated service worker code
@@ -63,7 +63,7 @@ Your app now sort-of works offline. Try it now:
    this resource, yet.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/offline-capable.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/offline-capable.png"
          alt="The incomplete offline experience"/>
        <figcaption>
          <b>Figure 8</b>. The incomplete offline experience
@@ -81,7 +81,7 @@ The service worker code is generated based on your Workbox configuration.
   DevTools.
 
     <figure>
-      <img src="/web/tools/workbox/get-started/imgs/shared/lib-src.png"
+      <img src="/web/tools/workbox/guides/codelabs/imgs/shared/lib-src.png"
         alt="The code for Workbox's service worker library"/>
       <figcaption>
         <b>Figure 9</b>. The code for Workbox's service worker library

--- a/src/content/en/tools/workbox/guides/codelabs/_shared/try-complete.md
+++ b/src/content/en/tools/workbox/guides/codelabs/_shared/try-complete.md
@@ -10,7 +10,7 @@ The app now provides a complete offline experience. Try it now:
    the page, and then try again.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/offline-complete.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/offline-complete.png"
          alt="The complete offline experience"/>
        <figcaption>
          <b>Figure 10</b>. The complete offline experience

--- a/src/content/en/tools/workbox/guides/codelabs/_shared/try-initial.md
+++ b/src/content/en/tools/workbox/guides/codelabs/_shared/try-initial.md
@@ -11,7 +11,7 @@ service workers](http://caniuse.com/#search=service%20workers).
 1. Click **Show**. The live app appears in a new tab.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/live.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/live.png"
          alt="The live app"/>
        <figcaption>
          <b>Figure 2</b>. The live app
@@ -29,7 +29,7 @@ service workers](http://caniuse.com/#search=service%20workers).
    Chrome now has no connection to the Internet in this tab.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/offline.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/offline.png"
          alt="The 'Go Offline' command"/>
        <figcaption>
          <b>Figure 3</b>. The <b>Go Offline</b> command
@@ -40,7 +40,7 @@ service workers](http://caniuse.com/#search=service%20workers).
    the app doesn't work at all when offline.
 
      <figure>
-       <img src="/web/tools/workbox/get-started/imgs/shared/no-internet.png"
+       <img src="/web/tools/workbox/guides/codelabs/imgs/shared/no-internet.png"
          alt="The initial app doesn't work at all when offline"/>
        <figcaption>
          <b>Figure 4</b>. The initial app doesn't work at all when offline

--- a/src/content/en/tools/workbox/guides/codelabs/webpack.md
+++ b/src/content/en/tools/workbox/guides/codelabs/webpack.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Learn how to make a webpack-based app work offline by adding Workbox to it.
 
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-03-19 #}
 {# wf_published_on: 2017-10-31 #}
 {# wf_blink_components: N/A #}
 
@@ -13,7 +13,7 @@ description: Learn how to make a webpack-based app work offline by adding Workbo
 In this codelab, you use Workbox to make a simple web app work offline.
 
 If you'd like a conceptual overview of Workbox before starting this tutorial,
-see the [Overview](/web/tools/workbox/overview).
+see the [overview](/web/tools/workbox/).
 
 ## Step 1: Set up your project {: #setup }
 


### PR DESCRIPTION
R: @petele 
CC: @gauntface @kaycebasques 

https://github.com/google/WebFundamentals/pull/5907 inadvertently broke a few URLs when it migrated Workbox content over to `/web/tools/workbox/guides/codelabs/`