### PR TITLE
Fix Typo: ctor -> constructor

### DIFF
--- a/src/content/en/fundamentals/web-components/customelements.md
+++ b/src/content/en/fundamentals/web-components/customelements.md
@@ -118,7 +118,7 @@ create a **public JavaScript API** for your tag.
 
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
 
@@ -244,7 +244,7 @@ removed from the DOM (e.g. the user calls `el.remove()`).
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -520,7 +520,7 @@ To use Shadow DOM in a custom element, call `this.attachShadow` inside your
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -577,7 +577,7 @@ Example usage:
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         let shadowRoot = this.attachShadow({mode: 'open'});
         shadowRoot.appendChild(tmpl.content.cloneNode(true));
       }
@@ -616,7 +616,7 @@ structure of a custom element**.
 
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           shadowRoot.appendChild(tmpl.content.cloneNode(true));
         }
@@ -750,7 +750,7 @@ Extending another custom element is done by extending its class definition.
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
 
@@ -801,7 +801,7 @@ Similarly, an element that extends `<img>` needs to extend `HTMLImageElement`.
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
 
@@ -888,7 +888,7 @@ or create an instance in JavaScript:
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
 

--- a/src/content/en/fundamentals/web-components/shadowdom.md
+++ b/src/content/en/fundamentals/web-components/shadowdom.md
@@ -195,7 +195,7 @@ encapsulating its DOM/CSS:
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -734,7 +734,7 @@ Here's my summary of why you should never create web components with
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -917,7 +917,7 @@ focus behavior of element's within a shadow tree:
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/es/fundamentals/web-components/customelements.md
+++ b/src/content/es/fundamentals/web-components/customelements.md
@@ -97,7 +97,7 @@ Básicamente, usa la clase a fin de crear una **JavaScript API pública** para t
     
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -145,7 +145,7 @@ La extensión de otro elemento personalizado se realiza mediante la extensión d
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -184,7 +184,7 @@ elemento que extiende `<img>` debe extender `HTMLImageElement`.
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -259,7 +259,7 @@ También pueden crear una instancia en JavaScript:
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -317,7 +317,7 @@ del DOM (p. ej., el usuario llama a `el.remove()`).
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -592,7 +592,7 @@ Para usar Shadow DOM en un elemento personalizado, llama a `this.attachShadow` d
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -642,7 +642,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     constructor() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -674,7 +674,7 @@ Para aquellos que no lo conozcan, el [elemento `<template>`](https://html.spec.w
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/es/fundamentals/web-components/shadowdom.md
+++ b/src/content/es/fundamentals/web-components/shadowdom.md
@@ -191,7 +191,7 @@ encapsulando sus DOM/CSS:
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -728,7 +728,7 @@ Este es un resumen sobre por qué nunca deberías crear componentes web con
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -911,7 +911,7 @@ comportamiento del foco de los elementos dentro de un shadow tree:
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/id/fundamentals/web-components/customelements.md
+++ b/src/content/id/fundamentals/web-components/customelements.md
@@ -97,7 +97,7 @@ Pada dasarnya, gunakan kelas untuk membuat **JavaScript API publik** bagi tag An
     
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -145,7 +145,7 @@ Memperluas elemen khusus lain dilakukan dengan memperluas definisi kelasnya.
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -184,7 +184,7 @@ elemen yang memperluas `<img>` perlu memperluas `HTMLImageElement`.
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -259,7 +259,7 @@ atau membuat instance di JavaScript:
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -317,7 +317,7 @@ DOM (mis. pengguna memanggil `el.remove()`).
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -592,7 +592,7 @@ Untuk menggunakan Shadow DOM di elemen khusus, panggil `this.attachShadow` di da
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -642,7 +642,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     constructor() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -674,7 +674,7 @@ Bagi mereka yang belum familier, [elemen `<template>`](https://html.spec.whatwg.
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/id/fundamentals/web-components/shadowdom.md
+++ b/src/content/id/fundamentals/web-components/shadowdom.md
@@ -191,7 +191,7 @@ mengenkapsulasi DOM/CSS-nya:
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -728,7 +728,7 @@ Inilah rangkuman mengapa Anda jangan sampai membuat komponen web dengan
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -911,7 +911,7 @@ fokus elemen dalam shadow tree:
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/ja/fundamentals/web-components/customelements.md
+++ b/src/content/ja/fundamentals/web-components/customelements.md
@@ -93,7 +93,7 @@ HTML で問題を解決できない場合は、問題を解決できるカスタ
     
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -141,7 +141,7 @@ HTML で問題を解決できない場合は、問題を解決できるカスタ
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -180,7 +180,7 @@ HTML で問題を解決できない場合は、問題を解決できるカスタ
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -255,7 +255,7 @@ JavaScript でインスタンスを作成できます。
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -311,7 +311,7 @@ JavaScript でインスタンスを作成できます。
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -586,7 +586,7 @@ Shadow DOM は、ページの他の部分とは別に一連の DOM を所有、�
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -636,7 +636,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     constructor() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -668,7 +668,7 @@ if (supportsCustomElementsV1) {
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/ja/fundamentals/web-components/shadowdom.md
+++ b/src/content/ja/fundamentals/web-components/shadowdom.md
@@ -151,7 +151,7 @@ Shadow DOM は、[カスタム要素](/web/fundamentals/getting-started/primers/
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -667,7 +667,7 @@ Shadow DOM の別の特長は、「クローズド」モードと呼ばれます
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -841,7 +841,7 @@ Shadow ツリーの内部ノードで呼び出されるカスタム DOM イベ�
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/ko/fundamentals/web-components/customelements.md
+++ b/src/content/ko/fundamentals/web-components/customelements.md
@@ -97,7 +97,7 @@ description: 사용자설정 요소를 사용하면 웹 개발자가 새로운 H
     
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -145,7 +145,7 @@ Custom Elements API는 새로운 HTML 요소를 생성하는 데 유용하지만
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -184,7 +184,7 @@ Custom Elements API는 새로운 HTML 요소를 생성하는 데 유용하지만
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -259,7 +259,7 @@ Custom Elements API는 새로운 HTML 요소를 생성하는 데 유용하지만
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -317,7 +317,7 @@ Custom Elements API는 새로운 HTML 요소를 생성하는 데 유용하지만
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -592,7 +592,7 @@ DOM 집합을 소유하고, 렌더링하고, 이에 대한 스타일을 지정�
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -642,7 +642,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     constructor() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -674,7 +674,7 @@ if (supportsCustomElementsV1) {
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/ko/fundamentals/web-components/shadowdom.md
+++ b/src/content/ko/fundamentals/web-components/shadowdom.md
@@ -191,7 +191,7 @@ DOM/CSS를 캡슐화합니다.
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -728,7 +728,7 @@ Shadow DOM에 액세스할 수 없습니다.
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -911,7 +911,7 @@ Shadow DOM 내부에서 발생하는 이벤트는 호스팅 요소에서 발생�
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/pt-br/fundamentals/web-components/customelements.md
+++ b/src/content/pt-br/fundamentals/web-components/customelements.md
@@ -98,7 +98,7 @@ Essencialmente, use a classe para criar uma **JavaScript API pública** para a t
     
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -146,7 +146,7 @@ A extensão de outro elemento personalizado é efetuada estendendo sua definiç�
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -185,7 +185,7 @@ elemento que estende `<img>` precisa estender `HTMLImageElement`.
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -260,7 +260,7 @@ Ou criam uma instância no JavaScript:
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -318,7 +318,7 @@ DOM (por exemplo, o usuário chama `el.remove()`).
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -593,7 +593,7 @@ Para usar o Shadow DOM em um elemento personalizado, chame `this.attachShadow` d
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -643,7 +643,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     constructor() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -675,7 +675,7 @@ Para os que não sabem, o [elemento `<template>`](https://html.spec.whatwg.org/m
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/pt-br/fundamentals/web-components/shadowdom.md
+++ b/src/content/pt-br/fundamentals/web-components/shadowdom.md
@@ -191,7 +191,7 @@ encapsulando seu DOM/CSS:
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -728,7 +728,7 @@ totalmente o propósito original do modo fechado.
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -911,7 +911,7 @@ além do elemento focado.
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/zh-cn/fundamentals/web-components/customelements.md
+++ b/src/content/zh-cn/fundamentals/web-components/customelements.md
@@ -94,7 +94,7 @@ description:自定义元素允许网络开发者定义新的 HTML 标记、扩�
     
       // Can define constructor arguments if you wish.
       constructor() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -142,7 +142,7 @@ Custom Elements API 对创建新的 HTML 元素很有用，但它也可用于扩
 
     class FancyDrawer extends AppDrawer {
       constructor() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -181,7 +181,7 @@ Custom Elements API 对创建新的 HTML 元素很有用，但它也可用于扩
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -256,7 +256,7 @@ Custom Elements API 对创建新的 HTML 元素很有用，但它也可用于扩
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -312,7 +312,7 @@ Custom Elements API 对创建新的 HTML 元素很有用，但它也可用于扩
 
     class AppDrawer extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -587,7 +587,7 @@ Shadow DOM 提供了一种方法，可让元素以独立于页面其余部分的
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -637,7 +637,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     constructor() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -669,7 +669,7 @@ if (supportsCustomElementsV1) {
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         constructor() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/zh-cn/fundamentals/web-components/shadowdom.md
+++ b/src/content/zh-cn/fundamentals/web-components/shadowdom.md
@@ -162,7 +162,7 @@ Shadow DOM 与普通 DOM 相同，但有两点区别：1) 创建/使用的方式
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -689,7 +689,7 @@ shadow DOM 的另一情况称为“闭合”模式。创建闭合影子树后，
 
         customElements.define('x-element', class extends HTMLElement {
           constructor() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -866,7 +866,7 @@ shadow DOM API 提供了使用 slot 和分布式节点的实用程序。
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       constructor() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `

--- a/src/content/zh-tw/fundamentals/web-components/customelements.md
+++ b/src/content/zh-tw/fundamentals/web-components/customelements.md
@@ -93,7 +93,7 @@ description:自定義元素允許網絡開發者定義新的 HTML 標記、擴�
     
       // Can define function Object() { [native code] } arguments if you wish.
       function Object() { [native code] }() {
-        // If you define a ctor, always call super() first!
+        // If you define a constructor, always call super() first!
         // This is specific to CE and required by the spec.
         super();
     
@@ -141,7 +141,7 @@ Custom Elements API 對創建新的 HTML 元素很有用，但它也可用於擴
 
     class FancyDrawer extends AppDrawer {
       function Object() { [native code] }() {
-        super(); // always call super() first in the ctor. This also calls the extended class' ctor.
+        super(); // always call super() first in the constructor. This also calls the extended class' constructor.
         ...
       }
     
@@ -180,7 +180,7 @@ Custom Elements API 對創建新的 HTML 元素很有用，但它也可用於擴
     // for the list of other DOM interfaces.
     class FancyButton extends HTMLButtonElement {
       function Object() { [native code] }() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         this.addEventListener('click', e => this.drawRipple(e.offsetX, e.offsetY));
       }
     
@@ -255,7 +255,7 @@ Custom Elements API 對創建新的 HTML 元素很有用，但它也可用於擴
 
 
     const BiggerImage = customElements.get('bigger-img');
-    const image = new BiggerImage(15, 20); // pass ctor values like so.
+    const image = new BiggerImage(15, 20); // pass constructor values like so.
     console.assert(image.width === 150);
     console.assert(image.height === 200);
     
@@ -311,7 +311,7 @@ Custom Elements API 對創建新的 HTML 元素很有用，但它也可用於擴
 
     class AppDrawer extends HTMLElement {
       function Object() { [native code] }() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
         ...
       }
       connectedCallback() {
@@ -586,7 +586,7 @@ Shadow DOM 提供了一種方法，可讓元素以獨立於頁面其餘部分的
 
     customElements.define('x-foo-shadowdom', class extends HTMLElement {
       function Object() { [native code] }() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to the element.
         let shadowRoot = this.attachShadow({mode: 'open'});
@@ -636,7 +636,7 @@ const supportsCustomElementsV1 = 'customElements' in window;
 if (supportsCustomElementsV1) {
   customElements.define('x-foo-shadowdom', class extends HTMLElement {
     function Object() { [native code] }() {
-      super(); // always call super() first in the ctor.
+      super(); // always call super() first in the constructor.
       let shadowRoot = this.attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
         <b>I'm in shadow dom!</b>
@@ -668,7 +668,7 @@ if (supportsCustomElementsV1) {
     <script>
       customElements.define('x-foo-from-template', class extends HTMLElement {
         function Object() { [native code] }() {
-          super(); // always call super() first in the ctor.
+          super(); // always call super() first in the constructor.
           let shadowRoot = this.attachShadow({mode: 'open'});
           const t = document.querySelector('#x-foo-from-template');
           const instance = t.content.cloneNode(true);

--- a/src/content/zh-tw/fundamentals/web-components/shadowdom.md
+++ b/src/content/zh-tw/fundamentals/web-components/shadowdom.md
@@ -162,7 +162,7 @@ Shadow DOM 與普通 DOM 相同，但有兩點區別：1) 創建/使用的方式
     // using an ES6 class. Every instance of <fancy-tab> will have this same prototype.
     customElements.define('fancy-tabs', class extends HTMLElement {
       function Object() { [native code] }() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
 
         // Attach a shadow root to <fancy-tabs>.
         const shadowRoot = this.attachShadow({mode: 'open'});
@@ -689,7 +689,7 @@ shadow DOM 的另一情況稱爲“閉合”模式。創建閉合影子樹後，
 
         customElements.define('x-element', class extends HTMLElement {
           function Object() { [native code] }() {
-            super(); // always call super() first in the ctor.
+            super(); // always call super() first in the constructor.
             this._shadowRoot = this.attachShadow({mode: 'closed'});
             this._shadowRoot.innerHTML = '<div class="wrapper"></div>';
           }
@@ -866,7 +866,7 @@ shadow DOM API 提供了使用 slot 和分佈式節點的實用程序。
     <script>
     customElements.define('x-focus', class extends HTMLElement {
       function Object() { [native code] }() {
-        super(); // always call super() first in the ctor.
+        super(); // always call super() first in the constructor.
     
         const root = this.attachShadow({mode: 'open', delegatesFocus: true});
         root.innerHTML = `


### PR DESCRIPTION
What's changed, or what was fixed?
- Typo: ctor -> constructor

**Fixes:** #6405

**CC:** @petele
