### PR TITLE
[lighthouse] add plugins reference

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -158,7 +158,11 @@ toc:
     path: /web/tools/lighthouse/audits/canonical
   - title: Document Doesn't Use Legible Font Sizes
     path: /web/tools/lighthouse/audits/font-sizes
+  - title: Document uses plugins
+    path: /web/tools/lighthouse/audits/plugins
   - title: Links Do Not Have Descriptive Text
     path: /web/tools/lighthouse/audits/descriptive-link-text
   - title: Page has unsuccessful HTTP status code
     path: /web/tools/lighthouse/audits/successful-http-code
+  - title: Page is blocked from indexing
+    path: /web/tools/lighthouse/audits/indexing

--- a/src/content/en/tools/lighthouse/audits/plugins.md
+++ b/src/content/en/tools/lighthouse/audits/plugins.md
@@ -1,0 +1,56 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Document uses plugins" Lighthouse audit.
+
+{# wf_updated_on: 2018-03-26 #}
+{# wf_published_on: 2018-03-26 #}
+{# wf_blink_components: Platform>DevTools #}
+
+# Document uses plugins  {: .page-title }
+
+## Overview {: #overview }
+
+Plugins harm SEO in two ways:
+
+1. Search engines can't index plugin content. Plugin content won't show up in search results.
+2. Many mobile devices don't support plugins, which creates frustrating experiences for
+   mobile users This is likely to increase your bounce rate and other signals that indicate to
+   search engines that the page is not helpful for mobile users.
+
+Source:
+
+* [Unplayable content](/search/mobile-sites/mobile-seo/common-mistakes#unplayable-content)
+
+## Recommendations {: #recommendations }
+
+Remove the plugins and convert your content to HTML.
+
+See [Video](/web/fundamentals/media/video) to learn the best practices for displaying video on
+the web.
+
+## More information {: #more-info }
+
+Lighthouse checks the page for tags that commonly represent plugins:
+
+* `embed`
+* `object`
+* `applet`
+
+And then flags each tag as a plugin if its MIME type matches any of the following:
+
+* `application/x-java-applet`
+* `application/x-java-bean`
+* `application/x-shockwave-flash`
+* `application/x-silverlight`
+* `application/x-silverlight-2`
+
+Or if the tag points to a URL with a file format that is known to represent plugin content:
+
+* `swf`
+* `flv`
+* `class`
+* `xap`
+
+[Audit source][src]{:.external}
+
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/seo/plugins.js


### PR DESCRIPTION
What's changed, or what was fixed?
- adds reference for plugin audit
- adds a ToC entry for the index reference doc (not related to the plugins work)

**Fixes:** N/A

**Target Live Date:** 2018-04-01

- [x] This has been reviewed and approved by @rviscomi 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
