### PR TITLE
Fix captions not supporting links.

### DIFF
--- a/src/content/en/updates/2018/07/search-ads-speed.md
+++ b/src/content/en/updates/2018/07/search-ads-speed.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Speed is now a landing page factor for Google Search and Ads.
 
-{# wf_updated_on: 2018-07-25 #}
+{# wf_updated_on: 2018-07-24 #}
 {# wf_published_on: 2018-07-25 #}
 {# wf_tags: performance #}
 {# wf_blink_components: Blink>PerformanceAPIs #}
@@ -86,7 +86,7 @@ frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
 <figcaption class="clearfix align-center">
 <i>
 Watch the keynote to learn about Google's latest ads, analytics, and platforms
-announcements. Speed announcement at [34:30](https://youtu.be/MmfaZV96x7A?t=2055).
+announcements. Speed announcement at 34:30.
 </i>
 </figcaption>
 </figure>


### PR DESCRIPTION
What's changed, or what was fixed?

We ran into an issue with video captions not supporting inline links. As this is live, I'm going to drop the link while I try to play around with what can render.

![image](https://user-images.githubusercontent.com/110953/43151644-4629a406-8f21-11e8-99b9-4b21b257605e.png)


- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
