### PR TITLE
add a no-config "was this page helpful?" feedback widget

### DIFF
--- a/src/content/en/_shared/helpful.html
+++ b/src/content/en/_shared/helpful.html
@@ -1,0 +1,38 @@
+<style>
+  .helpful--container {
+    margin: 1em 0;
+    position: relative;
+  }
+  .helpful--section {
+    position: static;
+  }
+</style>
+
+<p>Was this page helpful?</p>
+
+<div class="helpful--container">
+  <section class="expandable helpful--section">
+    <button class="button button-primary expand-control gc-analytics-event"
+            data-category="Helpful" data-value="1"
+            data-label="{% dynamic print request.path %}"
+            style="background-color:#f44336;">
+      Yes
+    </button>
+    <aside class="success">
+      Great! Thank you for the feedback.
+    </aside>
+  </section>
+  <section class="expandable helpful--section">
+    <button class="button button-primary expand-control gc-analytics-event"
+            data-category="Helpful" data-value="1"
+            data-label="{% dynamic print request.path %}"
+            style="position:absolute;top:0;left:70px;background-color:#f44336;">
+      No
+    </button>
+    <aside class="warning">
+      Sorry to hear that. Please <a
+      href="https://github.com/google/WebFundamentals/issues/new">open an
+      issue</a> and tell us how we can improve.
+    </aside>
+  </section>
+</div>

--- a/src/content/en/tools/lighthouse/audits/unused-css.md
+++ b/src/content/en/tools/lighthouse/audits/unused-css.md
@@ -140,39 +140,4 @@ Sources:
 
 ## Feedback {: #feedback }
 
-{% framebox width="auto" height="auto" enable_widgets="true" %}
-<script>
-var label = '/web/tools/lighthouse/audits/unused-css';
-var title = '[feedback] ' + label;
-var url = 'https://github.com/google/webfundamentals/issues/new?title=' + title;
-var link = '<a href="' + url + '">open an issue</a>';
-var response = 'Thanks for the feedback. Please ' + link + ' and tell us how we can improve.';
-var feedback = {
-  category: "Helpful",
-  question: "Was this page helpful?",
-  choices: [
-    {
-      button: {
-        text: "Yes"
-      },
-      response: response,
-      analytics: {
-        label: label,
-        value: 1
-      }
-    },
-    {
-      button: {
-        text: "No"
-      },
-      response: response,
-      analytics: {
-        label: label,
-        value: 0
-      }
-    }
-  ]
-};
-</script>
-{% include "web/_shared/multichoice.html" %}
-{% endframebox %}
+{% include "web/_shared/helpful.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- adds a "was this page helpful?" widget that doesn't require any manual configuration... you just `{% include %}` the widget on the page

**Fixes:** N/A

**Target Live Date:** 2018-07-20

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
