### PR TITLE
fixes small grammatical error on Text Alternatives for Images

### DIFF
--- a/src/content/en/fundamentals/accessibility/semantics-builtin/text-alternatives-for-images.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/text-alternatives-for-images.md
@@ -3,8 +3,9 @@ book_path: /web/fundamentals/_book.yaml
 description: Using the alt attribute to provide text alternatives for images
 
 
-{# wf_updated_on: 2017-07-25 #}
+{# wf_updated_on: 2018-04-06 #}
 {# wf_published_on: 2016-10-04 #}
+{# wf_blink_components: N/A #}
 
 # Text Alternatives for Images {: .page-title }
 
@@ -30,7 +31,7 @@ Take a look at this image.
 </article>
 
 In the page we have a picture of a cat, illustrating an article on cats'
-well-known judgmental behavior. A screen reader will announces this image using
+well-known judgmental behavior. A screen reader will announce this image using
 its literal name, `"/160204193356-01-cat-500.jpg"`. That's accurate, but not at
 all useful.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes a small grammatical error found on the Accessibility - Text Alternatives for Images page
- Added `{# wf_blink_components: N/A #}` to header to allow tests to pass

**Fixes:** none

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
