### PR TITLE
[devtools] add vid to wndt68

### DIFF
--- a/src/content/en/updates/2018/05/devtools.md
+++ b/src/content/en/updates/2018/05/devtools.md
@@ -23,7 +23,7 @@ New to DevTools in Chrome 68:
 * [Argument hints](#hints). As you type functions, the Console shows you the expected arguments
   for that function.
 * [Function autocompletion](#autocomplete). After typing a function call such as
-  `document.querySelector('p')`, the Console shows you the the functions and properties that
+  `document.querySelector('p')`, the Console shows you the functions and properties that
   the return value supports.
 * [ES2017 keywords in the Console](#keywords). Keywords such as `await` are now available in the
   Console's autocomplete UI.
@@ -230,8 +230,8 @@ Was this page helpful?
         Yes
       </button>
       <aside id="quickstart-feedback-success" class="success">
-        Great! Thank you for the feedback. Please use the feedback channels below to tell us what we're
-        doing well, or how we can improve.
+        Great! Thank you for the feedback. Please use the feedback channels below to tell us what
+        we're doing well, or how we can improve.
       </aside>
     </section>
     <section class="expandable">
@@ -255,8 +255,8 @@ Was this page helpful?
         Yes
       </button>
       <aside id="quickstart-feedback-success" class="success">
-        Great! Thank you for the feedback. Please use the feedback channels below to tell us what we're
-        doing well, or how we can improve.
+        Great! Thank you for the feedback. Please use the feedback channels below to tell us what
+        we're doing well, or how we can improve.
       </aside>
     </section>
     <section class="expandable">

--- a/src/content/en/updates/2018/05/devtools.md
+++ b/src/content/en/updates/2018/05/devtools.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Eager evaluation, argument hints, function autocompletion, Lighthouse 3.0, and more.
 experiments_path: /web/updates/2018/05/_experiments.yaml
 
-{# wf_updated_on: 2018-06-01 #}
+{# wf_updated_on: 2018-07-17 #}
 {# wf_published_on: 2018-05-21 #}
 {# wf_tags: chrome68,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -15,8 +15,6 @@ experiments_path: /web/updates/2018/05/_experiments.yaml
 # What's New In DevTools (Chrome 68) {: .page-title }
 
 {% include "web/_shared/contributors/kaycebasques.html" %}
-
-Note: The video version of these release notes will be published around late July 2018.
 
 New to DevTools in Chrome 68:
 
@@ -40,6 +38,14 @@ New to DevTools in Chrome 68:
 Note: Check what version of Chrome you're running at `chrome://version`. If you're running
 an earlier version, these features won't exist. If you're running a later version, these features
 may have changed. Chrome auto-updates to a new major version about every 6 weeks.
+
+Read on, or watch the video version of the release notes, below.
+
+<div class="video-wrapper-full-width">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="br4JZ5qz_20"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
 ## Assistive Console {: #console }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- embeds youtube vid into doc

**Fixes:** N/A

**Target Live Date:** 2018-07-17

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
