### PR TITLE
Avoid warning for `wf_tags: javascript`

### DIFF
--- a/src/data/common-typos.yaml
+++ b/src/data/common-typos.yaml
@@ -41,7 +41,7 @@
   fix: Firefox
   caseSensitive: True
 
-- typo: '[^\S](java\s*script|java\s*Script|Java\s*script)[^\S]'
+- typo: '(?<!wf_tags:\s+)(java\s*script|java\s*Script|Java\s*script)'
   fix: JavaScript
   caseSensitive: True
 


### PR DESCRIPTION
Tags need to be in lowercase, so `wf_tags: javascript` is never a typo.

This patch uses negative lookbehind (Node v9+) to avoid the false positive.

Although this is a small change, we should only merge it once everyone has updated to Node.js v9 or ideally **Node.js v10**.

Adding DO NOT MERGE label until @petele gives the go-ahead.