### PR TITLE
Fix typo: console.err is not a function

### DIFF
--- a/src/content/en/tools/puppeteer/articles/ssr.md
+++ b/src/content/en/tools/puppeteer/articles/ssr.md
@@ -195,7 +195,7 @@ async function ssr(url) {
     await page.goto(url, {waitUntil: 'networkidle0'});
     await page.waitForSelector('#posts'); // ensure #posts exists in the DOM.
   } catch (err) {
-    console.err(err);
+    console.error(err);
     throw new Error('page.goto/waitForSelector timed out.');
   }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- this PR just fixes a typo: `console.err()` => `console.error()`

**Fixes:** #issue

**Target Live Date:** 2018-04-05

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
