### PR TITLE
Fix the cacheName option in the Workbox guides.

### DIFF
--- a/src/content/en/tools/workbox/guides/generate-service-worker/cli.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/cli.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to generate a complete service worker with Workbox CLI.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-06-08 #}
+{# wf_updated_on: 2018-07-18 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Generate a Complete Service Worker with Workbox CLI {: .page-title }
@@ -74,9 +74,6 @@ module.exports = {
 
   // Define runtime caching rules.
   runtimeCaching: [{
-    // Use a custom cache name.
-    cacheName: 'images',
-
     // Match any request ends with .png, .jpg, .jpeg or .svg.
     urlPattern: /\.(?:png|jpg|jpeg|svg)$/,
 
@@ -84,6 +81,9 @@ module.exports = {
     handler: 'cacheFirst',
 
     options: {
+      // Use a custom cache name.
+      cacheName: 'images',
+
       // Only cache 10 images.
       expiration: {
         maxEntries: 10,

--- a/src/content/en/tools/workbox/guides/generate-service-worker/webpack.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/webpack.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to generate a complete service worker with the Workbox Webpack Plugin.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-06-08 #}
+{# wf_updated_on: 2018-07-18 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Generate a Service Worker with Webpack {: .page-title }
@@ -72,9 +72,6 @@ module.exports = {
 
       // Define runtime caching rules.
       runtimeCaching: [{
-        // Use a custom cache name.
-        cacheName: 'images',
-
         // Match any request ends with .png, .jpg, .jpeg or .svg.
         urlPattern: /\.(?:png|jpg|jpeg|svg)$/,
 
@@ -82,6 +79,9 @@ module.exports = {
         handler: 'cacheFirst',
 
         options: {
+          // Use a custom cache name.
+          cacheName: 'images',
+
           // Only cache 10 images.
           expiration: {
             maxEntries: 10,

--- a/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to generate a complete service worker with workbox-build.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-06-08 #}
+{# wf_updated_on: 2018-07-18 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Generate a Service Worker with workbox-build {: .page-title }
@@ -77,9 +77,6 @@ const buildSW = () => {
 
     // Define runtime caching rules.
     runtimeCaching: [{
-      // Use a custom cache name.
-      cacheName: 'images',
-
       // Match any request ends with .png, .jpg, .jpeg or .svg.
       urlPattern: /\.(?:png|jpg|jpeg|svg)$/,
 
@@ -87,6 +84,9 @@ const buildSW = () => {
       handler: 'cacheFirst',
 
       options: {
+        // Use a custom cache name.
+        cacheName: 'images',
+
         // Only cache 10 images.
         expiration: {
           maxEntries: 10,


### PR DESCRIPTION
This fixes an incorrect option included in some of the Workbox guides.

**Target Live Date:** 2018-07-25

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
