### PR TITLE
[devtools] attempt to fix devsite bug with verbatim tag

### DIFF
--- a/src/content/en/tools/chrome-devtools/console/get-started.md
+++ b/src/content/en/tools/chrome-devtools/console/get-started.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Learn how to view messages and run JavaScript in the Console.
 
-{# wf_updated_on: 2018-03-22 #}
+{# wf_updated_on: 2018-04-02 #}
 {# wf_published_on: 2018-03-08 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -208,23 +208,29 @@ filter the **Console** to only show messages that you care about.
    filtering.
 
        {% framebox width="auto" height="auto" enable_widgets="true" %}
-         <button class="gc-analytics-event" data-category="DevTools"
-                 data-label="Console / Get Started / 1.C.1 (Numbers)">Log Numbers</button>
-         <script>
-           const button = document.querySelector('button');
-           button.addEventListener('click', function () {
-             function isPrime(num) {
-               for (let i = 2, s = Math.sqrt(num); i <= s; i++) {
-                 if (num % i === 0) return false;
+
+         {% verbatim %}
+
+           <button class="gc-analytics-event" data-category="DevTools"
+                   data-label="Console / Get Started / 1.C.1 (Numbers)">Log Numbers</button>
+           <script>
+             const button = document.querySelector('button');
+             button.addEventListener('click', function () {
+               function isPrime(num) {
+                 for (let i = 2, s = Math.sqrt(num); i <= s; i++) {
+                   if (num % i === 0) return false;
+                 }
+                 return num !== 1;
+               };
+               for (let j = 1; j <= 1000; j++) {
+                 const label = isPrime(j) ? 'prime:' : 'not prime:';
+                 j % 3 === 0 ? console.warn(label, j) : console.log(label, j);
                }
-               return num !== 1;
-             };
-             for (let j = 1; j <= 1000; j++) {
-               const label = isPrime(j) ? 'prime:' : 'not prime:';
-               j % 3 === 0 ? console.warn(label, j) : console.log(label, j);
-             }
-           });
-         </script>
+             });
+           </script>
+
+         {% endverbatim %}
+
        {% endframebox %}
 
 1. Type `123` in the **Filter** text box. The **Console** only shows messages that contain


### PR DESCRIPTION
What's changed, or what was fixed?
- DevSite has a bug (issue 77295609) that's borking the example that logs prime numbers to the Console. This is Lazin's suggested workaround.

**Fixes:** N/A

**Target Live Date:** 2018-04-02

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.
   * Note: The staging server is actually spitting out the verbatim tags as plaintext, but I think it's just a limitation of the staging server. We'll see.

**CC:** @petele
