### PR TITLE
Fix: Lazy-loading images image path

### DIFF
--- a/src/content/en/fundamentals/performance/lazy-loading-guidance/images-and-video/index.md
+++ b/src/content/en/fundamentals/performance/lazy-loading-guidance/images-and-video/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: If your site has a ton of images and video, but you don't want to cut down on any of it, lazy loading might be just the technique you need to improve initial page load time and lower per-page payload.
 
-{# wf_updated_on: 2018-03-28 #}
+{# wf_updated_on: 2018-05-28 #}
 {# wf_published_on: 2018-04-04 #}
 {# wf_blink_components: Blink>PerformanceAPIs,Blink>JavaScript>Runtime,Blink>Input #}
 
@@ -52,8 +52,8 @@ the viewport.
 
 <figure>
   <img srcset="images/lazy-loading-example-2x.jpg 2x,
-images/images/lazy-loading-example-1x.jpg 1x"
-src="images/images/lazy-loading-example-1x.jpg" alt="A screenshot of the website
+images/lazy-loading-example-1x.jpg 1x"
+src="images/lazy-loading-example-1x.jpg" alt="A screenshot of the website
 Medium in the browsing, demonstrating lazy loading in action. The blurry
 placeholder is on the left, and the loaded resource is on the right.">
   <figcaption><b>Figure 2</b>. An example of image lazy loading in action. A

--- a/src/content/en/fundamentals/performance/lazy-loading-guidance/images-and-video/index.md
+++ b/src/content/en/fundamentals/performance/lazy-loading-guidance/images-and-video/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: If your site has a ton of images and video, but you don't want to cut down on any of it, lazy loading might be just the technique you need to improve initial page load time and lower per-page payload.
 
-{# wf_updated_on: 2018-05-28 #}
+{# wf_updated_on: 2018-04-04 #}
 {# wf_published_on: 2018-04-04 #}
 {# wf_blink_components: Blink>PerformanceAPIs,Blink>JavaScript>Runtime,Blink>Input #}
 


### PR DESCRIPTION
Issue: lazy-loading-example-1x.jpg had an extraneous `/images/` added to it.

What's changed, or what was fixed?
- Broken image in the new lazy-loading guide

**Target Live Date:** asap

- [X] This has been reviewed and approved by (me)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @robdodson 
