### PR TITLE
Anchors for config options in Workbox docs

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/single/cacheId.html
+++ b/src/content/en/tools/workbox/_shared/config/single/cacheId.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}cacheId">
   <td>
     <p>cacheId</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/clientsClaim.html
+++ b/src/content/en/tools/workbox/_shared/config/single/clientsClaim.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}clientsClaim">
   <td>
     <p>clientsClaim</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/directoryIndex.html
+++ b/src/content/en/tools/workbox/_shared/config/single/directoryIndex.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}directoryIndex">
   <td>
     <p>directoryIndex</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/dontCacheBustUrlsMatching.html
+++ b/src/content/en/tools/workbox/_shared/config/single/dontCacheBustUrlsMatching.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}dontCacheBustUrlsMatching">
     <td>
       <p>dontCacheBustUrlsMatching</p>
     </td>

--- a/src/content/en/tools/workbox/_shared/config/single/globDirectory.html
+++ b/src/content/en/tools/workbox/_shared/config/single/globDirectory.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}globDirectory">
   <td>
     <p>globDirectory</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/globFollow.html
+++ b/src/content/en/tools/workbox/_shared/config/single/globFollow.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}globFollow">
   <td>
     <p>globFollow</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/globIgnores.html
+++ b/src/content/en/tools/workbox/_shared/config/single/globIgnores.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}globIgnores">
   <td>
     <p>globIgnores</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/globPatterns.html
+++ b/src/content/en/tools/workbox/_shared/config/single/globPatterns.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}globPatterns">
   <td>
     <p>globPatterns</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/globStrict.html
+++ b/src/content/en/tools/workbox/_shared/config/single/globStrict.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}globStrict">
   <td>
     <p>globStrict</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/ignoreUrlParametersMatching.html
+++ b/src/content/en/tools/workbox/_shared/config/single/ignoreUrlParametersMatching.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}ignoreUrlParametersMatching">
   <td>
     <p>ignoreUrlParametersMatching</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/importScripts.html
+++ b/src/content/en/tools/workbox/_shared/config/single/importScripts.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}importScripts">
   <td>
     <p>importScripts</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/importWorkboxFrom.html
+++ b/src/content/en/tools/workbox/_shared/config/single/importWorkboxFrom.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}importWorkboxFrom">
     <td>
       <p>importWorkboxFrom</p>
     </td>

--- a/src/content/en/tools/workbox/_shared/config/single/injectionPointRegexp.html
+++ b/src/content/en/tools/workbox/_shared/config/single/injectionPointRegexp.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}injectionPointRegexp">
   <td>
     <p>injectionPointRegexp</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/manifestTransforms.html
+++ b/src/content/en/tools/workbox/_shared/config/single/manifestTransforms.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}manifestTransforms">
   <td>
     <p>manifestTransforms</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/maximumFileSizeToCacheInBytes.html
+++ b/src/content/en/tools/workbox/_shared/config/single/maximumFileSizeToCacheInBytes.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}maximumFileSizeToCacheInBytes">
   <td>
     <p>maximumFileSizeToCacheInBytes</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/modifyUrlPrefix.html
+++ b/src/content/en/tools/workbox/_shared/config/single/modifyUrlPrefix.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}modifyUrlPrefix">
   <td>
     <p>modifyUrlPrefix</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/navigateFallback.html
+++ b/src/content/en/tools/workbox/_shared/config/single/navigateFallback.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}navigateFallback">
   <td>
     <p>navigateFallback</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/navigateFallbackBlacklist.html
+++ b/src/content/en/tools/workbox/_shared/config/single/navigateFallbackBlacklist.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}navigateFallbackBlacklist">
   <td>
     <p>navigateFallbackBlacklist</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/navigateFallbackWhitelist.html
+++ b/src/content/en/tools/workbox/_shared/config/single/navigateFallbackWhitelist.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}navigateFallbackWhitelist">
   <td>
     <p>navigateFallbackWhitelist</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/runtimeCaching.html
+++ b/src/content/en/tools/workbox/_shared/config/single/runtimeCaching.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}runtimeCaching">
     <td>
       <p>runtimeCaching</p>
     </td>

--- a/src/content/en/tools/workbox/_shared/config/single/skipWaiting.html
+++ b/src/content/en/tools/workbox/_shared/config/single/skipWaiting.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}skipWaiting">
   <td>
     <p>skipWaiting</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/swDest.html
+++ b/src/content/en/tools/workbox/_shared/config/single/swDest.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}swDest">
   <td>
     <p>swDest</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/swSrc.html
+++ b/src/content/en/tools/workbox/_shared/config/single/swSrc.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}swSrc">
   <td>
     <p>swSrc</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/single/templatedUrls.html
