### PR TITLE
Workbox precaching docs formatting

### DIFF
--- a/src/content/en/tools/workbox/guides/configure-workbox.md
+++ b/src/content/en/tools/workbox/guides/configure-workbox.md
@@ -81,7 +81,7 @@ If you wanted to use a cache for images, you might configure a route like this:
 ```javascript
 workbox.routing.registerRoute(
   /.*\.(?:png|jpg|jpeg|svg|gif)/g,
-  new workbox.strategies.CacheFirst({
+  workbox.strategies.CacheFirst({
     cacheName: 'my-image-cache',
   })
 );
@@ -109,7 +109,7 @@ using a credentials mode of 'include', you can set up the following route:
 ```javascript
 workbox.routing.registerRoute(
   new RegExp('https://third-party\.example\.com/'),
-  new workbox.strategies.NetworkFirst({
+  workbox.strategies.NetworkFirst({
     fetchOptions: {
       credentials: 'include',
     },

--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-core.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-06-11 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Precaching {: .page-title }
@@ -25,11 +25,10 @@ the API and ensuring assets are downloaded efficiently.
 
 ## How workbox-precaching Works
 
-When a web app is loaded for the first time workbox-precaching will
-
-look at all the assets you want to download, remove any duplicates and hook
-up the relevant service worker events to download and store the assets,
-saving information about the revision of the asset in indexedDB.
+When a web app is loaded for the first time workbox-precaching will look at all 
+the assets you want to download, remove any duplicates and hook up the relevant 
+service worker events to download and store the assets, saving information about 
+the revision of the asset in indexedDB.
 
 ![Workbox precaching list to precached assets](../images/modules/workbox-precaching/precaching-step-1.png)
 
@@ -84,13 +83,11 @@ This allows workbox-precaching to know when the file has changed and update it.
 Workbox comes with tools to help with generating this list:
 
 - workbox-build
-  - This is an npm module that can be used in a gulp task or as an npm
-    run script.
+    - This is an npm module that can be used in a gulp task or as an npm run script.
 - workbox-webpack-plugin
-  - Webpack users can use the Workbox webpack plugin.
+    - Webpack users can use the Workbox webpack plugin.
 - workbox-cli
-  - Our CLI can also be used to generate the list of assets and add them
-    to your service worker.
+    - Our CLI can also be used to generate the list of assets and add them to your service worker.
 
 These tools make it easy to generate and use the list of assets for your site
 but you can generate the list yourself, just make sure you include unique


### PR DESCRIPTION
What's changed, or what was fixed?
- "How workbox-precaching Works" paragraph had a CR mid sentence which made reading difficult
- "help with generating this list": the nested lists were broken, again making reading difficult

**Fixes:** n/a

**Target Live Date:** n/a

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
