### PR TITLE
Deprecations and removals in Chrome 66

### DIFF
--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -26,6 +26,12 @@ Current thinking on setting device options is to use the [constrainable pattern]
 
 ## Service worker: disallow CORS responses for same-origin requests
 
+Previous versions of the service worker specification allowed a service worker to return a CORS response to a same-origin request. The thinking was that the service worker could read from a CORS response to create a completely synthetic response. In spite of this, the original request URL was maintained in the response. So `outerResponse.url` exactly equaled `url` and `innerResponse.url` exactly equaled `crossOriginURL`.
+
+A recent [change to the Fetch specification](https://github.com/whatwg/fetch/pull/146) requires that `Response.url` be exposed if it is present. A consequence of this is scenarios in which `self.location.href` returns a different origin than `self.origin`. To avoid this service workers are no longer allowed to return CORS responses for same origin requests.
+
+For a longer discussion on this change, see the [issue filed agains the Fetch specification](https://github.com/whatwg/fetch/issues/629) in November 2017.
+
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5694278818856960) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=800234)
 

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -41,7 +41,7 @@ exactly equaled `crossOriginURL`.
 A recent [change to the Fetch specification](https://github.com/whatwg/fetch/pull/146)
 requires that `Response.url` be exposed if it is present. A consequence of this
 is scenarios in which `self.location.href` returns a different origin than
-`self.origin`. To avoid this service workers are no longer allowed to return
+`self.origin`. To avoid this, service workers are no longer allowed to return
 CORS responses for same origin requests.
 
 For a longer discussion on this change, see the
@@ -54,7 +54,7 @@ in November 2017.
 
 ## WebAudio: dezippering removed
 
-WebAudio originally shipped with dezippering support.  When an AudioParam value
+Web audio originally shipped with dezippering support.  When an AudioParam value
 was set directly with the value setter, the value was not updated immediately.
 Instead, an exponential smoother was applied with a time constant of about 10 ms
 so that the change was done smoothly, limiting glitches.  It was never specified
@@ -68,7 +68,7 @@ use the existing `AudioParam.setTargetAtTime()` method to do the dezippering,
 giving you full control on when to apply it, how fast to change, and on which
 parameters should be smoothed.
 
-Removing this reduces developer confusion on what AudioParams have dezippering.
+Removing this reduces developer confusion which audio parameters support dezippering.
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/YKYRrh0nWMo/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5287995770929152) &#124;

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -81,7 +81,7 @@ values not support values with three parts. It's believed this approach makes
 processing shorthand syntax easier. The current version of the
 [CSS Values and Units Module](https://drafts.csswg.org/css-values-4) applies
 this requirement to all CSS position values. As of Chrome 66, three-part
-position values are deprecated. No removal date has been set.
+position values are deprecated. Removal is expected in Chrome 68, around July 2018.
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/oBKMVCOX1sY/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5116559680864256) &#124;

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -38,6 +38,12 @@ For a longer discussion on this change, see the [issue filed agains the Fetch sp
 
 ## WebAudio: dezippering removed
 
+WebAudio originally shipped with dezippering support.  When an AudioParam value was set directly with the value setter, the value was not updated immediately.  Instead, an exponential smoother was applied with a time constant of about 10 ms so that the change was done smoothly, limiting glitches.  It was never specified which parameters had smoothing and what the time constant was.  It wasn’t even obvious if the actual time constant was the appropriate value.
+
+After [much discussion](https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2FWebAudio%2Fweb-audio-api%2Fissues%2F76&sa=D&sntz=1&usg=AFQjCNGdcDCW3wiMGghiBNln2AT5mjEqpg), the working group removed dezippering from the spec. Now, the value is changed immediately when set. In place of dezippering, it is recommended that developers use the existing `AudioParam.setTargetAtTime()` method to do the dezippering, giving you full control on when to apply it, how fast to change, and on which parameters should be smoothed.
+
+Removing this reduces developer confusion on what AudioParams have dezippering.
+
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/YKYRrh0nWMo/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5287995770929152) &#124;
 [Chromium Bug](http://crbug.com/496282)

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -59,6 +59,8 @@ Recently specifications have required that new properties accepting position val
 
 ## Methods document.createTouch(), document.createTouchList() are deprecated
 
+The `TouchEvent()` constructor has been [supported in Chrome](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent#Browser_compatibility) since version 48. To comply with the specification, `document.createTouch()` and `document.createTouchList()` are now deprecated.
+
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/GLbUpUUnQzc/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5668612064935936) &#124;
 [Chromium Bug](https://crbug.com/518868)

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -18,21 +18,23 @@ description: A round up of the deprecations and removals in Chrome 66 to help yo
 
 ## ImageCapture.setOptions() removed
 
+Current thinking on setting device options is to use the [constrainable pattern](https://w3c.github.io/mediacapture-main/archives/20141205/getusermedia.html#constrainable-interface). Consequently this property was removed from the [ImageCapture specification](https://www.w3.org/TR/image-capture/#imagecaptureapi). Since this method appears to have little to no use on production websites, it is being removed. A replacement method is not available at this time.
+
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/tPbZ0eaO-yw/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5552970657693696) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=771283)
-
-## WebAudio: dezippering removed
-
-[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/YKYRrh0nWMo/discussion) &#124;
-[Chromestatus Tracker](https://www.chromestatus.com/feature/5287995770929152) &#124;
-[Chromium Bug](http://crbug.com/496282)
 
 ## Service worker: disallow CORS responses for same-origin requests
 
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5694278818856960) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=800234)
 
+
+## WebAudio: dezippering removed
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/YKYRrh0nWMo/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5287995770929152) &#124;
+[Chromium Bug](http://crbug.com/496282)
 
 ## CSS position values with three parts deprecated
 

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -1,13 +1,13 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
-description: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version,
+description: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version, improved service worker security, changes to CSS position values, and more.
 
 {# wf_updated_on: 2018-03-22 #}
 {# wf_published_on: 2018-03-26 #}
 {# wf_tags: deprecations,removals,chrome66 #}
 {# wf_blink_components: Blink>CSS,Blink>HTML,Blink>Input,Blink>WebAudio,Blink>ServiceWorker #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
-{# wf_featured_snippet: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version,   #}
+{# wf_featured_snippet: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version, improved service worker security, changes to CSS position values, and more.  #}
 
 {% include "web/updates/_shared/see-all-dep-rem.html" %}
 

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -5,7 +5,7 @@ description: A round up of the deprecations and removals in Chrome 66 to help yo
 {# wf_updated_on: 2018-03-22 #}
 {# wf_published_on: 2018-03-26 #}
 {# wf_tags: deprecations,removals,chrome66 #}
-{# wf_blink_components: Blink,Blink>Bindings,Blink>Network #}
+{# wf_blink_components: Blink>CSS,Blink>HTML,Blink>Input,Blink>WebAudio,Blink>ServiceWorker #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
 {# wf_featured_snippet: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version,   #}
 

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -18,7 +18,12 @@ description: A round up of the deprecations and removals in Chrome 66 to help yo
 
 ## ImageCapture.setOptions() removed
 
-Current thinking on setting device options is to use the [constrainable pattern](https://w3c.github.io/mediacapture-main/archives/20141205/getusermedia.html#constrainable-interface). Consequently this property was removed from the [ImageCapture specification](https://www.w3.org/TR/image-capture/#imagecaptureapi). Since this method appears to have little to no use on production websites, it is being removed. A replacement method is not available at this time.
+Current thinking on setting device options is to use the
+[constrainable pattern](https://w3c.github.io/mediacapture-main/archives/20141205/getusermedia.html#constrainable-interface)
+. Consequently this property was removed from the
+[ImageCapture specification](https://www.w3.org/TR/image-capture/#imagecaptureapi)
+. Since this method appears to have little to no use on production websites, it
+is being removed. A replacement method is not available at this time.
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/tPbZ0eaO-yw/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5552970657693696) &#124;
@@ -26,11 +31,22 @@ Current thinking on setting device options is to use the [constrainable pattern]
 
 ## Service worker: disallow CORS responses for same-origin requests
 
-Previous versions of the service worker specification allowed a service worker to return a CORS response to a same-origin request. The thinking was that the service worker could read from a CORS response to create a completely synthetic response. In spite of this, the original request URL was maintained in the response. So `outerResponse.url` exactly equaled `url` and `innerResponse.url` exactly equaled `crossOriginURL`.
+Previous versions of the service worker specification allowed a service worker
+to return a CORS response to a same-origin request. The thinking was that the
+service worker could read from a CORS response to create a completely synthetic
+response. In spite of this, the original request URL was maintained in the
+response. So `outerResponse.url` exactly equaled `url` and `innerResponse.url`
+exactly equaled `crossOriginURL`.
 
-A recent [change to the Fetch specification](https://github.com/whatwg/fetch/pull/146) requires that `Response.url` be exposed if it is present. A consequence of this is scenarios in which `self.location.href` returns a different origin than `self.origin`. To avoid this service workers are no longer allowed to return CORS responses for same origin requests.
+A recent [change to the Fetch specification](https://github.com/whatwg/fetch/pull/146)
+requires that `Response.url` be exposed if it is present. A consequence of this
+is scenarios in which `self.location.href` returns a different origin than
+`self.origin`. To avoid this service workers are no longer allowed to return
+CORS responses for same origin requests.
 
-For a longer discussion on this change, see the [issue filed agains the Fetch specification](https://github.com/whatwg/fetch/issues/629) in November 2017.
+For a longer discussion on this change, see the
+[issue filed agains the Fetch specification](https://github.com/whatwg/fetch/issues/629)
+in November 2017.
 
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5694278818856960) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=800234)
@@ -38,9 +54,19 @@ For a longer discussion on this change, see the [issue filed agains the Fetch sp
 
 ## WebAudio: dezippering removed
 
-WebAudio originally shipped with dezippering support.  When an AudioParam value was set directly with the value setter, the value was not updated immediately.  Instead, an exponential smoother was applied with a time constant of about 10 ms so that the change was done smoothly, limiting glitches.  It was never specified which parameters had smoothing and what the time constant was.  It wasn’t even obvious if the actual time constant was the appropriate value.
+WebAudio originally shipped with dezippering support.  When an AudioParam value
+was set directly with the value setter, the value was not updated immediately.
+Instead, an exponential smoother was applied with a time constant of about 10 ms
+so that the change was done smoothly, limiting glitches.  It was never specified
+which parameters had smoothing and what the time constant was.  It wasn’t even
+obvious if the actual time constant was the appropriate value.
 
-After [much discussion](https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2FWebAudio%2Fweb-audio-api%2Fissues%2F76&sa=D&sntz=1&usg=AFQjCNGdcDCW3wiMGghiBNln2AT5mjEqpg), the working group removed dezippering from the spec. Now, the value is changed immediately when set. In place of dezippering, it is recommended that developers use the existing `AudioParam.setTargetAtTime()` method to do the dezippering, giving you full control on when to apply it, how fast to change, and on which parameters should be smoothed.
+After [much discussion](https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2FWebAudio%2Fweb-audio-api%2Fissues%2F76&sa=D&sntz=1&usg=AFQjCNGdcDCW3wiMGghiBNln2AT5mjEqpg)
+, the working group removed dezippering from the spec. Now, the value is changed
+immediately when set. In place of dezippering, it is recommended that developers
+use the existing `AudioParam.setTargetAtTime()` method to do the dezippering,
+giving you full control on when to apply it, how fast to change, and on which
+parameters should be smoothed.
 
 Removing this reduces developer confusion on what AudioParams have dezippering.
 
@@ -50,7 +76,12 @@ Removing this reduces developer confusion on what AudioParams have dezippering.
 
 ## CSS position values with three parts deprecated
 
-Recently specifications have required that new properties accepting position values not support values with three parts. It's believed this approach makes processing shorthand syntax easier. The current version of the [CSS Values and Units Module](https://drafts.csswg.org/css-values-4) applies this requirement to all CSS position values. As of Chrome 66, three-part position values are deprecated. No removal date has been set.
+Recently specifications have required that new properties accepting position
+values not support values with three parts. It's believed this approach makes
+processing shorthand syntax easier. The current version of the
+[CSS Values and Units Module](https://drafts.csswg.org/css-values-4) applies
+this requirement to all CSS position values. As of Chrome 66, three-part
+position values are deprecated. No removal date has been set.
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/oBKMVCOX1sY/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5116559680864256) &#124;
@@ -59,7 +90,10 @@ Recently specifications have required that new properties accepting position val
 
 ## Methods document.createTouch(), document.createTouchList() are deprecated
 
-The `TouchEvent()` constructor has been [supported in Chrome](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent#Browser_compatibility) since version 48. To comply with the specification, `document.createTouch()` and `document.createTouchList()` are now deprecated.
+The `TouchEvent()` constructor has been
+[supported in Chrome](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent#Browser_compatibility)
+since version 48. To comply with the specification, `document.createTouch()` and
+`document.createTouchList()` are now deprecated.
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/GLbUpUUnQzc/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5668612064935936) &#124;

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -1,0 +1,55 @@
+project_path: /web/_project.yaml
+book_path: /web/updates/_book.yaml
+description: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version,
+
+{# wf_updated_on: 2018-03-22 #}
+{# wf_published_on: 2018-03-26 #}
+{# wf_tags: deprecations,removals,chrome66 #}
+{# wf_blink_components: Blink,Blink>Bindings,Blink>Network #}
+{# wf_featured_image: /web/updates/images/generic/warning.png #}
+{# wf_featured_snippet: A round up of the deprecations and removals in Chrome 66 to help you plan. In this version,   #}
+
+{% include "web/updates/_shared/see-all-dep-rem.html" %}
+
+# Deprecations and removals in Chrome 66 {: .page-title }
+
+{% include "web/_shared/contributors/josephmedley.html" %}
+
+
+## ImageCapture.setOptions() removed
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/tPbZ0eaO-yw/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5552970657693696) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=771283)
+
+## WebAudio: dezippering removed
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/YKYRrh0nWMo/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5287995770929152) &#124;
+[Chromium Bug](http://crbug.com/496282)
+
+## Service worker: disallow CORS responses for same-origin requests
+
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5694278818856960) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=800234)
+
+
+## CSS position values with three parts deprecated
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/oBKMVCOX1sY/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5116559680864256) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=804187)
+
+
+## Methods document.createTouch(), document.createTouchList() are deprecated
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/GLbUpUUnQzc/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5668612064935936) &#124;
+[Chromium Bug](https://crbug.com/518868)
+
+
+{% include "web/updates/_shared/deprecations-policy.html" %}
+
+{% include "web/_shared/rss-widget-updates.html" %}
+
+{% include "comment-widget.html" %}

--- a/src/content/en/updates/2018/03/chrome-66-deprecations.md
+++ b/src/content/en/updates/2018/03/chrome-66-deprecations.md
@@ -38,6 +38,8 @@ Current thinking on setting device options is to use the [constrainable pattern]
 
 ## CSS position values with three parts deprecated
 
+Recently specifications have required that new properties accepting position values not support values with three parts. It's believed this approach makes processing shorthand syntax easier. The current version of the [CSS Values and Units Module](https://drafts.csswg.org/css-values-4) applies this requirement to all CSS position values. As of Chrome 66, three-part position values are deprecated. No removal date has been set.
+
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/oBKMVCOX1sY/discussion) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5116559680864256) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=804187)


### PR DESCRIPTION
**Target Live Date:** 2018-03-26

- [x] This has been reviewed and approved by feature owners
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
