### PR TITLE
Webpack article fixes

### DIFF
--- a/src/content/en/fundamentals/performance/webpack/decrease-frontend-size.md
+++ b/src/content/en/fundamentals/performance/webpack/decrease-frontend-size.md
@@ -34,8 +34,10 @@ in libraries, [and more](https://medium.com/webpack/webpack-4-mode-and-optimizat
 
 ## Enable minification {: #enable-minification }
 
-Note: if you’re using [webpack 4 with the production mode](#enable-the-production-mode), the
-bundle-level minification is already enabled. You’ll only need to enable loader-specific options.
+Note: most of this is webpack 3 only. If you use
+[webpack 4 with the production mode](#enable-the-production-mode), the bundle-level minification
+is already enabled – you’ll only need to enable
+[loader-specific options](#loader-specific-options).
 
 Minification is when you compress the code by removing extra spaces, shortening variable names and
 so on. Like this:
@@ -59,6 +61,8 @@ so on. Like this:
 
 Webpack supports two ways to minify the code: _the bundle-level minification_ and
 _loader-specific options_. They should be used simultaneously.
+
+### Bundle-level minification {: #bundle-level-minification }
 
 The bundle-level minification compresses the whole bundle after compilation. Here’s how it works:
 
@@ -136,7 +140,9 @@ If you need to compile the new syntax, use the
 is the same plugin that’s bundled with webpack, but newer, and it’s able to compile the ES2015+
 code.
 
-The second way is loader-specific options ([what a loader
+### Loader-specific options {: #loader-specific-options }
+
+The second way to minify the code is loader-specific options ([what a loader
 is](https://webpack.js.org/concepts/loaders/)). With loader options, you can compress things that
 the minifier can’t minify. For example, when you import a CSS file with
 [`css-loader`](https://github.com/webpack-contrib/css-loader), the file is compiled into a string:
@@ -184,8 +190,9 @@ module.exports = {
 
 ## Specify `NODE_ENV=production`
 
-Note: if you’re using [webpack 4 with the production mode](#enable-the-production-mode), the
-`NODE_ENV=production` optimization is already enabled. Feel free to skip this section.
+Note: this is webpack 3 only. If you use
+[webpack 4 with the production mode](#enable-the-production-mode), the `NODE_ENV=production`
+optimization is already enabled – feel free to skip the section.
 
 Another way to decrease the front-end size is to set the `NODE_ENV`
 [environmental variable](https://superuser.com/questions/284342/what-are-path-and-other-environment-variables-and-how-can-i-set-or-use-them)

--- a/src/content/en/fundamentals/performance/webpack/decrease-frontend-size.md
+++ b/src/content/en/fundamentals/performance/webpack/decrease-frontend-size.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: How to use webpack to make your app as small as possible
 
-{# wf_updated_on: 2018-03-01 #}
+{# wf_updated_on: 2018-04-02 #}
 {# wf_published_on: 2017-12-18 #}
 {# wf_blink_components: N/A #}
 
@@ -370,7 +370,7 @@ separate export point in the bundle:
 
 <li>
 
-[The minifier](#enable-minification) removes the unused variable:
+<a href="#enable-minification">The minifier</a> removes the unused variable:
 
 <pre class="prettyprint">
 // bundle.js (part that corresponds to comments.js)

--- a/src/content/en/fundamentals/performance/webpack/decrease-frontend-size.md
+++ b/src/content/en/fundamentals/performance/webpack/decrease-frontend-size.md
@@ -15,8 +15,9 @@ possible. Here’s how to do this with webpack.
 
 ## Use the production mode (webpack 4 only) {: #use-the-production-mode }
 
-Webpack 4 introduced the new `mode` flag. You could set this flag to `'development'` or
-`'production'` to hint webpack that you’re building the application for a specific environment:
+Webpack 4 introduced [the new `mode` flag](https://webpack.js.org/concepts/mode/). You could set
+this flag to `'development'` or `'production'` to hint webpack that you’re building
+the application for a specific environment:
 
     // webpack.config.js
     module.exports = {


### PR DESCRIPTION
What's changed, or what was fixed?
- _Link to webpack docs about `mode`._ the docs finally got updated with this section
- _Make the “webpack 3 only” notice cleaner._ A couple of people on Twitter asked why “Minification” and “NODE_ENV=production” sections are present if we’re writing about webpack 4. Looks like they didn’t notice the notes
- _Fix a layout issue._ I accidentally used markdown inside a `<li>` tag, and it wasn’t compiled into HTML

**Target Live Date:** ¯\\\_(ツ)_/¯ (when it’s convenient)

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass. (I’m on Windows, and it’s hard here, sorry)
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @addyosmani 
