### PR TITLE
Small typo in the urlManipulation example

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -212,7 +212,7 @@ workbox.precaching.precacheAndRoute(
     { url: '/index.html', revision: '383676' },
   ],
   {
-    urlManipulaion: ({url}) => {
+    urlManipulation: ({url}) => {
       ...
       return [alteredUrlOption1, alteredUrlOption2, ...];
     }


### PR DESCRIPTION
What's changed, or what was fixed?
- Very minor typo in the urlManipulation example on workbox-precaching.md page

**Fixes:** n/a

**Target Live Date:** n/a

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
