### PR TITLE
Fix hyperlink to “using programmatically” doc

### DIFF
--- a/src/content/en/tools/lighthouse/index.md
+++ b/src/content/en/tools/lighthouse/index.md
@@ -155,7 +155,7 @@ To see audit options:
 See [Using programmatically][programmatic] for an example of running Lighthouse
 programmatically, as a Node module.
 
-[programmatic]: https://github.com/GoogleChrome/lighthouse#using-programmatically
+[programmatic]: https://github.com/GoogleChrome/lighthouse/blob/master/docs/readme.md#using-programmatically
 
 ### Run Lighthouse as a Chrome Extension {: #extension }
 


### PR DESCRIPTION
The hyperlink &ldquo;Using programmatically&rdquo; on [`developers.google.com/web/tools/lighthouse`](https://developers.google.com/web/tools/lighthouse/#programmatic) does not point to the right document and fragment on GH now. This fixes that.