### PR TITLE
Add temporary updates for WebVR and WebXR for Chrome 67 beta

### DIFF
--- a/src/content/en/_shared/webxr-status.html
+++ b/src/content/en/_shared/webxr-status.html
@@ -1,0 +1,5 @@
+<aside class="note">
+  Note: This article is written for <a href="/web/fundamentals/vr/status#version_1_1">
+  WebVR 1.1</a>, not the <a href="/web/fundamentals/vr/status/#xrdevice">WebXR
+  Device API</a>, which is still in development and subject to change.
+</aside>

--- a/src/content/en/_shared/webxr-status.html
+++ b/src/content/en/_shared/webxr-status.html
@@ -1,5 +1,5 @@
-<aside class="note">
-  Note: This article is written for <a href="/web/fundamentals/vr/status#version_1_1">
+<aside class="caution">
+  Caution: This article is written for <a href="/web/fundamentals/vr/status#version_1_1">
   WebVR 1.1</a>, not the <a href="/web/fundamentals/vr/status/#xrdevice">WebXR
   Device API</a>, which is still in development and subject to change.
 </aside>

--- a/src/content/en/fundamentals/vr/adding-input-to-a-webvr-scene/index.md
+++ b/src/content/en/fundamentals/vr/adding-input-to-a-webvr-scene/index.md
@@ -109,7 +109,7 @@ That should now cover mouse and touch interactions. Let’s see what’s involve
 
 There are two important notes to understand about using the Gamepad API in WebVR today:
 
-* In Chrome 56 you will need to enable the Gamepad Extensions flag in `chrome://flags`. If you have an [Origin Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md) the Gamepad Extensions will already be enabled along with the WebVR APIs. **For local development you’ll need the flag enabled**.
+* In Chrome 56 you will need to enable the Gamepad Extensions flag in `chrome://flags`. If you have an [Origin Trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md) the Gamepad Extensions will already be enabled along with the WebVR APIs. **For local development you’ll need the flag enabled**.
 
 * Pose information for the gamepad (which is how you get access to those 3 degrees of freedom) are **only enabled once a user has pressed a button on their VR controller**.
 

--- a/src/content/en/fundamentals/vr/adding-input-to-a-webvr-scene/index.md
+++ b/src/content/en/fundamentals/vr/adding-input-to-a-webvr-scene/index.md
@@ -2,15 +2,13 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Discover how to use the Ray Input library to add input to your WebVR scene.
 
