### PR TITLE
replace invite link to slack

### DIFF
--- a/src/content/en/feedback/_index.yaml
+++ b/src/content/en/feedback/_index.yaml
@@ -103,7 +103,7 @@ landing_page:
             </a>
           </li>
           <li>
-            <a href="https://chromiumdev-slack.herokuapp.com/?linkId=18742368" class="gc-analytics-event" data-category="webfundamentals" data-label="slack-chromiumdev">
+            <a href="https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE" class="gc-analytics-event" data-category="webfundamentals" data-label="slack-chromiumdev">
               ChromiumDev Slack Channel
             </a>
           </li>

--- a/src/content/en/resources/translations.md
+++ b/src/content/en/resources/translations.md
@@ -31,7 +31,7 @@ If you find any issues or feature requests, please file them in
 [GitLocalize's issue tracker](https://github.com/gitlocalize/feedback/issues).
 
 To chat with other translation contributors, [register to the ChromiumDev
-Slack](https://chromiumdev-slack.herokuapp.com/) and join #l10n channel.
+Slack](https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE) and join #l10n channel.
 
 Note: It's important you find someone to review your translation. Try finding a
 reviewer in the Slack's #l10n channel if [no one is assigned as a language

--- a/src/content/en/tools/workbox/community.md
+++ b/src/content/en/tools/workbox/community.md
@@ -32,7 +32,7 @@ the **#workbox** room on the
 [ChromiumDev Slack Channel](https://chromiumdev.slack.com/).
 
 If you're not already a member of the channel, you can
-[request access here](https://chromiumdev-slack.herokuapp.com/).
+[request access here](https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE).
 
 Times of when we'll be meeting are on the calendar below.
 

--- a/src/content/en/updates/2016/11/get-ready-for-cds.md
+++ b/src/content/en/updates/2016/11/get-ready-for-cds.md
@@ -70,7 +70,7 @@ Chrome Dev Summit in real-time:
   [Twitter](https://twitter.com/ChromiumDev) that include the
   [#ChromeDevSummit](https://twitter.com/search?q=%23ChromeDevSummit) hashtag
   or join our [Slack](https://chromiumdev.slack.com/) by signing up
-  [here](https://chromiumdev-slack.herokuapp.com/) and a team of onsite
+  [here](https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE) and a team of onsite
   Googlers will do their best to track down an answer in real time for you.
 
 We're looking forward to having you with us you for 2 days of web fun, soon!

--- a/src/content/ja/resources/translations.md
+++ b/src/content/ja/resources/translations.md
@@ -70,4 +70,4 @@ description: Web Fundamentals を日本語化したい人は、誰でも Contrib
 
 ## コミュニティ
 Web Fundamentals の翻訳作業について何かわからないことがあれば、Slack の [chromiumdev.slack.com](https://chromiumdev.slack.com/) にある #l10n チャネルで質問してください。  
-（ [https://chromiumdev-slack.herokuapp.com/](https://chromiumdev-slack.herokuapp.com/) から参加できます）  
+（ [こちら](https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE) から参加できます）  

--- a/src/content/zh-cn/resources/translations.md
+++ b/src/content/zh-cn/resources/translations.md
@@ -27,7 +27,7 @@ description: "欢迎您将Web Fundamentals翻译去其他的语言。"
 如果您遇到任何问题或者有功能请求，您可以在[GitLocalize的issue tracker](https://github.com/gitlocalize/feedback/issues)提供建议。
 
 
-与其他翻译贡献者聊天，您可以[注册ChromiumDev的Slack](https://chromiumdev-slack.herokuapp.com/)并加入#l10n频道。
+与其他翻译贡献者聊天，您可以[注册ChromiumDev的Slack](https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE)并加入#l10n频道。
 
 Note: 让别人来审查你的翻译是非常重要的。[如果您翻译的语言没有版主](https://gitlocalize.com/repo/107/roles)，您可以在Slack的#l10n频道寻找可以帮助您审查文章的人。 如果您有兴趣当版主，您可以在#l10n找@agektmr。
 

--- a/src/content/zh-tw/resources/translations.md
+++ b/src/content/zh-tw/resources/translations.md
@@ -26,7 +26,7 @@ description: "歡迎您將Web Fundamentals翻譯去其他的語言。"
 
 如果您遇到任何問題或者有功能請求，您可以在[GitLocalize的issue tracker](https://github.com/gitlocalize/feedback/issues)提供建議。
 
-與其他翻譯貢獻者聊天，您可以[註冊ChromiumDev的Slack](https://chromiumdev-slack.herokuapp.com/)並加入#l10n頻道。
+與其他翻譯貢獻者聊天，您可以[註冊ChromiumDev的Slack](https://join.slack.com/t/chromiumdev/shared_invite/enQtMzM3NjYwNjI0MDM4LTk2NjEyYTIxODk1MDYxMmNjNWYzMGMxZGVhMDNhY2I1ZjBhMjdlYTg0MTg4ZGE0OTQ0ZmYwNTRiMGJlYzVjOTE)並加入#l10n頻道。
 
 Note: 讓別人來審查你的翻譯是非常重要的。[如果您翻譯的語言沒有版主](https://gitlocalize.com/repo/107/roles)，您可以在Slack的#l10n頻道尋找可以幫助您審查文章的人。 如果您有興趣當版主，您可以在#l10n找@agektmr。
 


### PR DESCRIPTION
This change replaces link to slack invite link currently run on heroku to slack native invite link. 

- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @PaulKinlan 
