### PR TITLE
Foreign fetch was removed from the SW spec.

### DIFF
--- a/src/content/en/updates/2016/09/foreign-fetch.md
+++ b/src/content/en/updates/2016/09/foreign-fetch.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Third-party services can start deploying their own network request handlers.
 
-{# wf_updated_on: 2018-04-16 #}
+{# wf_updated_on: 2018-05-31 #}
 {# wf_published_on: 2016-09-12 #}
 {# wf_tags: chrome54,origintrials,serviceworker,cors,fetch #}
 {# wf_featured_image: /web/updates/images/2016/09/foreign-fetch/show-all-service-workers.png #}
@@ -12,8 +12,10 @@ description: Third-party services can start deploying their own network request 
 
 {% include "web/_shared/contributors/jeffposnick.html" %}
 
-
-
+Warning: The information in this post is out of date. Foreign fetch is no longer
+available for testing in Chrome, and
+[has been removed](https://github.com/w3c/ServiceWorker/issues/1188)
+from the service worker specification.
 
 ## Background
 


### PR DESCRIPTION
As per https://github.com/w3c/ServiceWorker/issues/1188, foreign fetch was officially removed from the service worker specification.

**Target Live Date:** 2018-06-07

- [ ] This has been reviewed and approved by (@petele)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
