### PR TITLE
Correcting PolyFill Link

### DIFF
--- a/src/content/en/tools/lighthouse/audits/offscreen-images.md
+++ b/src/content/en/tools/lighthouse/audits/offscreen-images.md
@@ -38,7 +38,7 @@ all the things!][IATT] for more on this approach.
 If you do use an IntersectionObserver, make sure to include the
 [polyfill][polyfill], because native browser support is limited.
 
-[polyfill]: https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill
+[polyfill]: https://github.com/w3c/IntersectionObserver/tree/master/polyfill
 
 ## More information {: #more-info }
 


### PR DESCRIPTION
Correcting PolyFill Link on Offscreen Images pages linked to within Lighthouse Audit Reports

What's changed, or what was fixed?
- The Link here https://developers.google.com/web/tools/lighthouse/audits/offscreen-images to https://github.com/w3c/IntersectionObserver/tree/gh-pages/polyfill is a 404.
- The correct link is here https://github.com/w3c/IntersectionObserver/tree/master/polyfill

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