-{# wf_updated_on: 2016-10-17 #}
+{# wf_updated_on: 2018-04-16 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
 # Adding Input to a WebVR Scene {: .page-title }
 
-Note: This article is written for [WebVR 1.1](../status#version_1_1), not
-[WebVR 2.0](../status#version_2_0), which is still under development. WebVR is
-still experimental and subject to change.
+{% include "web/_shared/webxr-status.html" %}
 
 In the [Getting Started with WebVR section](../getting-started-with-webvr/) we looked at how to take a WebGL scene and add WebVR functionality to it. While that works, and you can look around the scene in VR, there’s so much more fun to be had when you can interact with entities in the scene.
 

--- a/src/content/en/fundamentals/vr/getting-started-with-webvr/index.md
+++ b/src/content/en/fundamentals/vr/getting-started-with-webvr/index.md
@@ -18,7 +18,7 @@ Let’s start with [a scene that puts a box inside a wireframe room](https://goo
 
 ### A small note on support
 
-WebVR is available in Chrome 56+ behind a runtime flag. Enabling the flag (head to `chrome://flags` and search for "WebVR") will allow you to build and test your VR work locally. If you want to support WebVR for your visitors, you can opt into an [Origin Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md), which will allow you to have WebVR enabled for your origin.
+WebVR is available in Chrome 56+ behind a runtime flag. Enabling the flag (head to `chrome://flags` and search for "WebVR") will allow you to build and test your VR work locally. If you want to support WebVR for your visitors, you can opt into an [Origin Trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md), which will allow you to have WebVR enabled for your origin.
 
 You can also use the [Web VR polyfill](https://github.com/googlevr/webvr-polyfill), but bear in mind that there are significant performance penalties when using polyfills. You should definitely test on your target devices, and avoid shipping anything that does not keep up with the device’s refresh rate. A poor or variable frame rate can result in significant discomfort for the people using your experience!
 

--- a/src/content/en/fundamentals/vr/getting-started-with-webvr/index.md
+++ b/src/content/en/fundamentals/vr/getting-started-with-webvr/index.md
@@ -2,15 +2,13 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to take a WebGL scene in Three.js and add WebVR capabilities.
 
-{# wf_updated_on: 2017-10-18 #}
+{# wf_updated_on: 2018-04-16 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
 # Getting Started with WebVR {: .page-title }
 
-Note: This article is written for [WebVR 1.1](../status#version_1_1), not
-[WebVR 2.0](../status#version_2_0), which is still under development. WebVR is
-still experimental and subject to change.
+{% include "web/_shared/webxr-status.html" %}
 
 In this guide we will be exploring the WebVR APIs, and using them to enhance a simple WebGL scene built with [Three.js](https://threejs.org/). For production work, however, you may want to starting with existing solutions, like [WebVR Boilerplate](https://github.com/borismus/webvr-boilerplate). If you’re totally new to Three.js, you can use this [handy starting guide](https://aerotwist.com/tutorials/getting-started-with-three-js/). The community is also extremely supportive, so if you get stuck, definitely give them a shout.
 

--- a/src/content/en/fundamentals/vr/index.md
+++ b/src/content/en/fundamentals/vr/index.md
@@ -30,7 +30,7 @@ but you can try it out with:
 
 * The `#webxr` flag in Chrome 66 and later.
 * As an [Origin
-Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
+Trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
 in Chrome 67 and later.
 
 

--- a/src/content/en/fundamentals/vr/index.md
+++ b/src/content/en/fundamentals/vr/index.md
@@ -2,13 +2,13 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: WebVR
 
-{# wf_updated_on: 2017-10-17 #}
+{# wf_updated_on: 2018-04-16 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
 # WebVR {: .page-title }
 
-Warning: WebVR is still experimental and subject to change.
+{% include "web/_shared/webxr-status.html" %}
 
 <div class="video-wrapper">
   <iframe class="devsite-embedded-youtube-video" data-video-id="jT2mR9WzJ7Y"

--- a/src/content/en/fundamentals/vr/index.md
+++ b/src/content/en/fundamentals/vr/index.md
@@ -24,20 +24,22 @@ and Pixel phone — to create fully immersive 3D experiences in your browser.
 
 ## Support and Availability
 
-Today the WebVR 2.0 API is
+Today the WebXR Device API is
 [under development](https://www.chromestatus.com/features/5680169905815552),
-but you can try out the WebVR 1.1 API in:
+but you can try it out with:
 
-* Chrome Beta (M56+), via an [Origin Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md).
-* Firefox Nightly.
-* Samsung Internet for Android and for Gear VR.
+* The `#webxr` flag in Chrome 66 and later.
+* As an [Origin
+Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
+in Chrome 67 and later.
 
-For browsers that don’t support WebVR, or perhaps have older versions of the
-APIs, you can fall back to the [WebVR Polyfill](https://github.com/googlevr/webvr-polyfill).
-Bear in mind, however, that VR is *extremely performance-sensitive* and
+
+It's also available through the [WebXR
+Polyfill](https://github.com/immersive-web/webxr-polyfill).
+Bear in mind, that VR is *extremely performance-sensitive* and
 polyfills typically have a relatively large performance cost, so it may be worth
 considering whether or not you wish to use the polyfill for a user who doesn’t
-have native support for WebVR.
+have native support for the WebXR Device API.
 
 When in doubt, avoid giving people motion sickness through poorly-performing
 experiences!

--- a/src/content/en/fundamentals/vr/status/index.md
+++ b/src/content/en/fundamentals/vr/status/index.md
@@ -1,8 +1,8 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: Get the latest info on WebVR's status, as well as things to keep in mind when building WebVR experiences.
+description: Get the latest info on WebVR and AR's status, as well as things to keep in mind when building WebVR experiences.
 
-{# wf_updated_on: 2017-11-17 #}
+{# wf_updated_on: 2018-04-16 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
@@ -12,14 +12,34 @@ Warning: WebVR is still experimental and subject to change.
 
 ## WebVR Implementation Status
 
+### WebXR Device API (formerly WebVR 2.0) {:#xrdevice}
+
+Today the API is available in:
+
+* Under the `#webxr` flag in Chrome 66 and later.
+* As an [Origin
+Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
+in Chrome 67 and later.
+
+Follow it's progress below:
+
+<iframe width="100%" height="320"
+  src="https://www.chromestatus.com/feature/5680169905815552?embed"
+  style="border: 1px solid #CCC" allowfullscreen>
+</iframe>
+
+Find more information on browser implementation status on
+[chromestatus.com](https://www.chromestatus.com/features/5680169905815552).
+
 ### Version 1.1 {:#version_1_1}
 
 Today the WebVR 1.1 API is available in:
 
-* Chrome Beta (M56+), via an
-  [Origin Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md).
 * Firefox Nightly.
 * Samsung Internet for Android and for Gear VR.
+* A Chrome [Origin
+Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
+that ran from version 56 beta to June of 2017.
 
 It's supported on:
 
@@ -34,39 +54,17 @@ It's supported on:
 Find more information on browser implementation status on
 [chromestatus.com](https://www.chromestatus.com/features/4532810371039232).
 
-### Version 2.0 {:#version_2_2}
-
-A [new version of the spec](https://w3c.github.io/webvr/spec/latest/) is
-under development. Follow it's progress below:
-
-<iframe width="100%" height="320"
-  src="https://www.chromestatus.com/feature/5680169905815552?embed"
-  style="border: 1px solid #CCC" allowfullscreen>
-</iframe>
-
-Find more information on browser implementation status on
-[chromestatus.com](https://www.chromestatus.com/features/5680169905815552).
-
 ## Considerations
 
 Here are things to remember when building WebVR experiences today.
 
 * **You must serve your WebVR content over HTTPS.** If you don’t your users will
-  get warnings from the browser.
-    * See
-      [Enabling HTTPS on Your Servers](/web/fundamentals/security/encrypt-in-transit/enable-https)
-      for more guidance.
-* **Chrome only supports native WebVR on Android today.** You must be using a
-  Daydream headset with a Pixel phone.
-* **The [WebVR Polyfill](https://github.com/googlevr/webvr-polyfill) may not
+  get warnings from the browser. See [Enabling HTTPS on Your
+  Servers](/web/fundamentals/security/encrypt-in-transit/enable-https)
+  for more guidance.
+* **The [WebXR Polyfill](https://github.com/immersive-web/webxr-polyfill) may not
   always be a 1:1 match with native implementations of the spec.** If you plan
   to use the Polyfill, be sure to check on both VR-capable and non-VR devices.
-* **Users must click a VR controller button before it's available to your
-  code**. You must account for this in your code, typically by showing the user
-  a message requesting they press a controller button at the start of their VR
-  experience.
-* **You must enable Gamepad pose information in Chrome 56 when running locally**.
-  The gamepad information will not contain pose (or location) information when
-  running on localhost unless you enable the Gamepad Extensions runtime flag in
-  Chrome 56. If you are running an Origin Trial the Gamepad Extensions are
-  enabled with the WebVR API.
+* **For some types of sessions, users must click a button before
+  AR or VR are available to your code**. See the [Immersive Web Early Adopters
+  Guide](https://immersive-web.github.io/webxr-reference/) for more information.

--- a/src/content/en/fundamentals/vr/status/index.md
+++ b/src/content/en/fundamentals/vr/status/index.md
@@ -46,6 +46,9 @@ It's supported on:
  * Daydream View since M56
  * Google Cardboard since M57
 
+It's also available through the [WebXR
+Polyfill](https://github.com/immersive-web/webxr-polyfill).
+
 <iframe width="100%" height="320"
   src="https://www.chromestatus.com/feature/4532810371039232?embed"
   style="border: 1px solid #CCC" allowfullscreen>

--- a/src/content/en/fundamentals/vr/status/index.md
+++ b/src/content/en/fundamentals/vr/status/index.md
@@ -8,7 +8,7 @@ description: Get the latest info on WebVR and AR's status, as well as things to 
 
 # WebVR Status and Considerations {: .page-title }
 
-Warning: WebVR is still experimental and subject to change.
+{% include "web/_shared/webxr-status.html" %}
 
 ## WebVR Implementation Status
 

--- a/src/content/en/fundamentals/vr/status/index.md
+++ b/src/content/en/fundamentals/vr/status/index.md
@@ -18,7 +18,7 @@ Today the API is available in:
 
 * Under the `#webxr` flag in Chrome 66 and later.
 * As an [Origin
-Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
+Trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
 in Chrome 67 and later.
 
 Follow it's progress below:
@@ -38,7 +38,7 @@ Today the WebVR 1.1 API is available in:
 * Firefox Nightly.
 * Samsung Internet for Android and for Gear VR.
 * A Chrome [Origin
-Trial](https://github.com/jpchase/OriginTrials/blob/gh-pages/developer-guide.md)
+Trial](https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md)
 that ran from version 56 beta to June of 2017.
 
 It's supported on:

--- a/src/content/en/fundamentals/vr/vr-perspective/index.md
+++ b/src/content/en/fundamentals/vr/vr-perspective/index.md
@@ -2,15 +2,13 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Find out more about how creating content for WebVR is different from creating regular web content.
 
-{# wf_updated_on: 2017-10-17 #}
+{# wf_updated_on: 2018-04-16 #}
 {# wf_published_on: 2017-06-05 #}
 {# wf_blink_components: Blink>WebVR #}
 
 # Seeing the Web from a VR Perspective {: .page-title }
 
-Note: This article is written for [WebVR 1.1](../status#version_1_1), not
-[WebVR 2.0](../status#version_2_0), which is still under development. WebVR is
-still experimental and subject to change.
+{% include "web/_shared/webxr-status.html" %}
 
 There are several things about creating WebVR content that are not like regular
 web development. This means that you need different techniques and a different


### PR DESCRIPTION
The changes in this PR are just stop-gap measures until a more formal update can be published. It's intended to publish with Chrome 67 beta, with a hoped-for release on April 26.

**Target Live Date:** 2018-04-26

- [x] This has been reviewed and approved by appropriate reviewers.
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele

[WF_IGNORE:MAX_LEN,SCRIPT]