### PR TITLE
Add reference to privacy whitepaper

### DIFF
--- a/src/content/en/updates/2013/01/Voice-Driven-Web-Apps-Introduction-to-the-Web-Speech-API.md
+++ b/src/content/en/updates/2013/01/Voice-Driven-Web-Apps-Introduction-to-the-Web-Speech-API.md
@@ -95,5 +95,6 @@ book_path: /web/updates/_book.yaml
 <li>For comments on Chrome’s implementation of this spec: <a href="mailto:chromium-html5@chromium.org?subject=Web%20Speech%20API">email</a>, <a href="https://groups.google.com/a/chromium.org/forum/?fromgroups#!forum/chromium-html5">mailing archive</a></li>
 </ul>
 
+<p>Please refer to the <a href="https://www.google.com/chrome/privacy/whitepaper.html#speech">Chrome Privacy Whitepaper<a/> to learn how Google is handling voice data from this API.</p>
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2013/01/Voice-Driven-Web-Apps-Introduction-to-the-Web-Speech-API.md
+++ b/src/content/en/updates/2013/01/Voice-Driven-Web-Apps-Introduction-to-the-Web-Speech-API.md
@@ -4,6 +4,7 @@ book_path: /web/updates/_book.yaml
 {# wf_updated_on: 2013-01-13 #}
 {# wf_published_on: 2013-01-13 #}
 {# wf_tags: news,voice,multimedia,webspeech #}
+{# wf_blink_components: N/A #}
 
 # Voice Driven Web Apps: Introduction to the Web Speech API {: .page-title }
 


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=850164

What's changed, or what was fixed?
- adding reference to privacy whitepaper

**Target Live Date:** 2018-06-24

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
