### PR TITLE
Update ignoreUrlParametersMatching example

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -148,7 +148,7 @@ workbox.precaching.precacheAndRoute(
     { url: '/index.html', revision: '383676' },
   ],
   {
-    ignoreUrlParametersMatching: /.*/
+    ignoreUrlParametersMatching: [/.*/]
   }
 );
 ```

--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-core.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-06-11 #}
+{# wf_updated_on: 2018-07-02 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Precaching {: .page-title }


### PR DESCRIPTION
Update the ignoreUrlParametersMatching example on the workbox-precaching.md page to correctly identify the parameter as an array of Regex patterns

What's changed, or what was fixed?
- Correctly depict ignoreUrlParametersMatching as an array of Regex patterns

**Fixes:** #6277 

**CC:** @petele
