### PR TITLE
Fix of typo in code example

### DIFF
--- a/src/content/en/fundamentals/discovery/social-discovery/_code/social-sites.html
+++ b/src/content/en/fundamentals/discovery/social-discovery/_code/social-sites.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!-- // [START ogp] -->
 <!-- // [START twitter] -->
-<html prefix="g: http://ogp.me/ns#">
+<html prefix="og: http://ogp.me/ns#">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
"Social Discovery" page has a typo in code examples.
Prefix attribute value at root HTML tag has namespace "g" instead of "og"
which is used at the rest part of the code.

What's changed, or what was fixed?
- "g:" in prefix is changed to "og:"

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
