### PR TITLE
Adding a link to UC Browser's A2HS docs page to our docs page

### DIFF
--- a/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
+++ b/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
@@ -64,5 +64,5 @@
   <a href="https://developer.mozilla.org/en-US/Apps/Progressive/Add_to_home_screen#How_do_you_make_an_app_A2HS-ready">Firefox</a>,
   <a href="https://dev.opera.com/articles/installable-web-apps/">Opera</a>,
   <a href="https://samsunginter.net/docs/ambient-badging">Samsung Internet</a>, and
-  <a href="https://plus.ucweb.com/docs/pwa/docs-zh/ort5m1?locale=en-US">UC Browser</a>.
+  <a href="https://plus.ucweb.com/docs/pwa/docs-en/zvrh56">UC Browser</a>.
 </aside>


### PR DESCRIPTION
Adding a link to UC Browser's A2HS docs page to our docs page.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
