### PR TITLE
Add license to CrUX docs

### DIFF
--- a/src/content/en/tools/chrome-user-experience-report/index.md
+++ b/src/content/en/tools/chrome-user-experience-report/index.md
@@ -1,7 +1,7 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 
-{# wf_updated_on: 2018-05-02 #}
+{# wf_updated_on: 2018-05-31 #}
 {# wf_published_on: 2017-10-23 #}
 {# wf_blink_components: N/A #}
 
@@ -247,3 +247,8 @@ the sections above.
 We would love to hear your feedback, questions, and suggestions to help us 
 improve the Chrome User Experience Report. Please join the conversation on our 
 [public Google Group](https://groups.google.com/a/chromium.org/forum/#!forum/chrome-ux-report).
+
+## License
+
+"Chrome User Experience Report" datasets by Google are licensed under a 
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
What's changed, or what was fixed?
- added license info to the CrUX docs

**Fixes:** N/A

**Target Live Date:** 2018-05-31

- [x] This has been reviewed and approved by @igrigorik 
- [x] I have run `gulp test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