+++ b/src/content/en/tools/workbox/_shared/config/single/templatedUrls.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}templatedUrls">
   <td>
     <p>templatedUrls</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/chunks.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/chunks.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}chunks">
   <td>
     <p>chunks</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/exclude.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/exclude.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}exclude">
   <td>
     <p>exclude</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/excludeChunks.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/excludeChunks.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}excludeChunks">
   <td>
     <p>excludeChunks</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/importsDirectory.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/importsDirectory.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}importsDirectory">
   <td>
     <p>importsDirectory</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/include.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/include.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}include">
   <td>
     <p>include</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/precacheManifestFilename.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/precacheManifestFilename.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}precacheManifestFilename">
   <td>
     <p>precacheManifestFilename</p>
   </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/swDest.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/swDest.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}swDest">
     <td>
       <p>swDest</p>
     </td>

--- a/src/content/en/tools/workbox/_shared/config/webpack-single/swSrc.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/swSrc.html
@@ -1,4 +1,4 @@
-<tr>
+<tr id="{{ anchor_prefix }}swSrc">
   <td>
     <p>swSrc</p>
   </td>

--- a/src/content/en/tools/workbox/modules/workbox-build.md
+++ b/src/content/en/tools/workbox/modules/workbox-build.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-build.
 
-{# wf_updated_on: 2018-03-15 #}
+{# wf_updated_on: 2018-07-09 #}
 {# wf_published_on: 2018-01-31 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -52,6 +52,7 @@ configuration.
 
 ### Full generateSW Config
 
+{% with anchor_prefix="generateSW-" %}
 <table class="responsive">
   <tbody>
 {% include "web/tools/workbox/_shared/config/single/swDest.html" %}
@@ -59,6 +60,7 @@ configuration.
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ## injectManifest Mode
 
@@ -84,6 +86,7 @@ it into your existing service worker file.
 
 ### Full injectManifest Config
 
+{% with anchor_prefix="injectManifest-" %}
 <table class="responsive">
   <tbody>
 {% include "web/tools/workbox/_shared/config/single/swDest.html" %}
@@ -91,6 +94,7 @@ it into your existing service worker file.
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ## Additional modes
 
@@ -117,6 +121,7 @@ generateSWString({
 
 The supported configuration options are:
 
+{% with anchor_prefix="generateSWString-" %}
 <table class="responsive">
   <tbody>
 {% include "web/tools/workbox/_shared/config/groups/generate-sw-string-schema.html" %}
@@ -124,6 +129,7 @@ The supported configuration options are:
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ### getManifest Mode
 
@@ -146,9 +152,11 @@ getManifest({
 
 The supported configuration options are:
 
+{% with anchor_prefix="getManifest-" %}
 <table class="responsive">
   <tbody>
 {% include "web/tools/workbox/_shared/config/groups/get-manifest-schema.html" %}
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}

--- a/src/content/en/tools/workbox/modules/workbox-cli.md
+++ b/src/content/en/tools/workbox/modules/workbox-cli.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-cli.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-15 #}
+{# wf_updated_on: 2018-07-09 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox CLI  {: .page-title }
@@ -171,6 +171,7 @@ automatically by `workbox wizard` or tweaked manually.
 
 Below is a list of options used by **just** the `generateSW` command.
 
+{% with anchor_prefix="generateSW-" %}
 <table class="responsive">
   <tbody>
     <tr>
@@ -179,11 +180,13 @@ Below is a list of options used by **just** the `generateSW` command.
 {% include "web/tools/workbox/_shared/config/groups/common-generate-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ### Options used by `injectManifest`
 
 Below is a list of options used by **just** the `injectManifest` command.
 
+{% with anchor_prefix="injectManifest-" %}
 <table class="responsive">
   <tbody>
     <tr>
@@ -193,11 +196,13 @@ Below is a list of options used by **just** the `injectManifest` command.
 {% include "web/tools/workbox/_shared/config/groups/build-inject-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ### Options used by both
 
 The remaining options are used by both commands.
 
+{% with anchor_prefix="common-" %}
 <table class="responsive">
   <tbody>
     <tr>
@@ -207,3 +212,4 @@ The remaining options are used by both commands.
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}

--- a/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
+++ b/src/content/en/tools/workbox/modules/workbox-webpack-plugin.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-webpack-plugin.
 
-{# wf_updated_on: 2018-03-19 #}
+{# wf_updated_on: 2018-07-09 #}
 {# wf_published_on: 2017-12-15 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -75,6 +75,7 @@ module.exports = {
 };
 ```
 
+{% with anchor_prefix="generateSW-" %}
 <table class="responsive">
   <tbody>
     <tr>
@@ -88,6 +89,7 @@ module.exports = {
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ## InjectManifest Plugin
 
@@ -130,6 +132,7 @@ module.exports = {
 };
 ```
 
+{% with anchor_prefix="injectManifest-" %}
 <table class="responsive">
   <tbody>
     <tr>
@@ -143,6 +146,7 @@ module.exports = {
 {% include "web/tools/workbox/_shared/config/groups/base-schema.html" %}
   </tbody>
 </table>
+{% endwith %}
 
 ## Cache additional, non-webpack assets
 


### PR DESCRIPTION
As per conversation with @petele, the `{{` and `}}` characters are intentional, even though they make `npm test` fail.

I've tried manually staging a subset of this PR to confirm that the `{{ anchor_prefix }}` replacement works as expected, and it looked good.