### PR TITLE
HTTP 203 podcast missing link.

### DIFF
--- a/src/content/en/shows/http203/podcast/smooshy-wasm-stacks.md
+++ b/src/content/en/shows/http203/podcast/smooshy-wasm-stacks.md
@@ -20,7 +20,7 @@ In this episode:
 * Memory vs imagination.
 * Desperate attempts to create work-life balance.
 * Jake narrowly avoids being arrested for terrorism.
-* [Smoosh! The real story behind the MooTools mess.](/web/updates/2018/03/smooshgate)
+* [Smoosh! The real story behind the MooTools mess](/web/updates/2018/03/smooshgate).
 * Conversations in conversations in conversations.
 * [`document.all` is falsey](https://stackoverflow.com/a/10394873/123395).
 * Ugh it's range requests again.
@@ -28,7 +28,7 @@ In this episode:
 * [Tinder for bananas](https://tinderforbananas.com/).
 * Screen readers on phones.
 * [Fixing HTML headings and sections](https://github.com/whatwg/html/pull/3499).
-* Porting image codecs to WASM.
+* [Porting image codecs to WASM](/web/updates/2018/03/emscripting-a-c-library).
 
 <a href="http://feeds.feedburner.com/Http203Podcast">
   <span class="material-icons">rss_feed</span>


### PR DESCRIPTION
I forgot a link in the show notes.

**Target Live Date:** asap

- [ ] This has been reviewed and approved by (does this need review?)
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
