### PR TITLE
Info about the crossorigin attribute in the Workbox cross origin guide

### DIFF
--- a/src/content/en/tools/workbox/guides/handle-third-party-requests.md
+++ b/src/content/en/tools/workbox/guides/handle-third-party-requests.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to handle third party requests with Workbox.
 
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-04-18 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -36,6 +36,33 @@ of this Workbox treats opaque responses differently.
 
 You can learn more from this
 [Stackoverflow Q&A](https://stackoverflow.com/questions/39109789/what-limitations-apply-to-opaque-responses).
+
+### Remember to Opt-in to CORS Mode
+
+If you're loading assets from a third party web server that *does* support CORS,
+but you're unexpectedly getting back opaque responses, it could be due to how
+your web app makes those cross-origin requests.
+
+For example, the following HTML will trigger
+[`no-cors` requests](https://fetch.spec.whatwg.org/#concept-request-mode) that
+lead to opaque responses, even if the `example.com` server supports CORS:
+
+```html
+<link rel="stylesheet" href="https://example.com/path/to/style.css">
+<img src="https://example.com/path/to/image.png">
+```
+
+In order to explicitly trigger a
+[`cors` request](https://fetch.spec.whatwg.org/#concept-request-mode), and get
+back a non-opaque response, you need to explicitly opt-in to CORS mode by adding
+the
+[`crossorigin` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+to your HTML:
+
+<pre class="prettyprint">
+&lt;link <b>crossorigin="anonymous"</b> rel="stylesheet" href="https://example.com/path/to/style.css"&gt;
+&lt;img <b>crossorigin="anonymous"</b> src="https://example.com/path/to/image.png"&gt;
+</pre>
 
 ## Workbox Caches Opaque Response Sometimes
 


### PR DESCRIPTION
This addresses a point that can cause confusion (e.g. https://twitter.com/jeffposnick/status/982036941595176960) when folks are trying to figure out why they're seeing opaque responses for subresources loaded via HTML.

**Target Live Date:** 2018-05-01

- [ ] This has been reviewed and approved by (@gauntface)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
