### PR TITLE
Warnings about async Workbox importScripts()

### DIFF
--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description:Get Started with Workbox.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-08-10 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Get Started {: .page-title }
@@ -71,6 +71,15 @@ officially loaded in our service worker.
 ![DevTools screenshot of Workbox loading in a service worker.](../images/guides/get-started/yay-loaded.png)
 
 Now we can start using Workbox.
+
+Warning: Importing `workbox-sw.js` will create a
+[`workbox` object](/web/tools/workbox/modules/workbox-sw) inside of your service worker, and that
+instance is responsible for importing other helper libraries, based on the features you use. Due to
+restrictions in the
+[service worker specification](https://www.chromestatus.com/feature/5748516353736704),
+these imports need to happen either inside of an `install` event handler, or synchronously in the
+top-level code for your service worker. More details, along with workarounds, can be found in the
+[`workbox-sw` documentation](/web/tools/workbox/modules/workbox-sw#avoid_async_imports).
 
 ## Using Workbox
 
@@ -155,7 +164,7 @@ workbox.routing.registerRoute(
 
 Routing and caching strategies are performed by the `routing` and
 `strategies` modules, but there are plenty of other modules, each offering
-specific behaviours that you can use in your service worker.
+specific behaviors that you can use in your service worker.
 
 You'll find a number of guides that cover other features of Workbox as well
 as more information on configuring Workbox. Find a full list on the left, but

--- a/src/content/en/tools/workbox/modules/workbox-strategies.md
+++ b/src/content/en/tools/workbox/modules/workbox-strategies.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-routing.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-04-03 #}
+{# wf_updated_on: 2018-08-10 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Strategies {: .page-title }
@@ -136,7 +136,7 @@ workbox.routing.registerRoute(
   new RegExp('/images/'),
   workbox.strategies.cacheFirst({
     cacheName: 'image-cache'
-  }
+  })
 );
 ```
 
@@ -164,7 +164,7 @@ workbox.registerRoute(
         maxEntries: 10,
       }),
     ]
-  }
+  })
 );
 ```
 

--- a/src/content/en/tools/workbox/modules/workbox-sw.md
+++ b/src/content/en/tools/workbox/modules/workbox-sw.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-sw.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2018-05-03 #}
+{# wf_updated_on: 2018-08-10 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox {: .page-title }
@@ -66,7 +66,72 @@ workbox.setConfig({
 });
 ```
 
-With this, you’ll use only the local workbox files.
+With this, you’ll use only the local Workbox files.
+
+## Avoid Async Imports
+
+Under the hood, loading new modules for the first time involves calling
+[`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts)
+with the path to the corresponding JavaScript file (either hosted on the CDN, or via a local URL).
+In either case, an important restriction applies: the implicit calls to `importScripts()` can only
+happen inside of a service worker's `install` handler, *or* during the synchronous,
+[initial execution](https://stackoverflow.com/questions/38835273) of the service worker script.
+
+In order to avoid violating this restriction, a best practice is to reference the various
+`workbox.*` namespaces outside of any event handlers or asynchronous functions.
+
+For example, the following top-level service worker code is fine:
+
+```js
+importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
+
+// This will work!
+workbox.routing.registerRoute(
+  new RegExp('\.png$'),
+  workbox.strategies.cacheFirst()
+);
+```
+
+But this code could be a problem if you have not referenced `workbox.strategies` elsewhere in your
+service worker:
+
+```js
+importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.endsWith('.png') {
+    // Oops! This causes workbox-strategies.js to be imported inside a fetch handler,
+    // outside of the initial, synchronous service worker execution.
+    const cacheFirst = workbox.strategies.cacheFirst();
+    event.respondWith(cacheFirst.makeRequest({request: event.request}));
+  }
+});
+```
+
+If you need to write code that would otherwise run afoul of this restriction, you can explicitly
+trigger the `importScripts()` call outside of the event handler, using the
+[`workbox.loadModule()`](/web/tools/workbox/reference-docs/latest/workbox#.loadModule) method:
+
+```js
+importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
+
+// This will trigger the importScripts() needed for workbox.core and workbox.strategies
+workbox.loadModule('workbox-core');
+workbox.loadModule('workbox-strategies');
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.endsWith('.png') {
+    // Referencing workbox.strategies will now work as expected.
+    const cacheFirst = workbox.strategies.cacheFirst();
+    event.respondWith(cacheFirst.makeRequest({request: event.request}));
+  }
+});
+```
+
+Note: Some versions of Chrome do not honor this restriction, and asynchronous calls to
+`importScripts()` don't trigger the expected failure. Developers are advised *not* to rely on this
+broken behavior. Chrome [plans](https://www.chromestatus.com/feature/5748516353736704) on making
+a change to start disallowing this usage, bringing it in line with what other browsers already do.
 
 ## Force Use of Debug or Production Builds
 
@@ -90,7 +155,7 @@ workbox.setConfig({
 
 Some developers want to be able to publish a new service worker and have it
 update and control a web page as soon as possible, skipping the default
-service worker lifecycle.
+[service worker lifecycle](/web/fundamentals/primers/service-workers/lifecycle).
 
 If you find yourself wanting this behavior, `workbox-sw` provides some helper
 methods to make this easy:
@@ -99,3 +164,9 @@ methods to make this easy:
 workbox.skipWaiting();
 workbox.clientsClaim();
 ```
+
+Note: If your web app lazy-loads resources that are uniquely versioned with, e.g., hashes in their
+URLs, it's recommended that you avoid using skip waiting. Enabling it could
+[lead to failures](https://stackoverflow.com/questions/51715127)
+when lazily-loading URLs that were previously precached and were purged during an updated service
+worker's activation.


### PR DESCRIPTION
R: @philipwalton 

This is primarily to add in some info about avoiding asynchronous calls to `importScripts()` when using Workbox, in advance of a [change in Chrome](https://www.chromestatus.com/feature/5748516353736704) to adhere to a restriction that other browsers already employ.

See https://github.com/GoogleChrome/workbox/issues/1504 for more context.

It also fixes a small typo pointed out in https://github.com/GoogleChrome/workbox/issues/1602 and provides some context as to why you might *not* want to call `workbox.skipWaiting()`.

**CC:** @petele
