### PR TITLE
Fix Workbox docs typo: s/weary/wary

### DIFF
--- a/src/content/en/tools/workbox/guides/route-requests.md
+++ b/src/content/en/tools/workbox/guides/route-requests.md
@@ -38,7 +38,7 @@ workbox.routing.registerRoute(
 );
 ```
 
-The only thing to be weary of is that this would only match for requests
+The only thing to be wary of is that this would only match for requests
 on your origin. If there was a separate site what had the URL
 "https://some-other-origin.com/logo.png", this route wouldn’t match, because
 in most cases, that’s not what was intended. Instead you’d need to define

--- a/src/content/en/tools/workbox/guides/route-requests.md
+++ b/src/content/en/tools/workbox/guides/route-requests.md
@@ -39,7 +39,7 @@ workbox.routing.registerRoute(
 ```
 
 The only thing to be wary of is that this would only match for requests
-on your origin. If there was a separate site what had the URL
+on your origin. If there was a separate site that had the URL
 "https://some-other-origin.com/logo.png", this route wouldn’t match, because
 in most cases, that’s not what was intended. Instead you’d need to define
 the entire URL to match.


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed a typo in the docs. “weary” means tired, but I think the docs meant to say “wary” which means cautious.

**CC:** @petele
