### PR TITLE
Update es2015-proxies.md

### DIFF
--- a/src/content/en/updates/2016/02/es2015-proxies.md
+++ b/src/content/en/updates/2016/02/es2015-proxies.md
@@ -2,10 +2,11 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: ES2015 Proxies (in Chrome 49 and later) provide JavaScript with an intercession API, enabling us to trap or intercept all of the operations on a target object and modify how this target operates.
 
-{# wf_updated_on: 2016-02-29 #}
+{# wf_updated_on: 2018-03-30 #}
 {# wf_published_on: 2016-02-01 #}
 {# wf_tags: javascript,es2015,chrome49 #}
 {# wf_featured_image: /web/updates/images/2016/02/es2015-proxies/featured.png #}
+{# wf_blink_components: N/A #}
 
 # Introducing ES2015 Proxies {: .page-title }
 
@@ -54,8 +55,10 @@ Let’s begin by taking a plain object and adding some interception middleware t
 
 Running the above code in Chrome 49 we get the following:
 
+<pre>
 get was called for: power  
 "Flight"
+</pre>
 
 As we can see in practice, performing our property get or property set on the proxy object correctly resulted in a meta-level call to the corresponding trap on the handler. Handler operations include property reads, property assignment, and function application, all of which get forwarded to the corresponding trap.
 
@@ -199,7 +202,7 @@ Access control is another good use case for Proxies. Rather than passing a targe
 
 ## Using reflection with proxies
 
-[Reflect](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect) is a new built-in object that provides methods for interceptable JavaScript operations, very much useful for working with Proxies. In fact, Reflect methods are the the same as those of [proxy handlers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler).
+[Reflect](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect) is a new built-in object that provides methods for interceptable JavaScript operations, very much useful for working with Proxies. In fact, Reflect methods are the same as those of [proxy handlers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler).
 
 Statically typed languages like Python or C# have long offered a reflection API, but JavaScript hasn’t really needed one being a dynamic language. One can argue ES5 already has quite a few reflection features, such as `Array.isArray()` or `Object.getOwnPropertyDescriptor()` which would be considered reflection in other languages. ES2015 introduces a Reflection API which will house future methods for this category, making them easier to reason about. This makes sense as Object is meant to be a base prototype rather than a bucket for reflection methods.
 
@@ -302,5 +305,6 @@ Google has released a [limited polyfill for Proxy](https://github.com/GoogleChro
 * [Metaprogramming in ES6 using Reflect](http://blog.keithcirkel.co.uk/metaprogramming-in-es6-part-2-reflect/)
 * [ES6 everyday Reflect](http://www.loganfranken.com/blog/902/es6-everyday-reflect/)
 
+{% include "web/_shared/rss-widget-updates.html" %}
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2016/02/es2015-proxies.md
+++ b/src/content/en/updates/2016/02/es2015-proxies.md
@@ -43,7 +43,7 @@ Let’s begin by taking a plain object and adding some interception middleware t
     
     var superhero = new Proxy(target, {
        get: function(target, name, receiver) {
-           console.log('get was called for: ', name);
+           console.log('get was called for:', name);
            return target[name];
        }
     });
@@ -54,7 +54,7 @@ Let’s begin by taking a plain object and adding some interception middleware t
 
 Running the above code in Chrome 49 we get the following:
 
-get was called for:  power
+get was called for: power  
 "Flight"
 
 As we can see in practice, performing our property get or property set on the proxy object correctly resulted in a meta-level call to the corresponding trap on the handler. Handler operations include property reads, property assignment, and function application, all of which get forwarded to the corresponding trap.


### PR DESCRIPTION
Clarify console output as two lines of output (It was confusing to me about what caused "Flight" to be logged, since it appeared on the same line).

What's changed, or what was fixed?
- The markdown format collapsed whitespace and two lines that were intended to be on separate lines

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
