### PR TITLE
Replace broken tracing link in GIF/video article

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
@@ -287,8 +287,8 @@ GIF | 2,668 ms
 MPEG-4 | 1,994 ms
 WebM | 2,330 ms
 
-These figures were gathered in Chrome's tracing utility
-(record your own Chrome traces at `chrome://tracing`) over a period of ~6.5 seconds for each format. As
+These figures were gathered in Chrome's tracing utility (record your own Chrome
+traces at `chrome://tracing`) over a period of ~6.5 seconds for each format. As
 you can see, GIF takes the most CPU time, and less CPU time occurs for both
 videos, particularly MPEG-4. This is good stuff! It means that videos generally
 use less CPU time than animated GIF, which is a welcome performance enhancement

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
@@ -287,8 +287,8 @@ GIF | 2,668 ms
 MPEG-4 | 1,994 ms
 WebM | 2,330 ms
 
-These figures were gathered in Chrome's [tracing utility](chrome://tracing)
-(link only works in Chrome) over a period of ~6.5 seconds for each format. As
+These figures were gathered in Chrome's tracing utility
+(record your own Chrome traces at `chrome://tracing`) over a period of ~6.5 seconds for each format. As
 you can see, GIF takes the most CPU time, and less CPU time occurs for both
 videos, particularly MPEG-4. This is good stuff! It means that videos generally
 use less CPU time than animated GIF, which is a welcome performance enhancement


### PR DESCRIPTION
What's changed, or what was fixed?
- chrome://* links aren't followed by Chrome for security, this replaces the link with an instruction to navigate to the URL instead

**Fixes:** none filed

**Target Live Date:** 2018-04-23

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @malchata 
