### PR TITLE
Add tech editors to guides. Minor copy fixes.

### DIFF
--- a/src/content/en/fundamentals/performance/lazy-loading-guidance/images-and-video/index.md
+++ b/src/content/en/fundamentals/performance/lazy-loading-guidance/images-and-video/index.md
@@ -2,9 +2,9 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: If your site has a ton of images and video, but you don't want to cut down on any of it, lazy loading might be just the technique you need to improve initial page load time and lower per-page payload.
 
-{# wf_updated_on: 2018-04-04 #}
+{# wf_updated_on: 2018-06-11 #}
 {# wf_published_on: 2018-04-04 #}
-{# wf_blink_components: Blink>PerformanceAPIs,Blink>JavaScript>Runtime,Blink>Input #}
+{# wf_blink_components: Blink>Image,Blink>HTML,Blink>JavaScript #}
 
 # Lazy Loading Images and Video {: .page-title }
 
@@ -709,3 +709,11 @@ As far as performance improvement techniques go, lazy loading is reasonably
 uncontroversial. If you have a lot of inline imagery in your site, it's a
 perfectly fine way to cut down on unnecessary downloads. Your site's users and
 project stakeholders will appreciate it!
+
+_Special thanks to [François
+Beaufort](/web/resources/contributors/beaufortfrancois), Dean Hume, [Ilya
+Grigork](/web/resources/contributors/ilyagrigorik), [Paul
+Irish](/web/resources/contributors/paulirish), [Addy
+Osmani](/web/resources/contributors/addyosmani), [Jeff
+Posnick](/web/resources/contributors/jeffposnick), and Martin Schierle for their
+valuable feedback, which significantly improved the quality of this article._

--- a/src/content/en/fundamentals/performance/navigation-and-resource-timing/index.md
+++ b/src/content/en/fundamentals/performance/navigation-and-resource-timing/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: When we measure loading performance, we often do so using testing tools that only describe performance from the perspective of the tester. If we want to measure loading performance from the user's perspective, we must rely on the Navigation and Resource Timing APIs.
 
-{# wf_updated_on: 2018-06-07 #}
+{# wf_updated_on: 2018-06-11 #}
 {# wf_published_on: 2018-06-08 #}
 {# wf_blink_components: Blink>PerformanceAPIs,Blink>PerformanceAPIs>NavigationTiming,Blink>PerformanceAPIs>ResourceTiming #}
 
@@ -658,7 +658,8 @@ primarily because it's flexible. If you store the original metrics, you can
 always make corrections later in case of a measurement error.
 
 Finally, you don't need to store _every_ metric these APIs provide. For example,
-if you know you don't need specific metrics, don't store them.
+if you know for a fact you don't need to measure DOM processing time, don't feel
+like you _have_ to store those metrics.
 
 Of course, this guide isn't meant to be an exhaustive resource on these APIs,
 but rather to help you start using them with some confidence. If you want
@@ -682,3 +683,8 @@ With these APIs at your command, you'll be better equipped to understand how
 loading performance is experienced by real users. This means you'll be better
 equipped to diagnose and address performance issues in the wild, and that
 knowledge is truly powerful.
+
+_Special thanks to [Paul Irish](/web/resources/contributors/paulirish), Gray
+Norton, [Addy Osmani](/web/resources/contributors/addyosmani), and [Philip
+Walton](/web/resources/contributors/philipwalton) for their valuable feedback,
+which significantly improved the quality of this article._

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Everyone loves animated GIFs. The only problem is that they can be massive, often weighing in at several megabytes. In this guide, you'll learn how to curb the bloat caused by animated GIFs by replacing them with MPEG-4 and WebM video sources!
 
-{# wf_updated_on: 2018-04-19 #}
+{# wf_updated_on: 2018-06-11 #}
 {# wf_published_on: 2018-04-19 #}
 {# wf_tags: html5,video,gif,images #}
 {# wf_blink_components: Blink>Image,Blink>HTML #}
@@ -12,18 +12,18 @@ description: Everyone loves animated GIFs. The only problem is that they can be 
 {% include "web/_shared/contributors/jeremywagner.html" %}
 
 Have you ever seen an animated GIF on a service like Imgur or Gfycat and
-inspected it in your dev tools, only to find out that GIF was really a video?
-There's a good reason for that. Animated GIFs can be downright _huge_. It's not
-uncommon for GIFs to tip the scales at several megabytes, depending on quality,
-frame rate, and length. If you're trying to improve loading performance for your
-site and help users reduce data usage, animated GIF just isn't compatible with
-that goal.
+inspected it in DevTools, only to find out that GIF was really a video? There's
+a good reason for that. Animated GIFs can be downright _huge_. It's not uncommon
+for GIFs to tip the scales at several megabytes, depending on quality, frame
+rate, and length. If you're trying to improve loading performance for your site
+and help users reduce data usage, animated GIF just isn't compatible with that
+goal.
 
 <figure>
   <img src="images/gif-in-dev-tools-1x.png" srcset="images/gif-in-dev-tools-2x.png
-2x, images/gif-in-dev-tools-1x.png 1x" alt="Chrome dev tools showing a network
+2x, images/gif-in-dev-tools-1x.png 1x" alt="Chrome DevTools showing a network
 resource entry for a 13.7 MB GIF.">
-  <figcaption><strong>Figure 1</strong>. Chrome dev tools showing a 13.7 MB GIF.
+  <figcaption><strong>Figure 1</strong>. Chrome DevTools showing a 13.7 MB GIF.
 That's bigger than even most websites!</figcaption>
 </figure>
 
@@ -366,3 +366,11 @@ GIFV](https://lifehacker.com/imgur-revamps-gifs-for-faster-speeds-and-higher-qua
 - [GIF Revolution](https://telegram.org/blog/gif-revolution)
 - [Those GIFs on Twitter Aren't Actually
 GIFs](https://mashable.com/2014/06/20/twitter-gifs-mp4/#Mtz26DX1BZqG)
+
+_Special thanks to [François
+Beaufort](/web/resources/contributors/beaufortfrancois), [Patrick
+Hulce](/web/resources/contributors/patrickhulce), Dean Hume, [Paul
+Irish](/web/resources/contributors/paulirish), [Addy
+Osmani](/web/resources/contributors/addyosmani), and [Jeff
+Posnick](/web/resources/contributors/jeffposnick) for their valuable feedback,
+which significantly improved the quality of this article._

--- a/src/content/en/fundamentals/performance/why-performance-matters/index.md
+++ b/src/content/en/fundamentals/performance/why-performance-matters/index.md
@@ -2,9 +2,9 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Thanks to mobile device and network proliferation, more people are using the web than ever before. As this user base grows, performance is more important than ever. In this article, find out why performance matters, and learn what you can do to make the web faster for everyone.
 
-{# wf_updated_on: 2018-04-23 #}
+{# wf_updated_on: 2018-06-11 #}
 {# wf_published_on: 2018-03-08 #}
-{# wf_blink_components: Blink>PerformanceAPIs,Blink>JavaScript>Runtime,Blink>Input #}
+{# wf_blink_components: N/A #}
 
 # Why Performance Matters {: .page-title }
 

--- a/src/content/en/updates/2018/05/lighthouse.md
+++ b/src/content/en/updates/2018/05/lighthouse.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: New perf audits for preload, preconnect, GIFs, and more.
 
-{# wf_updated_on: 2018-05-14 #}
+{# wf_updated_on: 2018-06-11 #}
 {# wf_published_on: 2018-05-08 #}
 {# wf_tags: lighthouse #}
 {# wf_featured_image: /web/progressive-web-apps/images/pwa-lighthouse.png #}
@@ -330,6 +330,12 @@ code by downloading [Chrome
 Canary](https://www.google.com/chrome/browser/canary.html).
 * For Node users: Run `npm update lighthouse`, or `npm update lighthouse -g` if
 you installed Lighthouse globally.
+
+_Special thanks to [Kayce Basques](/web/resources/contributors/kaycebasques),
+[Patrick Hulce](/web/resources/contributors/patrickhulce), [Addy
+Osmani](/web/resources/contributors/addyosmani), and [Vinamrata
+Singal](/web/resources/contributors/vinamratasingal) for their valuable
+feedback, which significantly improved the quality of this article._
 
 {% include "comment-widget.html" %}
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Added tech editor credits to bottom of guides.
- Minor copy edits to articles where appropriate.

**Target Live Date:** Whenever works.

- [x] I have run `gulp test` locally and all tests pass.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele, @addyosmani 
