### PR TITLE
[lighthouse] add redirects reference; update template

### DIFF
--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -20,6 +20,8 @@ toc:
     path: /web/tools/lighthouse/audits/first-meaningful-paint
   - title: Has Enormous Network Payloads
     path: /web/tools/lighthouse/audits/network-payloads
+  - title: Has multiple page redirects
+    path: /web/tools/lighthouse/audits/redirects
   - title: JavaScript Bootup Time Is Too High
     path: /web/tools/lighthouse/audits/bootup
   - title: Keep Server Response Times Low

--- a/src/content/en/tools/lighthouse/audits/_template.md
+++ b/src/content/en/tools/lighthouse/audits/_template.md
@@ -1,12 +1,12 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
+description: Reference documentation for the "TODO" Lighthouse audit.
 
-{# wf_updated_on: 2018-03-29 #}
+{# wf_updated_on: 2018-04-02 #}
 {# wf_published_on: 2018-04-XX #}
 {# wf_blink_components: Platform>DevTools #}
 
-# AUDIT_NAME  {: .page-title }
+# TODO  {: .page-title }
 
 {# wf_ignore_file - REMOVE THIS BEFORE SAVING FILE!! #}
 
@@ -16,8 +16,8 @@ description: Reference documentation for the "AUDIT_NAME" Lighthouse audit.
 
 ## More information {: #more-info }
 
-* Sources
+Sources:
 
 * [Audit source][src]{:.external}
 
-[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/AUDIT_NAME
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/TODO

--- a/src/content/en/tools/lighthouse/audits/redirects.md
+++ b/src/content/en/tools/lighthouse/audits/redirects.md
@@ -1,0 +1,51 @@
+project_path: /web/tools/_project.yaml
+book_path: /web/tools/_book.yaml
+description: Reference documentation for the "Has multiple page redirects" Lighthouse audit.
+
+{# wf_updated_on: 2018-04-02 #}
+{# wf_published_on: 2018-04-02 #}
+{# wf_blink_components: Platform>DevTools #}
+
+# Has multiple page redirects  {: .page-title }
+
+## Overview {: #overview }
+
+Redirects slow down your page load speed.
+
+When a browser requests a resource that has been redirected, the server usually
+returns an HTTP response like this:
+
+    HTTP/1.1 301 Moved Permanently
+    Location: /path/to/new/location
+
+The browser must then make another HTTP request at the new location in order to
+retrieve the resource. This additional trip across the network can delay the
+loading of the resource by hundreds of milliseconds.
+
+## Recommendations {: #recommendations }
+
+Your Lighthouse report lists resources that are being redirected.
+Update the links to these resources. The links should
+point to the current locations of the resources, so that the redirects are
+eliminated. It's especially important to avoid redirects in resources that
+are required for your [Critical Rendering Path][CRP].
+
+[CRP]: /web/fundamentals/performance/critical-rendering-path/
+
+If you're using redirects to divert mobile users to the mobile version of your
+page, consider re-designing your site to use [Responsive Design][RD].
+
+[RD]: /web/fundamentals/design-and-ux/responsive/
+
+## More information {: #more-info }
+
+A page fails this audit when it has 2 or more redirects.
+
+Sources:
+
+* [Redirections in HTTP][MDN]{:.external}
+* [Avoid Landing Page Redirects](/speed/docs/insights/AvoidRedirects)
+* [Audit source][src]{:.external}
+
+[MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/redirects.js


### PR DESCRIPTION
What's changed, or what was fixed?
- update template
- add reference for redirects audit

**Fixes:** N/A

**Target Live Date:** 2018-04-02

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
