### PR TITLE
Consistently capitalize “the Web”

### DIFF
--- a/src/content/en/updates/2018/03/smooshgate.md
+++ b/src/content/en/updates/2018/03/smooshgate.md
@@ -127,10 +127,10 @@ working, that’s bad for *everyone*:
   of fiction”](https://www.webstandards.org/2009/05/13/interview-with-ian-hickson-editor-of-the-html-5-specification/#about-browsers)),
   which is bad for the standardization process.
 
-Sure, in retrospect MooTools did the wrong thing — but breaking the web
+Sure, in retrospect MooTools did the wrong thing — but breaking the Web
 doesn’t punish them, it punishes users. These users do not know what a moo
 tool is. Alternatively, we can find another solution, and users can continue
-to use the web. The choice is easy to make.
+to use the Web. The choice is easy to make.
 
 ## Does that mean bad APIs can never be removed from the Web Platform? {: #removing-apis }
 


### PR DESCRIPTION
Thanks to @tomayac for pointing this out.

**Target Live Date:** 2018-03-20

- [x] This has been reviewed and approved by @tomayac
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
