### PR TITLE
workbox-navigation-preload module doc

### DIFF
--- a/src/content/en/tools/workbox/modules/_index.yaml
+++ b/src/content/en/tools/workbox/modules/_index.yaml
@@ -153,6 +153,22 @@ landing_page:
         - label: Demo
           path: https://workbox-demos.firebaseapp.com/demo/workbox-streams/
 
+    - items:
+      - heading: workbox.navigationPreload
+        description: >
+          Enable navigation preload, to get a network response for navigation
+          requests faster.
+        buttons:
+        - label: Learn more
+          path: ./workbox-navigation-preload
+        - label: Reference
+          path: ../reference-docs/latest/workbox.navigationPreload
+
+      # Force Devsite 4-up layout
+      - heading: ""
+      - heading: ""
+      - heading: ""
+
     - heading: Node Modules
       description: >
         Workbox provides a set of Node modules that make it easy to generate

--- a/src/content/en/tools/workbox/modules/_toc.yaml
+++ b/src/content/en/tools/workbox/modules/_toc.yaml
@@ -24,6 +24,8 @@ toc:
   path: /web/tools/workbox/modules/workbox-cacheable-response
 - title: workbox.broadcastUpdate
   path: /web/tools/workbox/modules/workbox-broadcast-cache-update
+- title: workbox.navigationPreload
+  path: /web/tools/workbox/modules/workbox-navigation-preload
 
 - heading: Node Modules
 - title: Workbox CLI

--- a/src/content/en/tools/workbox/modules/workbox-navigation-preload.md
+++ b/src/content/en/tools/workbox/modules/workbox-navigation-preload.md
@@ -1,0 +1,75 @@
+project_path: /web/tools/workbox/_project.yaml
+book_path: /web/tools/workbox/_book.yaml
+description: The module guide for workbox-navigation-preload.
+
+{# wf_blink_components: N/A #}
+{# wf_updated_on: 2018-07-12 #}
+{# wf_published_on: 2018-07-12 #}
+
+# Workbox Navigation Preload {: .page-title }
+
+## What's navigation preload?
+
+"[Speed up Service Worker with Navigation Preloads](/web/updates/2017/02/navigation-preload)" does a
+great job of explaining what navigation preload is, and the benefits it offers to web apps whose
+service worker does not explicitly handle
+[navigation requests](/web/fundamentals/primers/service-workers/high-performance-loading#first_what_are_navigation_requests).
+
+## What does this module do?
+
+`workbox-navigation-preload` will handle checking at runtime to see if the current browser supports
+navigation preload, and if it does, it will automatically create an `activate` event handler to
+enable it.
+
+The shared code inside of `workbox-core` that handles making network requests across all of Workbox
+has also been updated to automatically take advantage of a preload response, if it's available. This
+means that any of the built-in strategies can automatically take advantage of navigation preload,
+once it's enabled.
+
+## Who should enable navigation preloads?
+
+**Developers who are already handling navigations by responding with precached HTML (potentially
+configured with an App Shell fallback) do not need to enable navigation preload!** This feature is
+intended to reduce navigation latency for developers who can't precache their HTML, but still want
+to use Workbox to handle caching of other assets on their sites.
+
+For instance, if you're following the [App Shell pattern](/web/fundamentals/architecture/app-shell),
+and you've got a [navigation route](/web/tools/workbox/modules/workbox-routing#how_to_register_a_navigation_route)
+already set up to use the precached HTML, enabling navigation preload will be a waste. The network
+response that associated with the preload request will never end up being used, since the precached
+HTML will be used unconditionally.
+
+## Basic Usage
+
+```javascript
+// Enable navigation preload.
+workbox.navigationPreload.enable();
+
+// Swap in networkOnly, cacheFirst, or staleWhileRevalidate as needed.
+const strategy = workbox.strategies.networkFirst({
+  cacheName: 'cached-navigations',
+  plugins: [
+    // Any plugins, like workbox.expiration, etc.
+  ],
+});
+
+const navigationRoute = new workbox.routing.NavigationRoute(strategy, {
+  // Optionally, provide a white/blacklist of RegExps to determine
+  // which paths will match this route.
+  // whitelist: [],
+  // blacklist: [],
+});
+
+workbox.routing.registerRoute(navigationRoute);
+```
+
+## What's the browser support story?
+
+Currently, Google Chrome is the only browser that supports navigation preload.
+`workbox.navigationPreload.enable()` will check for browser support at runtime, and only attempt to
+enable navigation preload if the current browser supports it. It's therefore safe to call
+`workbox.navigationPreload.enable()` unconditionally in your service worker.
+
+You should be aware that those browsers will not benefit from the navigation latency reduction, and
+it's recommended that you carefully measure the performance implications of shipping a service
+worker that doesn't handle navigation requests, and doesn't use navigation preload.

--- a/src/content/en/tools/workbox/modules/workbox-range-requests.md
+++ b/src/content/en/tools/workbox/modules/workbox-range-requests.md
@@ -1,9 +1,9 @@
 project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
-description: The module guide for workbox-core.
+description: The module guide for workbox-range-requests.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-04-03 #}
+{# wf_updated_on: 2018-07-12 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Range Requests {: .page-title }


### PR DESCRIPTION
Docs for the new `workbox-navigation-preload` module, which shipped in Workbox v3.4.1.

This PR depends on https://github.com/google/WebFundamentals/pull/6350 being merged first.

**CC:** @petele
