### PR TITLE
 Fixed single quotes in App Shell article

### DIFF
--- a/src/content/en/fundamentals/architecture/app-shell.md
+++ b/src/content/en/fundamentals/architecture/app-shell.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Application shell architecture keeps your UI local and loads content dynamically without sacrificing the linkability and discoverability of the web. 
 
-{# wf_updated_on: 2018-04-13 #}
+{# wf_updated_on: 2018-07-20 #}
 {# wf_published_on: 2016-09-27 #}
 {# wf_blink_components: N/A #}
 
@@ -231,9 +231,9 @@ using service worker's `install` event:
       '/js/scripts.js',
       '/images/logo.svg',
 
-      '/offline.html’,
+      '/offline.html',
 
-      '/’,
+      '/',
     ];
 
     self.addEventListener('install', function(e) {


### PR DESCRIPTION
What's changed, or what was fixed?

Using `'` instead of `’`.

**CC:** @petele
