### PR TITLE
Explain rel=noreferrer as well as rel=noopener

### DIFF
--- a/src/content/en/tools/lighthouse/audits/noopener.md
+++ b/src/content/en/tools/lighthouse/audits/noopener.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Opens External Anchors Using rel="noopener"" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-11 #}
+{# wf_updated_on: 2018-04-05 #}
 {# wf_published_on: 2016-11-30 #}
 {# wf_blink_components: N/A #}
 
@@ -21,14 +21,21 @@ has access to your `window` object via `window.opener`, and it can navigate your
 page to a different URL using `window.opener.location = newURL`. See [About
 `rel=noopener`][mths] for a demo and explanation of the vulnerability.
 
+Adding a `rel="noopener"` attribute prevents the new page from being able to
+access the `window.opener` property and will ensure it runs in a separate
+process. The `rel="noreferrer"` attribute has the same effect, but will also
+prevent the `Referer` header from being sent to the new page. See [HTML
+Standard: Link type "noreferrer"][whatwg] for an explanation of this behavior.
+
 [jake]: https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/
 [mths]: https://mathiasbynens.github.io/rel-noopener/
+[whatwg]: https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
 
 ## Recommendations {: #recommendations }
 
-Add `rel="noopener"` to each of the links that Lighthouse has identified in your
-report. In general, always add `rel="noopener"` when you open an external link
-in a new window or tab.
+Add `rel="noopener"` or `rel="noreferrer"` to each of the links that Lighthouse
+has identified in your report. In general, always add one of these attributes
+when you open an external link in a new window or tab.
 
     <a href="https://examplepetstore.com" target="_blank" rel="noopener">...</a>
 
@@ -38,7 +45,7 @@ Lighthouse uses the following algorithm to flag links as `rel="noopener"`
 candidates:
 
 1. Gather all `<a>` nodes that contain the attribute `target="_blank"` and do
-   not contain the attribute `rel="noopener"`.
+   not contain the attribute `rel="noopener"` or `rel="noreferrer"`.
 1. Filter out any same-host links.
 
 Because Lighthouse filters out same-host links, there's an edge case that you


### PR DESCRIPTION
What's changed, or what was fixed?
- Adds information on rel=noreferrer following GoogleChrome/lighthouse#4920

- [ ] This has been reviewed and approved by (?)
- [x] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
