### PR TITLE
Fix missing images in map infoboxes in web agency directory

### DIFF
--- a/src/content/en/agencies/js/directory.js
+++ b/src/content/en/agencies/js/directory.js
@@ -828,8 +828,13 @@ var initializeDirectory = function(requestUrl, alphabeticalSortKey) {
       if (company.image_url) {
         var imageCtn = div.cloneNode(false);
         imageCtn.classList.add('devsite-info-window-logo');
-        img.src = company.image_url;
-        imageCtn.appendChild(img);
+        var logoImg = img.cloneNode(false);
+        var logoImgAttrs = {
+         'alt': company.agency_name + ' logo',
+         'src': company.image_url,
+        };
+        setAttributes(logoImg, logoImgAttrs);
+        imageCtn.appendChild(logoImg);
         ctn.appendChild(imageCtn);
       }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- There were missing logos in the infoboxes in /web/agencies for infoboxes with more than one image.  Now there are logos visible for each of the agencies in the map infoboxes.

**Fixes:** N/A

**Target Live Date:** 2018-06-12 (Flexible, but as soon as it's possible)

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `gulp test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
