### PR TITLE
Fix typo: undefined stylesheetContents variable

### DIFF
--- a/src/content/en/tools/puppeteer/articles/ssr.md
+++ b/src/content/en/tools/puppeteer/articles/ssr.md
@@ -475,7 +475,7 @@ const URL = urlModule.URL;
 
 async function ssr(url) {
   ...
-  const stylesheetContent = {};
+  const stylesheetContents = {};
 
   // 1. Stash the responses of local stylesheets.
   page.on('response', async resp => {
@@ -483,7 +483,7 @@ async function ssr(url) {
     const sameOrigin = new URL(responseUrl).origin === new URL(url).origin;
     const isStylesheet = resp.request().resourceType() === 'stylesheet';
     if (sameOrigin && isStylesheet) {
-      stylesheetContent[responseUrl] = await resp.text();
+      stylesheetContents[responseUrl] = await resp.text();
     }
   });
 


### PR DESCRIPTION
What's changed, or what was fixed?
- This fixes an undefined stylesheetContents variable at line 504

**Fixes:** #issue

**Target Live Date:** 2018-04-08

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
