### PR TITLE
Remove new keyword from workbox.strategies inside registerRoute method

### DIFF
--- a/src/content/en/tools/workbox/guides/configure-workbox.md
+++ b/src/content/en/tools/workbox/guides/configure-workbox.md
@@ -81,7 +81,7 @@ If you wanted to use a cache for images, you might configure a route like this:
 ```javascript
 workbox.routing.registerRoute(
   /.*\.(?:png|jpg|jpeg|svg|gif)/g,
-  new workbox.strategies.CacheFirst({
+  workbox.strategies.CacheFirst({
     cacheName: 'my-image-cache',
   })
 );
@@ -109,7 +109,7 @@ using a credentials mode of 'include', you can set up the following route:
 ```javascript
 workbox.routing.registerRoute(
   new RegExp('https://third-party\.example\.com/'),
-  new workbox.strategies.NetworkFirst({
+  workbox.strategies.NetworkFirst({
     fetchOptions: {
       credentials: 'include',
     },


### PR DESCRIPTION
What's changed, or what was fixed?
- When registering a route with a loading strategy in 3.2.0 using the `new` keyword as the documentation on this page mention causes the following error: `Uncaught TypeError: workbox.strategies.staleWhileRevalidate is not a constructor`. Removing the new keyword works as expected so I assume this is an API change and the document hasn't been updated?

**Fixes:** n/a

**Target Live Date:** n/a

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
