### PR TITLE
Payments: update links to Google Pay Payment Request tutorial

### DIFF
--- a/src/content/en/fundamentals/_redirects.yaml
+++ b/src/content/en/fundamentals/_redirects.yaml
@@ -115,7 +115,7 @@ redirects:
   to: /web/fundamentals/payments/...
 
 - from: /web/fundamentals/payments/android-pay
-  to: /pay/api/web/paymentrequest/tutorial
+  to: /pay/api/web/guides/paymentrequest/tutorial
 
 - from: /web/fundamentals/feed.xml
   to: /web/fundamentals/rss.xml

--- a/src/content/en/fundamentals/payments/_toc.yaml
+++ b/src/content/en/fundamentals/payments/_toc.yaml
@@ -8,5 +8,5 @@ toc:
   - title: Payment Request UX considerations
     path: /web/fundamentals/payments/payment-request-ux-considerations
   - title: Set up Google Pay API
-    path: /pay/api/web/paymentrequest/tutorial
+    path: /pay/api/web/guides/paymentrequest/tutorial
     status: external

--- a/src/content/en/fundamentals/payments/android-pay.md
+++ b/src/content/en/fundamentals/payments/android-pay.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Android Pay enables simple and secure purchases online and eliminates the need for users to remember and manually enter their payment information. Integrate Android Pay to reach millions of Android users, drive higher conversion, and give users a true one-touch checkout experience.
 
 {# wf_blink_components: Blink>Payments #}
-{# wf_updated_on: 2018-02-20 #}
+{# wf_updated_on: 2018-05-22 #}
 {# wf_published_on: 2016-09-07 #}
 
 # Integrating Android Pay into Payment Request {: .page-title }
@@ -13,7 +13,7 @@ description: Android Pay enables simple and secure purchases online and eliminat
 
 Warning: Android Pay is now Google Pay and provides access to payment
 tokens on the device and credit and debit cards from a user's Google account. To
-learn more about Google Pay, read the [Google Pay API](/pay/api/) docs.
+learn more about Google Pay, read the [Google Pay API](/pay/api/web/) docs.
 
 Android Pay enables simple and secure purchases online and eliminates the
 need for users to remember and manually enter their payment information.

--- a/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/payments/deep-dive-into-payment-request.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: How to implement and take full advantage of the Payment Request API.
 
 {# wf_published_on: 2017-04-21 #}
-{# wf_updated_on: 2018-03-26 #}
+{# wf_updated_on: 2018-05-22 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Deep Dive into the Payment Request API {: .page-title }
@@ -176,7 +176,7 @@ an existing card will be selected for them.
 
 Note: To get access to all forms of payment available with Google, developers
 will need to implement the Google Pay method. Refer to the
-[Google Pay API](/pay/api/web/paymentrequest/tutorial) docs for more information.
+[Google Pay API](/pay/api/web/guides/paymentrequest/tutorial) docs for more information.
 
 <div class="attempt-center">
   <figure>
@@ -344,7 +344,7 @@ const googlePayPaymentMethod = {
 </div>
 
 We won't go into details of how to add Google Pay in this article, [we have
-a dedicated document to that](/pay/api/web/paymentrequest/tutorial "Google Pay API Payment Request tutorial").
+a dedicated document to that](/pay/api/web/guides/paymentrequest/tutorial "Google Pay API Payment Request tutorial").
 
 
 #### Edge Cases

--- a/src/content/en/fundamentals/payments/index.md
+++ b/src/content/en/fundamentals/payments/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Payment Request API is for fast, easy payments on the web.
 
 {# wf_published_on: 2016-07-25 #}
-{# wf_updated_on: 2018-03-26 #}
+{# wf_updated_on: 2018-05-22 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Introducing the Payment Request API {: .page-title }
@@ -92,7 +92,7 @@ the site.
 
 Note: Google Pay is one of payment methods you can use to get cards from a
 user's Google account and payment tokens on the device. To learn more, read [the
-Google Pay API docs](/pay/api/web/paymentrequest/tutorial).
+Google Pay API docs](/pay/api/web/guides/paymentrequest/tutorial).
 
 <div class="attempt-right">
   <figure>


### PR DESCRIPTION
The location of the Google Pay Payment Request tutorial has changed. Update links, avoiding redirect.

**CC:** @petele