### PR TITLE
Minor copy tweaks to the cache expiration page

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-cache-expiration.md
+++ b/src/content/en/tools/workbox/modules/workbox-cache-expiration.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-cache-expiration.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-04-03 #}
+{# wf_updated_on: 2018-06-15 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Cache Expiration {: .page-title }
@@ -20,7 +20,7 @@ period of time.
 ## Restrict the Number of Cache Entries
 
 To restrict the number of entries stored in a cache you can use the
-`cacheExpiration` option like so:
+`maxEntries` option like so:
 
 ```javascript
 workbox.routing.registerRoute(
@@ -45,8 +45,8 @@ that the number of cached entries doesn’t exceed the limit. If it does,
 
 ## Restrict the Age of Cached Entries
 
-To restrict how long a request is cached for you can define a max age in
-seconds like so;
+To restrict how long a request is cached for, you can define a max age in
+seconds using the `maxAgeSeconds` option like so:
 
 ```javascript
 workbox.routing.registerRoute(
@@ -71,7 +71,7 @@ One thing to note:
 used once, but will be expired after that.
 - To alleviate this, the plugin will check the "Date" header of the cached
 response, if one exists and the date can be parsed, it’ll expire based on this
-as it doesn’t require an IndexedDB lookup..
+as it doesn’t require an IndexedDB lookup.
 
 ## Advanced Usage
 


### PR DESCRIPTION
What's changed, or what was fixed?
- minor copy tweaks for readability and referenced `maxEntries` example in the copy. 

**Fixes:** n/a

**Target Live Date:** n/a

- [x] I have run `gulp test` locally and all tests pass.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
