### PR TITLE
Add "Was this page helpful?" widget

### DIFF
--- a/src/content/en/_shared/helpful.html
+++ b/src/content/en/_shared/helpful.html
@@ -1,0 +1,36 @@
+{% framebox width="auto" height="auto" enable_widgets="true" %}
+<script>
+var label = window.parent.location.pathname,
+  title = 'Feedback%20on%20' + label,
+  url = 'https://github.com/google/webfundamentals/issues/new?title=' + title,
+  link = '<a href="' + url + '">open an issue</a>',
+  response = 'Thanks for the feedback. Please ' + link + ' and tell us how we can improve.';
+var feedback = {
+  category: "Helpful",
+  question: "Was this page helpful?",
+  choices: [
+    {
+      button: {
+        text: "Yes"
+      },
+      response: response,
+      analytics: {
+        label: label,
+        value: 1
+      }
+    },
+    {
+      button: {
+        text: "No"
+      },
+      response: response,
+      analytics: {
+        label: label,
+        value: 0
+      }
+    }
+  ]
+};
+</script>
+{% include "web/_shared/multichoice.html" %}
+{% endframebox %}

--- a/src/content/en/_shared/helpful.html
+++ b/src/content/en/_shared/helpful.html
@@ -1,10 +1,10 @@
 {% framebox width="auto" height="auto" enable_widgets="true" %}
 <script>
