### PR TITLE
Deprecate old offline analytics post

### DIFF
--- a/src/content/en/updates/2016/07/offline-google-analytics.md
+++ b/src/content/en/updates/2016/07/offline-google-analytics.md
@@ -6,13 +6,14 @@ description: The sw-offline-google-analytics library gives you everything you ne
 {# wf_published_on: 2016-07-20 #}
 {# wf_tags: serviceworker,analytics,offline,indexeddb #}
 {# wf_featured_image: /web/updates/images/generic/timeline.png #}
+{# wf_blink_components: N/A #}
 
 # Offline Google Analytics Made Easy {: .page-title }
 
 {% include "web/_shared/contributors/jeffposnick.html" %}
 
 Warning: The information in this post is out of date. Developers are encouraged to follow
-[these steps](https://developers.google.com/web/tools/workbox/guides/enable-offline-analytics) to
+[these steps](/web/tools/workbox/guides/enable-offline-analytics) to
 use a solution based on the Workbox libraries.
 
 So you've got a [progressive web app](/web/progressive-web-apps/), complete with a [service worker](/web/fundamentals/getting-started/primers/service-workers) that allows it to work offline. Great! You've also got existing Google Analytics set up for your web app, and you don't want to miss out on any analytical insights coming from usage that occurs while offline. But if you try to send data to Google Analytics while offline, those requests will fail and the data will be lost.

--- a/src/content/en/updates/2016/07/offline-google-analytics.md
+++ b/src/content/en/updates/2016/07/offline-google-analytics.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: The sw-offline-google-analytics library gives you everything you need.
 
-{# wf_updated_on: 2016-07-26 #}
+{# wf_updated_on: 2018-03-28 #}
 {# wf_published_on: 2016-07-20 #}
 {# wf_tags: serviceworker,analytics,offline,indexeddb #}
 {# wf_featured_image: /web/updates/images/generic/timeline.png #}
@@ -11,7 +11,9 @@ description: The sw-offline-google-analytics library gives you everything you ne
 
 {% include "web/_shared/contributors/jeffposnick.html" %}
 
-
+Warning: The information in this post is out of date. Developers are encouraged to follow
+[these steps](https://developers.google.com/web/tools/workbox/guides/enable-offline-analytics) to
+use a solution based on the Workbox libraries.
 
 So you've got a [progressive web app](/web/progressive-web-apps/), complete with a [service worker](/web/fundamentals/getting-started/primers/service-workers) that allows it to work offline. Great! You've also got existing Google Analytics set up for your web app, and you don't want to miss out on any analytical insights coming from usage that occurs while offline. But if you try to send data to Google Analytics while offline, those requests will fail and the data will be lost.
 


### PR DESCRIPTION
This adds a deprecation warning to the old Offline Analytics post, with a link to the Workbox equivalent.

**Fixes:** #4842

**Target Live Date:** 2018-04-04

- [ ] This has been reviewed and approved by (@kosamari)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
