### PR TITLE
Tip about getting a fresh response body in cacheDidUpdate

### DIFF
--- a/src/content/en/tools/workbox/guides/using-plugins.md
+++ b/src/content/en/tools/workbox/guides/using-plugins.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to using plugins with Workbox.
 
-{# wf_updated_on: 2018-06-12 #}
+{# wf_updated_on: 2018-08-22 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: n/a #}
 
@@ -91,6 +91,10 @@ const myPlugin = {
   },
   cacheDidUpdate: async ({cacheName, request, oldResponse, newResponse}) => {
     // No return expected
+    // Note: `newResponse.bodyUsed` is `true` when this is called,
+    // meaning the body has already been read. If you need access to
+    // the body of the fresh response, use a technique like:
+    // const freshResponse = await caches.match(request, {cacheName});
   },
   cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse}) => {
     // Return `cachedResponse`, a different Response object or null


### PR DESCRIPTION
R: @philipwalton 
CC: @chrisdarroch

This adds an explanatory comment to the Workbox plugins guide.

**Fixes:** https://github.com/GoogleChrome/workbox/issues/1515

**Target Live Date:** 2018-09-10

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
