### PR TITLE
Highlight code

### DIFF
--- a/src/content/en/fundamentals/push-notifications/subscribing-a-user.md
+++ b/src/content/en/fundamentals/push-notifications/subscribing-a-user.md
@@ -23,17 +23,17 @@ push is supported with two simple checks.
 
 1. Check for *serviceWorker* on *navigator*.
 1. Check for *PushManager* on *window*.
+```
+if (!('serviceWorker' in navigator)) {
+  // Service Worker isn't supported on this browser, disable or hide UI.
+  return;
+}
 
-    if (!('serviceWorker' in navigator)) {
-      // Service Worker isn't supported on this browser, disable or hide UI.
-      return;
-    }
-
-    if (!('PushManager' in window)) {
-      // Push isn't supported on this browser, disable or hide UI.
-      return;
-    }
-
+if (!('PushManager' in window)) {
+  // Push isn't supported on this browser, disable or hide UI.
+  return;
+}
+```
 While browser support is growing quickly for both service worker and
 push messaging support, it's always a good idea to feature detect for both and
 [progressively enhance](https://en.wikipedia.org/wiki/Progressive_enhancement).

--- a/src/content/en/fundamentals/push-notifications/subscribing-a-user.md
+++ b/src/content/en/fundamentals/push-notifications/subscribing-a-user.md
@@ -1,8 +1,9 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-04-23 #}
 {# wf_published_on: 2016-06-30 #}
+{# wf_blink_components: Blink>PushAPI #}
 
 # Subscribing a User {: .page-title }
 


### PR DESCRIPTION
For unknown reasons, the four spaces doesn't work for the code under Feature Detection, so three backticks is applied instead.

What's changed, or what was fixed?
- The code under Feature Detection was not highlighted.

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
