### PR TITLE
[Workbox] Info on using the Cache Storage API from your web page

### DIFF
--- a/src/content/en/tools/workbox/guides/common-recipes.md
+++ b/src/content/en/tools/workbox/guides/common-recipes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Common recipes to use with Workbox.
 
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-05-22 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -155,5 +155,47 @@ we could use the regular expression `new RegExp('/static/.*/')`, like so:
 workbox.routing.registerRoute(
   new RegExp('/static/(.*)'),
   workbox.strategies.staleWhileRevalidate(),
+);
+```
+
+## Access Caches from Your Web App's Code
+
+The [Cache Storage
+API](/web/fundamentals/instant-and-offline/web-storage/cache-api) is available
+for use in both service worker and in the context of `window` clients. If you
+want to make changes to caches—add or remove entries, or get a list of cached
+URLs—from the context of your web app, you can do so directly, without having to
+communicate with the service worker via `postMessage()`.
+
+For instance, if you wanted to add a URL to the a given cache in response to a
+user action in your web app, you can use code like the following:
+
+```javascript
+// Inside app.js:
+
+async function addToCache(urls) {
+  const myCache = await window.caches.open('my-cache');
+  await myCache.addAll(urls);
+}
+
+// Call addToCache whenever you'd like. E.g. to add to cache after a page load:
+window.addEventListener('load', () => {
+  // ...determine the list of related URLs for the current page...
+  addToCache(['/static/relatedUrl1', '/static/relatedUrl2']);
+});
+```
+
+The cache name, `'my-cache'`, can then be referred to when setting up a route in
+your service worker, and that route can take advantage of any cache entries
+that were added by the web page itself:
+
+```javascript
+// Inside service-worker.js:
+
+workbox.routing.registerRoute(
+  new RegExp('^/static/'),
+  workbox.strategies.staleWhileRevalidate({
+    cacheName: 'my-cache', // Use the same cache name as before.
+  })
 );
 ```


### PR DESCRIPTION
This adds a Workbox recipe mentioned in https://github.com/GoogleChrome/workbox/issues/1377

**Target Live Date:** 2018-05-29

- [ ] This has been reviewed and approved by (@philipwalton)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
