### PR TITLE
Direct to the Chrome 63+ workspaces page

### DIFF
--- a/src/content/en/tools/chrome-devtools/sources.md
+++ b/src/content/en/tools/chrome-devtools/sources.md
@@ -158,7 +158,7 @@ your file system. Essentially, this lets you use DevTools as your code editor.
 
 See [Set Up Persistence With DevTools Workspaces][WS] to get started.
 
-[WS]: /web/tools/setup/setup-workflow
+[WS]: /web/tools/chrome-devtools/workspaces/
 
 ## Feedback {: #feedback }
 


### PR DESCRIPTION
The "Set Up Persistence..." link at https://developers.google.com/web/tools/chrome-devtools/sources#workspace currently points to a page that refers to Chrome 62 or older.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
