### PR TITLE
s/vp9/vp09.00.10.08/g

### DIFF
--- a/src/content/en/fundamentals/media/eme.md
+++ b/src/content/en/fundamentals/media/eme.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Enabling HTTPS on your servers is critical to securing your webpages.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-03-20 #}
 {# wf_published_on: 2014-01-16 #}
 {# wf_blink_components: Blink>Media #}
 
@@ -196,7 +196,7 @@ from a license server.
     var video = document.querySelector('video');
 
     var config = [{initDataTypes: ['webm'],
-      videoCapabilities: [{contentType: 'video/webm; codecs="vp9"'}]}];
+      videoCapabilities: [{contentType: 'video/webm; codecs="vp09.00.10.08"'}]}];
 
     if (!video.mediaKeys) {
       navigator.requestMediaKeySystemAccess('org.w3.clearkey',

--- a/src/content/en/fundamentals/media/fast-playback-with-video-preload.md
+++ b/src/content/en/fundamentals/media/fast-playback-with-video-preload.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Preload video and audio for faster playback.
 
 {# wf_published_on: 2017-08-17 #}
-{# wf_updated_on: 2018-01-08 #}
+{# wf_updated_on: 2018-03-20 #}
 {# wf_blink_components: Blink>Media #}
 
 # Fast Playback with Video Preload {: .page-title }
@@ -235,7 +235,7 @@ smaller files like "file_1.webm", "file_2.webm", "file_3.webm", etc.
 
   function sourceOpen() {
     URL.revokeObjectURL(video.src);
-    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp09.00.10.08"');
 
     // If video is preloaded already, fetch will return immediately a response
     // from the browser cache (memory cache). Otherwise, it will perform a
@@ -296,7 +296,7 @@ Player], [JW Player], and [Video.js] are built to handle this for you.
 
   function sourceOpen() {
     URL.revokeObjectURL(video.src);
-    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp09.00.10.08"');
 
     // Fetch beginning of the video by setting the Range HTTP request header.
     fetch('file.webm', { headers: { range: 'bytes=0-567139' } })
@@ -478,7 +478,7 @@ function onPlayButtonClick(videoFileUrl) {
     function sourceOpen() {
       URL.revokeObjectURL(video.src);
 
-      const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+      const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp09.00.10.08"');
       sourceBuffer.appendBuffer(data);
 
       video.play().then(_ => {

--- a/src/content/en/fundamentals/media/mse/basics.md
+++ b/src/content/en/fundamentals/media/mse/basics.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Media Source Extensions (MSE) is a JavaScript API that lets you build streams for playback from segments of audio or video.
 
 {# wf_published_on: 2017-02-08 #}
-{# wf_updated_on: 2017-07-14 #}
+{# wf_updated_on: 2018-03-20 #}
 {# wf_blink_components: Internals>Media #}
 
 # Media Source Extensions {: .page-title }
@@ -52,7 +52,7 @@ In practice, the chain looks like this:
     
     function sourceOpen(e) {
       URL.revokeObjectURL(vidElement.src);
-      var mime = 'video/webm; codecs="opus, vp9"';
+      var mime = 'video/webm; codecs="opus, vp09.00.10.08"';
       var mediaSource = e.target;
       var sourceBuffer = mediaSource.addSourceBuffer(mime);
       var videoUrl = 'droid.webm';
@@ -230,7 +230,7 @@ if (window.MediaSource) {
 
 function sourceOpen(e) {
   URL.revokeObjectURL(vidElement.src);
-  <strong>var mime = 'video/webm; codecs="opus, vp9"';
+  <strong>var mime = 'video/webm; codecs="opus, vp09.00.10.08"';
   // e.target refers to the mediaSource instance.
   // Store it in a variable so it can be used in a closure.
   var mediaSource = e.target;
@@ -254,7 +254,7 @@ to show part of the example we're building. If you want to see it in context,
 <pre class="prettyprint">
 function sourceOpen(e) {
   URL.revokeObjectURL(vidElement.src);
-  var mime = 'video/webm; codecs="opus, vp9"';  
+  var mime = 'video/webm; codecs="opus, vp09.00.10.08"';
   var mediaSource = e.target;  
   var sourceBuffer = mediaSource.addSourceBuffer(mime);  
   var videoUrl = 'droid.webm'; 
@@ -290,7 +290,7 @@ clause where I append it to the `SourceBuffer`.
 <pre class="prettyprint">
 function sourceOpen(e) {
   URL.revokeObjectURL(vidElement.src);
-  var mime = 'video/webm; codecs="opus, vp9"';
+  var mime = 'video/webm; codecs="opus, vp09.00.10.08"';
   var mediaSource = e.target;
   var sourceBuffer = mediaSource.addSourceBuffer(mime);
   var videoUrl = 'droid.webm';
@@ -312,7 +312,7 @@ After all `ArrayBuffers` are appended, and no further media data is expected, ca
 <pre class="prettyprint">
 function sourceOpen(e) {
   URL.revokeObjectURL(vidElement.src);
-  var mime = 'video/webm; codecs="opus, vp9"';
+  var mime = 'video/webm; codecs="opus, vp09.00.10.08"';
   var mediaSource = e.target;
   var sourceBuffer = mediaSource.addSourceBuffer(mime);
   var videoUrl = 'droid.webm';
@@ -348,7 +348,7 @@ Source Extensions.
     
     function sourceOpen(e) {
       URL.revokeObjectURL(vidElement.src);
-      var mime = 'video/webm; codecs="opus, vp9"';
+      var mime = 'video/webm; codecs="opus, vp09.00.10.08"';
       var mediaSource = e.target;
       var sourceBuffer = mediaSource.addSourceBuffer(mime);
       var videoUrl = 'droid.webm';

--- a/src/content/en/updates/2017/09/chrome-62-media-updates.md
+++ b/src/content/en/updates/2017/09/chrome-62-media-updates.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the audio/video updates in Chrome 62.
 
-{# wf_updated_on: 2017-12-20 #}
+{# wf_updated_on: 2018-03-20 #}
 {# wf_published_on: 2017-09-12 #}
 {# wf_tags: news,chrome62,media #}
 {# wf_featured_image: /web/updates/images/generic/play-outline.png #}
@@ -36,7 +36,7 @@ offline is now possible on Android as well.
     const config = [{
       sessionTypes: ['persistent-license'],
       videoCapabilities: [{
-        contentType: 'video/webm; codecs="vp9"',
+        contentType: 'video/webm; codecs="vp09.00.10.08"',
         robustness: 'SW_SECURE_DECODE' // Widevine L3
       }]
     }];
@@ -77,7 +77,7 @@ OS.
 
     const config = [{
       videoCapabilities: [{
-        contentType: 'video/webm; codecs="vp9"',
+        contentType: 'video/webm; codecs="vp09.00.10.08"',
         robustness: 'HW_SECURE_ALL' // Widevine L1
       }]
     }];

--- a/src/content/en/updates/2017/12/chrome-63-64-media-updates.md
+++ b/src/content/en/updates/2017/12/chrome-63-64-media-updates.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the audio/video updates in Chrome 63/64.
 
-{# wf_updated_on: 2017-12-20 #}
+{# wf_updated_on: 2018-03-20 #}
 {# wf_published_on: 2017-12-08 #}
 {# wf_tags: news,chrome63,chrome64,media,audio,video,origintrials #}
 {# wf_featured_image: /web/updates/images/generic/play-outline.png #}
@@ -213,7 +213,7 @@ example above needs to be updated based on your video encoding properties.
     Color depth is 48 bytes or more.
   </li>
   <li>
-    <span id="vp9"></span>
+    <span id="vp09.00.10.08"></span>
     Browser supports VP9 Profile 2, Level 1, 10-bit YUV content.
   </li>
 </ul>
@@ -245,7 +245,7 @@ the device is offline is now possible in Chrome 64 on Windows and Mac as well.
 const config = [{
   sessionTypes: ['persistent-license'],
   videoCapabilities: [{
-    contentType: 'video/webm; codecs="vp9"',
+    contentType: 'video/webm; codecs="vp09.00.10.08"',
     robustness: 'SW_SECURE_DECODE' // Widevine L3
   }]
 }];

--- a/src/content/it/fundamentals/media/fast-playback-with-video-preload.md
+++ b/src/content/it/fundamentals/media/fast-playback-with-video-preload.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Precaricare video e audio per una riproduzione più veloce.
 
 {# wf_published_on: 2017-08-17 #}
-{# wf_updated_on: 2018-01-08 #}
+{# wf_updated_on: 2018-03-20 #}
 {# wf_blink_components: Blink>Media #}
 
 # Riproduzione veloce con il precaricamento dei video {: .page-title}
@@ -228,7 +228,7 @@ piccoli come "file_1.webm", "file_2.webm", "file_3.webm", ecc.
 
   function sourceOpen() {
     URL.revokeObjectURL(video.src);
-    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp09.00.10.08"');
 
     // If video is preloaded already, fetch will return immediately a response
     // from the browser cache (memory cache). Otherwise, it will perform a
@@ -293,7 +293,7 @@ Google](http://videojs.com/) sono progettate per gestire questo per te.
 
   function sourceOpen() {
     URL.revokeObjectURL(video.src);
-    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+    const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp09.00.10.08"');
 
     // Fetch beginning of the video by setting the Range HTTP request header.
     fetch('file.webm', { headers: { range: 'bytes=0-567139' } })
@@ -482,7 +482,7 @@ function onPlayButtonClick(videoFileUrl) {
     function sourceOpen() {
       URL.revokeObjectURL(video.src);
 
-      const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+      const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp09.00.10.08"');
       sourceBuffer.appendBuffer(data);
 
       video.play().then(_ => {


### PR DESCRIPTION
This CL replaces all occurrences of deprecated "codecs=vp9" with new profile 0 ones in our documentation articles.

R: @chcunningham 