### PR TITLE
Add missing AMP mention to speed as a factor of search/ads doc

### DIFF
--- a/src/content/en/updates/2018/07/search-ads-speed.md
+++ b/src/content/en/updates/2018/07/search-ads-speed.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Speed is now a landing page factor for Google Search and Ads.
 
-{# wf_updated_on: 2018-07-24 #}
+{# wf_updated_on: 2018-07-25 #}
 {# wf_published_on: 2018-07-25 #}
 {# wf_tags: performance #}
 {# wf_blink_components: Blink>PerformanceAPIs #}
@@ -130,6 +130,8 @@ hands-on overview.
 <img src="/web/updates/images/2018/07/infographic-speed-tools.jpg" alt="Speed
 Tools infographic">
 </a>
+
+...or try [AMP](https://www.ampproject.org/).
 
 {% include "web/_shared/rss-widget-updates.html" %}
 


### PR DESCRIPTION
What's changed, or what was fixed?
Missing AMP line from the draft we worked on. 

- [X] This has been reviewed and approved by (igrigorik)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
