### PR TITLE
A2HS display requirement

### DIFF
--- a/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
+++ b/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
@@ -1,3 +1,5 @@
+{# wf_updated_on: 2018-05-21 #}
+
 Chrome will automatically show the Add to Home Screen prompt to the user when
 the following criteria are met:
 
@@ -14,9 +16,24 @@ the following criteria are met:
         Includes a <a href="/web/fundamentals/web-app-manifest/">
         web app manifest</a> that includes:
         <ul>
-          <li><code>short_name</code> or <code>name</code></li>
-          <li><code>icons</code> including a 192px and a 512px version</li>
-          <li><code>start_url</code></li>
+          <li>
+            <a href="/web/fundamentals/web-app-manifest/#name"><code>short_name</code>
+            or <code>name</code></a>
+          </li>
+          <li>
+            <a href="/web/fundamentals/web-app-manifest/#icons"><code>icons</code></a>
+            must include a 192px and a 512px sized icons
+          </li>
+          <li>
+            <a href="/web/fundamentals/web-app-manifest/#start-url"><code>start_url</code></a>
+          </li>
+          <li>
+            <a href="/web/fundamentals/web-app-manifest/#display"><code>display</code></a>
+            must be one of:
+            <a href="/web/fundamentals/web-app-manifest/#display-params"><code>fullscreen</code></a>,
+            <a href="/web/fundamentals/web-app-manifest/#display-params"><code>standalone</code></a>,
+            or <a href="/web/fundamentals/web-app-manifest/#display-params"><code>minimal-ui</code></a>
+          </li>
         </ul>
       </li>
       <li>Served over <b>HTTPS</b> (required for service workers)</li>

--- a/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
+++ b/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
@@ -1,4 +1,4 @@
-{# wf_updated_on: 2018-05-21 #}
+<div id="pwa-criteria" class="clearfix"></div>
 
 Chrome will automatically show the Add to Home Screen prompt to the user when
 the following criteria are met:

--- a/src/content/en/fundamentals/app-install-banners/index.md
+++ b/src/content/en/fundamentals/app-install-banners/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Add to Home Screen gives you the ability to let users quickly and seamlessly add your web app to their home screens without leaving the browser.
 
-{# wf_updated_on: 2018-05-10 #}
+{# wf_updated_on: 2018-05-21 #}
 {# wf_published_on: 2014-12-16 #}
 {# wf_blink_components: Platform>Apps>AppLauncher>Install #}
 
@@ -167,7 +167,12 @@ You can manually trigger the `beforeinstallprompt` event with Chrome DevTools.
 This makes it possible to see the user experience, understand how the flow
 works or debug the flow.
 
-Caution: If the PWA criteria aren't met, Chrome will throw an exception in
+Caution: To properly test the mobile flow, you <b>must</b> use
+<a href="/web/tools/chrome-devtools/remote-debugging/">remote debugging.</a>
+Testing the mobile install experience on the desktop will result in the
+desktop PWA install flow which may be different.
+
+If the PWA criteria aren't met, Chrome will throw an exception in
 the console, and the event will not be fired.
 
 Fire the `beforeinstallprompt` event from DevTools:

--- a/src/content/en/fundamentals/app-install-banners/index.md
+++ b/src/content/en/fundamentals/app-install-banners/index.md
@@ -154,37 +154,41 @@ reflected to the user after they've run your app again.
 
 ## Test your add to home screen experience {: #test }
 
+You can manually trigger the `beforeinstallprompt` event with Chrome DevTools.
+This makes it possible to see the user experience, understand how the flow
+works or debug the flow. If the [PWA criteria](#pwa-criteria) aren't met,
+Chrome will throw an exception in the console, and the event will not be fired.
+
+Caution: Chrome has a slightly different install flow for desktop and mobile.
+Although the instructions are similar, testing on mobile <b>requires</b> remote
+debugging, without it, it will use the desktop install flow.
+
+
+### Chrome for Android
+
+1. Open a [remote debugging](/web/tools/chrome-devtools/remote-debugging/)
+   session to your phone or tablet.
+2. Go to the **Application** panel.
+3. Go to the **Manifest** tab.
+4. Click **Add to home screen**
+
+
+### Chrome OS
+
+Dogfood: <a href="/web/updates/2018/05/dpwa">Desktop Progressive Web App</a>
+requires Chrome OS 67 or later. For Mac or Windows, you'll
+need to <a href="/web/updates/2018/05/dpwa#getting-started">enable the
+<code>#enable-desktop-pwas</code> flag.</a>
+
+1. Open Chrome DevTools
+2. Go to the **Application** panel.
+3. Go to the **Manifest** tab.
+4. Click **Add to home screen**
+
+
 ### Will `beforeinstallprompt` be fired?
 
 The easiest way to test if the `beforeinstallprompt` event will be fired, is
-to use Lighthouse to audit your app, and check the results of the
-[User Can Be Prompted To Install The Web App](/web/tools/lighthouse/audits/install-prompt)
+to use [Lighthouse](/web/tools/lighthouse/) to audit your app, and check the
+results of the [User Can Be Prompted To Install The Web App](/web/tools/lighthouse/audits/install-prompt)
 test.
-
-### Manually triggering the `beforeinstallprompt` event
-
-You can manually trigger the `beforeinstallprompt` event with Chrome DevTools.
-This makes it possible to see the user experience, understand how the flow
-works or debug the flow.
-
-Caution: To properly test the mobile flow, you <b>must</b> use
-<a href="/web/tools/chrome-devtools/remote-debugging/">remote debugging.</a>
-Testing the mobile install experience on the desktop will result in the
-desktop PWA install flow which may be different.
-
-If the PWA criteria aren't met, Chrome will throw an exception in
-the console, and the event will not be fired.
-
-Fire the `beforeinstallprompt` event from DevTools:
-
-1. Open Chrome DevTools.
-2. Go to the **Application** panel.
-3. Go to the **Manifest** tab.
-4. Click **Add to home screen**, highlighted in red in the screenshot below.
-
-![Add to home screen button on DevTools](images/devtools-a2hs.png)
-
-Note: See <a href="/web/tools/chrome-devtools/progressive-web-apps#add-to-homescreen">
-Simulate Add to Home Screen events</a> for more help.
-
-

--- a/src/content/en/fundamentals/web-app-manifest/index.md
+++ b/src/content/en/fundamentals/web-app-manifest/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: The web app manifest is a JSON file that gives you the ability to control how your web app or site appears to the user in areas where they would expect to see native apps (for example, a device's home screen), direct what the user can launch, and define its appearance at launch.
 
-{# wf_updated_on: 2018-05-10 #}
+{# wf_updated_on: 2018-05-21 #}
 {# wf_published_on: 2016-02-11 #}
 {# wf_blink_components: Manifest #}
 
@@ -64,7 +64,7 @@ encompass your web app:
 ## Key manifest properties
 
 
-### `short_name` and/or `name`
+### `short_name` and/or `name` {: #name }
 
 You must provide at least the `short_name` or `name` property. If both are
 provided, `short_name` is used on the user's home screen, launcher, or other
@@ -75,7 +75,7 @@ places where space may be limited. `name` is used on the
     "name": "Google Maps"
 
 
-### `icons`
+### `icons` {: #icons }
 
 When a user adds your site to their home screen, you can define a set of
 icons for the browser to use. These icons are used in places like the home
@@ -102,7 +102,7 @@ automatically scale the icon for the device. If you'd prefer to scale your
 own icons and adjust them for pixel-perfection, provide icons in increments
 of 48dp.
 
-### `start_url`
+### `start_url` {: #start-url }
 
 The `start_url` tells the browser where your application should start when it
 is launched, and prevents the app from starting on whatever page the user was
@@ -117,12 +117,12 @@ they open your app, and place them there.
 Success: add a query string to the end of the `start_url` to track how often
 your app is launched.
 
-### `background_color`
+### `background_color` {: #background-color }
 
 The `background_color` property is used on the [splash screen](#splash-screen)
 when the application is first launched.
 
-### `display`
+### `display` {: #display }
 
 You can customize what browser UI is shown when your app is launched. For
 example, you can hide the address bar and browser chrome. Or games may want
@@ -130,7 +130,7 @@ to go completely full screen.
 
     "display": "standalone"
 
-<table class="responsive">
+<table id="display-params" class="responsive">
   <tbody>
     <tr>
       <th colspan=2>Parameters</th>
@@ -138,7 +138,7 @@ to go completely full screen.
     <tr>
       <td><code>value</code></td><td><code>Description</code></td>
     </tr>
-    <tr>
+    <tr id="display-fullscreen">
       <td><code>fullscreen</code></td>
       <td>
         Opens the web application without any browser UI and takes
@@ -172,7 +172,7 @@ Success: In order to show the
 [Add to Home Screen Prompt](/web/fundamentals/app-install-banners/), `display`
 must be set to standalone.
 
-### `orientation`
+### `orientation` {: #orientation }
 
 You can enforce a specific orientation, which is advantageous for apps
 that work in only one orientation, such as games. Use this selectively.
@@ -180,7 +180,7 @@ Users prefer selecting the orientation.
 
     "orientation": "landscape"
 
-### `scope`
+### `scope` {: #scope }
 
 The `scope` defines the set of URLs that the browser considers within your app,
 and is used to decide when you’ve left your app, and should be bounced
@@ -201,7 +201,7 @@ A few other tips:
 * The `start_url` is relative to the path defined in the `scope` attribute.
 * A `start_url` starting with `/` will always be the root of the origin.
 
-### `theme_color`
+### `theme_color` {: #theme-color }
 
 The `theme_color` sets the color of the tool bar, and in the task switcher.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- add `display` property to the required manifest
- added comment about testing on remote debugging for the full experience
- added anchors for specific properties and linked to the docs


**Target Live Date:** ASAP

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

