### PR TITLE
Fix two typos

### DIFF
--- a/src/content/en/tools/puppeteer/articles/ssr.md
+++ b/src/content/en/tools/puppeteer/articles/ssr.md
@@ -107,7 +107,7 @@ they're doing!? ¯\\_(ツ)_/¯
 
 ## Prerendering pages using headless Chrome {: #headless }
 
-All crawlers under HTML. What we need to "solve" the indexing problem is
+All crawlers understand HTML. What we need to "solve" the indexing problem is
 a tool that produces HTML from executing JS. 🤔 What if I told you there is
 such a tool?
 
@@ -782,7 +782,7 @@ in this article, check out [this app](https://devwebfeed.appspot.com/ssr) and
 
 ### Discussion of prior art {: #art }
 
-Server-side rendering client-side apps is hard. How had? Just look
+Server-side rendering client-side apps is hard. How hard? Just look
 at how many [npm packages](https://www.npmjs.com/search?q=server%20side%20rendering)
 people have written which are dedicated to the topic. There are countless
 [patterns](https://en.wikipedia.org/wiki/Isomorphic_JavaScript),


### PR DESCRIPTION
What's changed, or what was fixed?
- Two typos

**Fixes:** #issue

**Target Live Date:** 2018-04-02
**CC:** @petele
