### PR TITLE
[devtools] set up A/B experiment

### DIFF
--- a/src/content/en/updates/2018/04/_experiments.yaml
+++ b/src/content/en/updates/2018/04/_experiments.yaml
@@ -1,0 +1,12 @@
+experiments:
+- name: inline_feedback
+  description: Test whether more specific inline feedback prompts elicit more responses.
+  analytics_id: UA-52746336-1
+  analytics_custom_dimension_index: 1
+  variants:
+  - name: generic_prompt
+    description: A generic prompt, not related to the page. Should get less responses.
+    percent: 50
+  - name: specific_prompt
+    description: A specific prompt, related to the page. Should get more responses.
+    percent: 50

--- a/src/content/en/updates/2018/04/devtools.md
+++ b/src/content/en/updates/2018/04/devtools.md
@@ -297,7 +297,7 @@ That's all for Chrome 67!
   {% framebox width="auto" height="auto" enable_widgets="true" %}
     <script>
       var label = '/web/updates/2018/04/devtools (generic)';
-      var response = "Thank your for the feedback!";
+      var response = "Thank you for the feedback!";
       var feedback = {
         category: "Helpful",
         question: "Was this page helpful?",
@@ -331,7 +331,7 @@ That's all for Chrome 67!
   {% framebox width="auto" height="auto" enable_widgets="true" %}
     <script>
       var label = '/web/updates/2018/04/devtools (specific)';
-      var response = "Thank your for the feedback!";
+      var response = "Thank you for the feedback!";
       var feedback = {
         category: "Helpful",
         question: "How are we doing with these release notes? Did you find this post helpful?",

--- a/src/content/en/updates/2018/04/devtools.md
+++ b/src/content/en/updates/2018/04/devtools.md
@@ -1,8 +1,9 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Search across network headers, copy requests as fetch, audit pages using desktop conditions, and much more.
+experiments_path: /web/updates/2018/04/_experiments.yaml
 
-{# wf_updated_on: 2018-05-02 #}
+{# wf_updated_on: 2018-05-03 #}
 {# wf_published_on: 2018-04-11 #}
 {# wf_tags: chrome67,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -290,7 +291,7 @@ a flame chart for each process so that you can see the total work that each proc
 
 ## Feedback {: #feedback }
 
-<meta name="experiments_path" value="/web/updates/2018/04/_experiments.yaml"/>
+That's all for Chrome 67!
 
 {% dynamic if experiments.inline_feedback.generic_prompt %}
   {% framebox width="auto" height="auto" enable_widgets="true" %}
@@ -329,11 +330,11 @@ a flame chart for each process so that you can see the total work that each proc
 {% dynamic elif experiments.inline_feedback.specific_prompt %}
   {% framebox width="auto" height="auto" enable_widgets="true" %}
     <script>
-      var label = '/web/updates/2018/04/devtools (generic)';
+      var label = '/web/updates/2018/04/devtools (specific)';
       var response = "Thank your for the feedback!";
       var feedback = {
         category: "Helpful",
-        question: "That's all for Chrome 67. How are we doing with these release notes? Did you find this post helpful?",
+        question: "How are we doing with these release notes? Did you find this post helpful?",
         choices: [
           {
             button: {
@@ -362,11 +363,13 @@ a flame chart for each process so that you can see the total work that each proc
   {% endframebox %}
 {% dynamic endif %}
 
+To discuss the new features and changes in this post, or anything else related to DevTools:
+
 * File bug reports at [Chromium Bugs](https://crbug.com){:.external}.
-* Discuss features and changes on the [Mailing List][ML]{:.external}. Please don't use this
-  channel for support questions. Use Stack Overflow, instead.
+* Discuss features and changes on the [Mailing List][ML]{:.external}. Please don't use the mailing
+  list for support questions. Use Stack Overflow, instead.
 * Get help on how to use DevTools on [Stack Overflow][SO]{:.external}. Please don't file bugs
-  here. Use Chromium Bugs, instead.
+  on Stack Overflow. Use Chromium Bugs, instead.
 * Tweet us at [@ChromeDevTools](https://twitter.com/chromedevtools).
 * File bugs on this doc in the [Web Fundamentals][WF]{:.external} repository.
 

--- a/src/content/en/updates/2018/04/devtools.md
+++ b/src/content/en/updates/2018/04/devtools.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Search across network headers, copy requests as fetch, audit pages using desktop conditions, and much more.
 
-{# wf_updated_on: 2018-04-11 #}
+{# wf_updated_on: 2018-05-02 #}
 {# wf_published_on: 2018-04-11 #}
 {# wf_tags: chrome67,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -289,6 +289,78 @@ a flame chart for each process so that you can see the total work that each proc
 [SI]: https://www.chromium.org/Home/chromium-security/site-isolation
 
 ## Feedback {: #feedback }
+
+<meta name="experiments_path" value="/web/updates/2018/04/_experiments.yaml"/>
+
+{% dynamic if experiments.inline_feedback.generic_prompt %}
+  {% framebox width="auto" height="auto" enable_widgets="true" %}
+    <script>
+      var label = '/web/updates/2018/04/devtools (generic)';
+      var response = "Thank your for the feedback!";
+      var feedback = {
+        category: "Helpful",
+        question: "Was this page helpful?",
+        choices: [
+          {
+            button: {
+              text: "Yes"
+            },
+            response: response,
+            analytics: {
+              label: label,
+              value: 1
+            }
+          },
+          {
+            button: {
+              text: "No"
+            },
+            response: response,
+            analytics: {
+              label: label,
+              value: 0
+            }
+          }
+        ]
+      };
+    </script>
+    {% include "web/_shared/multichoice.html" %}
+  {% endframebox %}
+{% dynamic elif experiments.inline_feedback.specific_prompt %}
+  {% framebox width="auto" height="auto" enable_widgets="true" %}
+    <script>
+      var label = '/web/updates/2018/04/devtools (generic)';
+      var response = "Thank your for the feedback!";
+      var feedback = {
+        category: "Helpful",
+        question: "That's all for Chrome 67. How are we doing with these release notes? Did you find this post helpful?",
+        choices: [
+          {
+            button: {
+              text: "Yes"
+            },
+            response: response,
+            analytics: {
+              label: label,
+              value: 1
+            }
+          },
+          {
+            button: {
+              text: "No"
+            },
+            response: response,
+            analytics: {
+              label: label,
+              value: 0
+            }
+          }
+        ]
+      };
+    </script>
+    {% include "web/_shared/multichoice.html" %}
+  {% endframebox %}
+{% dynamic endif %}
 
 * File bug reports at [Chromium Bugs](https://crbug.com){:.external}.
 * Discuss features and changes on the [Mailing List][ML]{:.external}. Please don't use this


### PR DESCRIPTION
What's changed, or what was fixed?
- adds A/B test to WNDT67 using devsite's infrastructure

**Fixes:** N/A

**Target Live Date:** 2018-05-05

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
