### PR TITLE
Fixed typo

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -166,7 +166,7 @@ use for your fallback, in the example below we'd need to cache the
 ```javascript
 const FALLBACK_IMAGE_URL = '/images/fallback.png';
 const imagesHandler = workbox.strategies.cacheFirst();
-worbox.routing.registerRoute(new RegExp('/images/'), ({event}) => {
+workbox.routing.registerRoute(new RegExp('/images/'), ({event}) => {
   return imagesHandler.handle({event})
     .catch(() => caches.match(FALLBACK_IMAGE_URL));
 });
@@ -203,7 +203,7 @@ const postMessagePlugin = {
 };
 
 // Later, use the plugin when creating a response strategy:
-worbox.routing.registerRoute(
+workbox.routing.registerRoute(
   new RegExp('/path/prefix'),
   workbox.strategies.staleWhileRevalidate({
     plugins: [postMessagePlugin],


### PR DESCRIPTION
**Fixed:**
Two typos in variables in code example under [Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes#provide_a_fallback_response_to_a_route) in Workbox.

**Fixes:** GoogleChrome/workbox#1420

**Target Live Date:** 2018-04-06

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @flexchar
