### PR TITLE
Fix broken link

### DIFF
--- a/src/content/en/updates/2018/08/wasm-av1.md
+++ b/src/content/en/updates/2018/08/wasm-av1.md
@@ -26,7 +26,7 @@ This article will walk through an example of how to take the existing AV1
 video codec source code, build a wrapper for it, and try it out inside your
 browser and tips to help with building a test harness to debug the wrapper.
 Full source code for the example here is available at
-https://github.com/GoogleChromeLabs/wasm-av1 for reference.
+[github.com/GoogleChromeLabs/wasm-av1](https://github.com/GoogleChromeLabs/wasm-av1) for reference.
 
 
 ## Choosing an interesting code-base

--- a/src/content/en/updates/2018/08/wasm-av1.md
+++ b/src/content/en/updates/2018/08/wasm-av1.md
@@ -462,4 +462,6 @@ on the web already today.
 Thanks to Jeff Posnick, Eric Bidelman and Thomas Steiner for providing
 valuable review and feedback.
 
+{% include "web/_shared/rss-widget-updates.html" %}
+
 {% include "comment-widget.html" %}


### PR DESCRIPTION
Link to the github repository didn't process as clickable from the Markdown

Explicit link added.

**Fixes:** #issue

**Target Live Date:** 20189-08-22

- [X ] This has been reviewed and approved by (NAME)
- [X ] I have run `npm test` locally and all tests pass.
- [X ] I have added the appropriate `type-something` label.
- [ X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
