### PR TITLE
remove chrome web store script

### DIFF
--- a/src/content/en/tools/lighthouse/index.md
+++ b/src/content/en/tools/lighthouse/index.md
@@ -47,8 +47,6 @@ figure {
 }
 </style>
 
-<script src="/_static/js/managed/cws_install.js" async></script>
-
 Lighthouse is an [open-source](https://github.com/GoogleChrome/lighthouse),
 automated tool for improving the quality of web pages. You can run it against
 any web page, public or requiring authentication. It has audits for performance,


### PR DESCRIPTION
What's changed, or what was fixed?
- removes chrome web store script

**Fixes:** N/A

**Target Live Date:** 2018-08-17

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
