### PR TITLE
Update insecure video src from 'https' to 'http'

### DIFF
--- a/src/content/en/fundamentals/security/prevent-mixed-content/_code/passive-mixed-content.html
+++ b/src/content/en/fundamentals/security/prevent-mixed-content/_code/passive-mixed-content.html
@@ -40,7 +40,7 @@
       <img src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy.jpg">
 
       <!-- An insecure video file loaded on a secure page -->
-      <video src="https://storage.googleapis.com/webfundamentals-assets/videos/chrome.webm" type="video/webm" controls></video>
+      <video src="http://storage.googleapis.com/webfundamentals-assets/videos/chrome.webm" type="video/webm" controls></video>
       <!-- // [END snippet1] -->
     </div>
     <script>


### PR DESCRIPTION
What's changed, or what was fixed?
- Sample passive mixed content insecure video src updated from 'https' to 'http'

**Fixes:** #6019

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
