### PR TITLE
Docs for some new workbox-webpack-plugin options

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/groups/common-webpack.html
+++ b/src/content/en/tools/workbox/_shared/config/groups/common-webpack.html
@@ -9,3 +9,7 @@
 {% include "web/tools/workbox/_shared/config/webpack-single/include.html" %}
 
 {% include "web/tools/workbox/_shared/config/webpack-single/exclude.html" %}
+
+{% include "web/tools/workbox/_shared/config/webpack-single/importsDirectory.html" %}
+
+{% include "web/tools/workbox/_shared/config/webpack-single/precacheManifestFilename.html" %}

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/importsDirectory.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/importsDirectory.html
@@ -1,0 +1,31 @@
+<tr>
+  <td>
+    <p>importsDirectory</p>
+  </td>
+  <td>
+    <p>
+      <em>Optional <code>String</code>, defaulting to <code>''</code></em>
+    </p>
+    <p>
+      Workbox creates assets as part of your webpack build process: a precache manifest file, and
+      potentially a local copy of the Workbox libraries (if <code>importWorkboxFrom</code> is set
+      to <code>'local'</code>).
+    </p>
+    <p>
+      These assets will, by default, be created at the root of your webpack build directory, i.e.
+      <code>output.path</code>. You can set the <code>importsDirectory</code> option if you want
+      these assets to be created in a subdirectory of <code>output.path</code> instead of at the
+      top-level.
+    </p>
+    <p>
+      <strong>Note:</strong> This option does not effect where the main service worker JavaScript
+      file is created. That is determined by the <code>swDest</code> option.
+    </p>
+    <p>
+      <strong>Example:</strong>
+    </p>
+    <pre class="prettyprint">// Use a 'wb-assets' directory for Workbox's assets,
+// under the top-level output directory.
+importsDirectory: 'wb-assets'</pre>
+  </td>
+</tr>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/precacheManifestFilename.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/precacheManifestFilename.html
@@ -1,0 +1,31 @@
+<tr>
+  <td>
+    <p>precacheManifestFilename</p>
+  </td>
+  <td>
+    <p>
+      <em>
+        Optional <code>String</code>, defaulting to
+        <code>'precache-manifest.[manifestHash].js'</code>
+      </em>
+    </p>
+    <p>
+      Workbox automatically creates a JavaScript file that contains information about URLs that
+      need to be precached. By default, this file is called
+      <code>precache-manifest.[manifestHash].js</code>, where <code>[manifestHash]</code> is
+      automatically replaced by a unique value that identifies the contents of the file.
+    </p>
+    <p>
+      <code>precacheManifestFilename</code> can be used to override this default filename. You must
+      include the string <code>[manifestHash]</code> somewhere as part of the filename.
+    </p>
+    <p>
+      If you'd like to change the output directory to which the precache manifest is written, you
+      can configure the <code>importsDirectory</code> option.
+    </p>
+    <p>
+      <strong>Example:</strong>
+    </p>
+    <pre class="prettyprint">precacheManifestFilename: 'wb-manifest.[manifestHash].js'</pre>
+  </td>
+</tr>


### PR DESCRIPTION
https://github.com/GoogleChrome/workbox/pull/1403 added some new options for the `workbox-webpack-plugin`. These are the docs for them.

Technically, these docs should go live at around the same time as the next Workbox release goes live... but at the same time, it's a small change to existing docs, and it might be hard to coordinate that. I'm not as worried if we merge this ahead of time.

**Target Live Date:** 2018-04-XX

- [ ] This has been reviewed and approved by (@gauntface)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
