### PR TITLE
Typo in code example on cache expiration page

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-cache-expiration.md
+++ b/src/content/en/tools/workbox/modules/workbox-cache-expiration.md
@@ -89,7 +89,7 @@ const expirationManager = new workbox.expiration.CacheExpiration(
   cacheName,
   {
     maxAgeSeconds: 24 * 60 * 60,
-    maxEntries 20,
+    maxEntries: 20,
   }
 );
 ```


### PR DESCRIPTION
What's changed, or what was fixed?
- small typo in example on cache expiration page

**Fixes:** n/a

**Target Live Date:** n/a

- [x] I have run `npm test` locally and all tests pass.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