-var label = window.parent.location.pathname,
-  title = 'Feedback%20on%20' + label,
-  url = 'https://github.com/google/webfundamentals/issues/new?title=' + title,
-  link = '<a href="' + url + '">open an issue</a>',
-  response = 'Thanks for the feedback. Please ' + link + ' and tell us how we can improve.';
+var label = window.parent.location.pathname;
+var title = 'Feedback%20on%20' + label;
+var url = 'https://github.com/google/webfundamentals/issues/new?title=' + title;
+var link = '<a href="' + url + '">open an issue</a>';
+var response = 'Thanks for the feedback. Please ' + link + ' and tell us how we can improve.';
 var feedback = {
   category: "Helpful",
   question: "Was this page helpful?",

--- a/src/content/en/tools/chrome-devtools/console/get-started.md
+++ b/src/content/en/tools/chrome-devtools/console/get-started.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Learn how to view messages and run JavaScript in the Console.
 
-{# wf_updated_on: 2018-04-02 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2018-03-08 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -405,42 +405,7 @@ See [Command Line API Reference][CLAPI] for the full reference.
   you.
 </aside>
 
-Was this tutorial helpful?
-
-{% framebox width="auto" height="auto" enable_widgets="true" %}
-<script>
-var label = 'Console / Get Started / Helpful';
-var url = 'https://github.com/google/webfundamentals/issues/new?title=[' +
-      label + ']';
-var feedback = {
-  "category": "DevTools",
-  "choices": [
-    {
-      "button": {
-        "text": "Yes"
-      },
-      "response": "Thank you for the feedback!",
-      "analytics": {
-        "label": label
-      }
-    },
-    {
-      "button": {
-        "text": "No"
-      },
-      "response": 'Sorry to hear that. Please <a href="' + url +
-          '" target="_blank">open a GitHub issue</a> and tell me how I can ' +
-          'make it better.',
-      "analytics": {
-        "label": label,
-        "value": 0
-      }
-    }
-  ]
-};
-</script>
-{% include "web/_shared/multichoice.html" %}
-{% endframebox %}
+{% include "web/_shared/helpful.html" %}
 
 {# Runs on page load. Down here because it takes up space, even though it's not supposed to. #}
 
@@ -450,3 +415,4 @@ var feedback = {
         'Read on to learn how messages like this get here.');
   </script>
 {% endframebox %}
+

--- a/src/content/en/tools/chrome-devtools/css/index.md
+++ b/src/content/en/tools/chrome-devtools/css/index.md
@@ -4,6 +4,7 @@ description: Learn how to use Chrome DevTools to view and change a page's CSS.
 
 {# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2017-06-08 #}
+{# wf_blink_components: Platform>DevTools #}
 
 # Get Started With Viewing And Changing CSS {: .page-title }
 

--- a/src/content/en/tools/chrome-devtools/css/index.md
+++ b/src/content/en/tools/chrome-devtools/css/index.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Learn how to use Chrome DevTools to view and change a page's CSS.
 
-{# wf_updated_on: 2017-06-08 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2017-06-08 #}
 
 # Get Started With Viewing And Changing CSS {: .page-title }
@@ -252,3 +252,7 @@ before doing this one.
     <b>Figure 7</b>. Changing the element's left-margin
   </figcaption>
 </figure>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/tools/chrome-devtools/progressive-web-apps.md
+++ b/src/content/en/tools/chrome-devtools/progressive-web-apps.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Use the Application panel to inspect, modify, and debug web app manifests, service workers, and service worker caches.
 
-{# wf_updated_on: 2016-07-25 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2016-07-25 #}
 
 # Debug Progressive Web Apps {: .page-title }
@@ -199,3 +199,7 @@ Related Guides:
 * [Inspect page resources](/web/tools/chrome-devtools/iterate/manage-data/page-resources)
 * [Inspect and manage local storage and
   caches](/web/tools/chrome-devtools/iterate/manage-data/local-storage)
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/tools/chrome-devtools/progressive-web-apps.md
+++ b/src/content/en/tools/chrome-devtools/progressive-web-apps.md
@@ -4,6 +4,7 @@ description: Use the Application panel to inspect, modify, and debug web app man
 
 {# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2016-07-25 #}
+{# wf_blink_components: Platform>DevTools #}
 
 # Debug Progressive Web Apps {: .page-title }
 

--- a/src/content/en/tools/chrome-devtools/security.md
+++ b/src/content/en/tools/chrome-devtools/security.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Use the Security Panel to ensure that all resources on your  site are protected with HTTPS.
 
-{# wf_updated_on: 2016-03-09 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2015-12-21 #}
 {# wf_blink_components: Security #}
 
@@ -83,3 +83,7 @@ served over HTTP.
 [mixed-content]: /web/fundamentals/security/prevent-mixed-content/what-is-mixed-content
 [same-origin-policy]: https://en.wikipedia.org/wiki/Same-origin_policy
 [why-https]: /web/fundamentals/security/encrypt-in-transit/why-https
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/tools/chrome-devtools/snippets.md
+++ b/src/content/en/tools/chrome-devtools/snippets.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Snippets are small scripts that you can author and execute within the Sources panel of Chrome DevTools. You can access and run them from any page. When you run a snippet, it executes from the context of the currently open page.
 
-{# wf_updated_on: 2016-06-26 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2015-10-12 #}
 
 # Run Snippets Of Code From Any Page {: .page-title }
@@ -65,3 +65,7 @@ Just like other scripts, you can set breakpoints on snippets. See
 [Pause Your Code With
 Breakpoints](/web/tools/chrome-devtools/debug/breakpoints/breakpoints)
 to learn how to add breakpoints from within the **Sources** panel.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/tools/chrome-devtools/snippets.md
+++ b/src/content/en/tools/chrome-devtools/snippets.md
@@ -4,6 +4,7 @@ description: Snippets are small scripts that you can author and execute within t
 
 {# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2015-10-12 #}
+{# wf_blink_components: Platform>DevTools #}
 
 # Run Snippets Of Code From Any Page {: .page-title }
 

--- a/src/content/en/tools/chrome-devtools/sources.md
+++ b/src/content/en/tools/chrome-devtools/sources.md
@@ -3,7 +3,7 @@ book_path: /web/tools/_book.yaml
 description: View and edit files, create Snippets, debug JavaScript, and set up Workspaces in the Sources panel of Chrome DevTools.
 
 {# wf_blink_components: Platform>DevTools #}
-{# wf_updated_on: 2018-01-09 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2018-01-09 #}
 
 {% include "web/tools/chrome-devtools/_shared/styles.html" %}
@@ -159,3 +159,7 @@ your file system. Essentially, this lets you use DevTools as your code editor.
 See [Set Up Persistence With DevTools Workspaces][WS] to get started.
 
 [WS]: /web/tools/setup/setup-workflow
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/tools/chrome-devtools/ui.md
+++ b/src/content/en/tools/chrome-devtools/ui.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: A reference on how to access and use common parts of the DevTools UI, and change the UI's appearance.
 
-{# wf_updated_on: 2017-01-25 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2017-01-25 #}
 
 <style>
@@ -164,3 +164,7 @@ The next time you open DevTools, there's a new page called **Experiments**
 in [Settings](#settings).
 
 [experiments]: chrome://flags/#enable-devtools-experiments
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/tools/chrome-devtools/ui.md
+++ b/src/content/en/tools/chrome-devtools/ui.md
@@ -4,6 +4,7 @@ description: A reference on how to access and use common parts of the DevTools U
 
 {# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2017-01-25 #}
+{# wf_blink_components: Platform>DevTools #}
 
 <style>
 .devtools-inline {

--- a/src/content/en/tools/chrome-devtools/workspaces/index.md
+++ b/src/content/en/tools/chrome-devtools/workspaces/index.md
@@ -3,7 +3,7 @@ book_path: /web/tools/_book.yaml
 description: Learn how to save changes made within DevTools to disk.
 
 {# wf_blink_components: Platform>DevTools #}
-{# wf_updated_on: 2018-04-23 #}
+{# wf_updated_on: 2018-04-24 #}
 {# wf_published_on: 2018-04-10 #}
 
 {# Links #}
@@ -385,42 +385,7 @@ listed at the bottom of this section.
 
 [Kayce]: https://twitter.com/kaycebasques
 
-{% framebox width="auto" height="auto" enable_widgets="true" %}
-<script>
-var label = 'Workspaces / Helpful';
-var url = 'https://github.com/google/webfundamentals/issues/new?title=[' +
-      label + ']';
-var no = 'Sorry to hear that. Please <a href="' + url + '" target="_blank" rel="noopener">open a' +
-  'GitHub issue</a> and tell me how I can make the tutorial better.';
-var feedback = {
-  category: "DevTools",
-  question: "Was this tutorial helpful?",
-  choices: [
-    {
-      button: {
-        text: "Yes"
-      },
-      response: "Great! Thanks for the feedback.",
-      analytics: {
-        label: label,
-        value: 1
-      }
-    },
-    {
-      button: {
-        text: "No"
-      },
-      response: no,
-      analytics: {
-        label: label,
-        value: 0
-      }
-    }
-  ]
-};
-</script>
-{% include "web/_shared/multichoice.html" %}
-{% endframebox %}
+{% include "web/_shared/helpful.html" %}
 
 {% framebox width="auto" height="auto" enable_widgets="true" %}
 <script>


### PR DESCRIPTION
What's changed, or what was fixed?
- adds a "was this page helpful?" inline feedback widget
- adds the widget to a few random pages

The new Helpful widget is an abstraction on top of the previous inline feedback work I've done. The main benefit is that we can now drop it in with a single line:

    {% include "web/_shared/helpful.html" %}

When users click the "Yes" or "No" button, it gets logged as a Google Analytics event, as before. The category is now "Helpful", and the label is the path to the page (thanks to `window.parent.location.pathname`, which Dan or Dave pointed me to). This will enable us to compare the helpfulness of every page, side-by-side, in the Google Analytics dashboard. The standardized structure also lends itself well to pulling the data into other dashboards.

We'll be able to replicate this pattern for other interesting general feedback questions, such as "was the page too long?" 

Note that it's not rendering correctly on the local dev server, but I tried it out on staging, and it seems to work just fine!


**Fixes:** N/A

**Target Live Date:** 2018-04-27

- [ ] This has been reviewed and approved by @petele
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @Meggin 
