### PR TITLE
DOMContentReady -> DOMContentLoaded

### DIFF
--- a/src/content/en/fundamentals/security/csp/index.md
+++ b/src/content/en/fundamentals/security/csp/index.md
@@ -271,7 +271,7 @@ to something more like:
     function doAmazingThings() {
       alert('YOU AM AMAZING!');
     }
-    document.addEventListener('DOMContentReady', function () {
+    document.addEventListener('DOMContentLoaded', function () {
       document.getElementById('amazing')
         .addEventListener('click', doAmazingThings);
     });


### PR DESCRIPTION
There is no such thing as DOMContentReady :)

What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @mikewest 
