### PR TITLE
Use unified a2hs criteria

### DIFF
--- a/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
+++ b/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
@@ -1,5 +1,6 @@
-Chrome will automatically show the Add to Home Screen prompt to the user when
-the following criteria are met:
+When the following criteria are met, Chrome will fire the
+<a href="/web/fundamentals/app-install-banners/#listen_for_beforeinstallprompt">
+<code>beforeinstallprompt</code></a> event, then show the prompt to the user.
 
 <ul>
   <li>The web app is not already installed</li>
@@ -19,7 +20,10 @@ the following criteria are met:
           <li><code>start_url</code></li>
         </ul>
       </li>
-      <li>Served over <b>HTTPS</b> (required for service workers)</li>
+      <li>
+        Served over <a href="/web/tools/lighthouse/audits/https"><b>HTTPS</b></a>
+        (required for service workers)
+      </li>
       <li>
         Has registered a <a href="/web/fundamentals/getting-started/primers/service-workers">
         service worker</a> with a <code>fetch</code> event handler
@@ -27,11 +31,6 @@ the following criteria are met:
     </ul>
   </li>
 </ul>
-
-If the web app manifest includes <code>related_applications</code> and
-has <code>"prefer_related_applications": true</code>, the
-<a href="/web/fundamentals/app-install-banners/native">native app install
-prompt</a> will be shown instead.
 
 <aside class="caution">
   <b>Caution:</b> Beginning in Chrome 68 (May 2018), Chrome will <b>not</b>

--- a/src/content/en/fundamentals/app-install-banners/index.md
+++ b/src/content/en/fundamentals/app-install-banners/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Add to Home Screen gives you the ability to let users quickly and seamlessly add your web app to their home screens without leaving the browser.
 
-{# wf_updated_on: 2018-05-10 #}
+{# wf_updated_on: 2018-05-21 #}
 {# wf_published_on: 2014-12-16 #}
 {# wf_blink_components: Platform>Apps>AppLauncher>Install #}
 
@@ -23,6 +23,11 @@ and home screen. Chrome handles most of the heavy lifting for you.
 ## What is the criteria? {: #criteria }
 
 {% include "web/fundamentals/app-install-banners/_a2hs-criteria.html" %}
+
+If the web app manifest includes <code>related_applications</code> and
+has <code>"prefer_related_applications": true</code>, the
+<a href="/web/fundamentals/app-install-banners/native">native app install
+prompt</a> will be shown instead.
 
 ## Show the add to home screen prompt {: #trigger }
 

--- a/src/content/en/tools/lighthouse/audits/install-prompt.md
+++ b/src/content/en/tools/lighthouse/audits/install-prompt.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "User Can Be Prompted To Install The Web App" Lighthouse audit.
 
-{# wf_updated_on: 2017-12-11 #}
+{# wf_updated_on: 2018-05-21 #}
 {# wf_published_on: 2017-06-16 #}
 {# wf_blink_components: N/A #}
 
@@ -23,25 +23,13 @@ Twitter's case study.
 
 ## Recommendations {: #recommendations }
 
-Google Chrome automatically displays the install prompt once it detects that
-a site qualifies as a Progressive Web App. These are Chrome's criteria:
+{% include "web/fundamentals/app-install-banners/_a2hs-criteria.html" %}
 
-* The site is served over HTTPS. HTTPS is required for
-  registering a service worker. See [Uses HTTPS][HTTPS].
-* A service worker is registered.
-* The scope of the service worker includes the page you audited and the
-  page specified in the `start_url` property of the web app manifest.
-* A web app manifest exists and meets the following criteria:
-    * Has a valid `name` property.
-    * Has a valid `short_name` property.
-    * Has a valid `start_url` property.
-    * Has a valid `display` property and the value is `standalone`,
-      `fullscreen`, or `minimal-ui`.
-    * Specifies an icon that is at least 192px by 192px.
 
-See [Web App Install Banners][WAIB] to learn more.
+In addition, the scope of the service worker includes the page you audited
+and the page specified in the `start_url` property of the web app manifest. See
+[add to home screen][WAIB] to learn more.
 
-[HTTPS]: /web/tools/lighthouse/audits/https
 [WAIB]: /web/fundamentals/app-install-banners
 
 {% framebox width="auto" height="auto" enable_widgets="true" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Removes existing a2hs criteria and uses unified criteria

**Target Live Date:** ASAP

- [ ] This has been reviewed and approved by @kaycebasques 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @kaycebasques 
