### PR TITLE
Swap sw-precache with workbox

### DIFF
--- a/src/content/en/fundamentals/codelabs/your-first-pwapp/index.md
+++ b/src/content/en/fundamentals/codelabs/your-first-pwapp/index.md
@@ -646,7 +646,7 @@ Our app uses a cache-first strategy, which results in a copy of any cached conte
 
 #### How do I avoid these edge cases?
 
-So how do we avoid these edge cases? Use a library like  [sw-precache](https://github.com/GoogleChrome/sw-precache), which provides fine control over what gets expired, ensures requests go directly to the network and handles all of the hard work for you.
+So how do we avoid these edge cases? Use a library like [Workbox](https://workboxjs.org), which provides fine control over what gets expired, ensures requests go directly to the network and handles all of the hard work for you.
 
 ### Tips for testing live service workers
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Changed sw-precache to workbox

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
