### PR TITLE
Update WebUSB demo code to latest Arduino library

### DIFF
--- a/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
+++ b/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
@@ -218,14 +218,7 @@ And here's the sketch that has been uploaded to the Arduino board.
     // Third-party WebUSB Arduino library
     #include <WebUSB.h>
     
-    const WebUSBURL URLS[] = {
-      { 1, "webusb.github.io/arduino/demos/" },
-      { 0, "localhost:8000" },
-    };
-    
-    const uint8_t ALLOWED_ORIGINS[] = { 1, 2 };
-    
-    WebUSB WebUSBSerial(URLS, 2, 1, ALLOWED_ORIGINS, 2);
+    WebUSB WebUSBSerial(1 /* https:// */, "webusb.github.io/arduino/demos");
     
     #define Serial WebUSBSerial
     


### PR DESCRIPTION
The parameters for constructing the WebUSBSerial object have been simplified in the latest version of the Arduino library. This patch updates our example code to match.

See: https://github.com/webusb/arduino/blob/gh-pages/demos/console/sketch/sketch.ino

**CC:** @petele
