### PR TITLE
Updated the workbox-build example with some logged details

### DIFF
--- a/src/content/en/tools/workbox/guides/precache-files/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/precache-files/workbox-build.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to precache files with workbox-build.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-05-18 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Precache Files with workbox-build {: .page-title }
@@ -46,6 +46,10 @@ const buildSW = () => {
     globPatterns: [
       '**\/*.{js,css,html,png}',
     ]
+  }).then(({count, size, warnings}) => {
+    // Optionally, log any warnings and details.
+    warnings.forEach(console.warn);
+    console.log(`${count} files will be precached, totaling ${size} bytes.`);
   });
 }
 
@@ -94,6 +98,10 @@ gulp.task('service-worker', () => {
     globPatterns: [
       '**\/*.{js,css,html,png}',
     ]
+  }).then(({count, size, warnings}) => {
+    // Optionally, log any warnings and details.
+    warnings.forEach(console.warn);
+    console.log(`${count} files will be precached, totaling ${size} bytes.`);
   });
 });
 ```


### PR DESCRIPTION
The example of using `workbox-build` from within a `gulp` script didn't take advantage of the new `warnings` and other context returned in the promise.

**Target Live Date:** 2018-05-31

- [x] This has been reviewed and approved by (@philipwalton)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
