### PR TITLE
Fixes a link used in the workbox-sw module guide.

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-sw.md
+++ b/src/content/en/tools/workbox/modules/workbox-sw.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-sw.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-05-03 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox {: .page-title }
@@ -51,13 +51,12 @@ offline use.
 If you don’t want to use the CDN, it’s easy enough to switch to Workbox files
 hosted on your own domain.
 
-The simplest approach is to get the files via [workbox-build#getFiles()]() or
-from a [Github Release](https://github.com/GoogleChrome/workbox/releases) and
-then tell `workbox-sw` where to find these files via the `modulePathPrefix`
-config option.
+The simplest approach is to get the files via [`workbox-cli`'s `copyLibraries`
+command](/web/tools/workbox/modules/workbox-cli#copylibraries) or from a [GitHub
+Release](https://github.com/GoogleChrome/workbox/releases), and then tell
+`workbox-sw` where to find these files via the `modulePathPrefix` config option.
 
-Let’s say you put the files under `/third_party/workbox/`, you would use them
-like so:
+If you put the files under `/third_party/workbox/`, you would use them like so:
 
 ```javascript
 importScripts('/third_party/workbox/workbox-sw.js');


### PR DESCRIPTION
Fixes misleading anchor text and link in the `workbox-sw` module guide.

**Fixes:** https://github.com/GoogleChrome/workbox/issues/1469

**Target Live Date:** 2018-05-10

- [ ] This has been reviewed and approved by (@philipwalton)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @abraham
