### PR TITLE
Fix array mutation on RSS generation

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -353,11 +353,17 @@ gulp.task('build:updates', function() {
   // Build updates widget for /web/index
   const template = path.join(
     global.WF.src.templates, 'landing-page', 'latest-updates.html');
-  const context = {articles: files.splice(0, 4)};
+  // Create a new array so we don't mutate the existing array;
+  const articles = [];
+  for (let i = 0; i < 4; i++) {
+    articles.push(files[i]);
+  }
+  const context = {articles};
   const outFile = path.join(
     global.WF.src.content, '_index-latest-updates.html');
   wfTemplateHelper.renderTemplate(template, context, outFile);
 
+  // Generate the RSS/ATOM feeds for each year
   options = {
     title: 'Updates',
     description: description,

--- a/gulp-tasks/wfTemplateHelper.js
+++ b/gulp-tasks/wfTemplateHelper.js
@@ -255,9 +255,13 @@ function generateIndex(files, options) {
  */
 function generateLatestWidget(files, options) {
   gutil.log(' ', 'Generating latest updates widget...');
-  const context = {
-    articles: files.splice(0, options.articlesToShow),
-  };
+  // Create a new array instead of mutating the existing array
+  const articles = [];
+  const len = options.articlesToShow || files.length;
+  for (let i = 0; i < len; i++) {
+    articles.push(files[i]);
+  }
+  const context = {articles};
   const template = path.join(global.WF.src.templates, 'latest_articles.html');
   const outputFile = path.join(options.outputPath, '_shared',
       'latest_articles.html');


### PR DESCRIPTION
What's changed, or what was fixed?
Last 8 articles were being dropped from the RSS feed generation because the array of files was being mutated as it generated other files. This prevents the array from being mutated.

**CC:** @ebidel 
