### PR TITLE
Remove tags from project yaml

### DIFF
--- a/gulp-tasks/tests/projectYaml.js
+++ b/gulp-tasks/tests/projectYaml.js
@@ -77,7 +77,6 @@ const SCHEMA_PROJECT = {
       },
       additionalProperties: false,
     },
-    tags: {type: 'array'},
   },
   additionalProperties: false,
 };

--- a/src/content/en/_project.yaml
+++ b/src/content/en/_project.yaml
@@ -8,11 +8,6 @@ content_license: cc3-apache2
 footer_path: /web/_footer.yaml
 icon:
   path: /web/images/web-fundamentals-icon192x192.png
-tags:
-  - html5
-  - mobile
-  - performance
-  - web
 google_analytics_ids:
   - UA-52746336-1
 social_media:

--- a/src/content/en/feedback/_project.yaml
+++ b/src/content/en/feedback/_project.yaml
@@ -10,11 +10,6 @@ icon:
   path: /web/images/web-fundamentals-icon192x192.png
 google_analytics_ids:
   - UA-52746336-1
-tags:
-  - html5
-  - mobile
-  - performance
-  - web
 social_media:
   image:
     path: /web/images/social-webfu-16x9.png

--- a/src/content/en/fundamentals/_project.yaml
+++ b/src/content/en/fundamentals/_project.yaml
@@ -10,11 +10,6 @@ icon:
   path: /web/images/web-fundamentals-icon192x192.png
 google_analytics_ids:
   - UA-52746336-1
-tags:
-  - html5
-  - mobile
-  - performance
-  - web
 social_media:
   image:
     path: /web/images/social-webfu-16x9.png


### PR DESCRIPTION
Per DevSite, tags have been deprecated for a while, officially removing from our `_project.yaml` files, and removing from valid params in tests
