### PR TITLE
OffscreeCanvas: Fix inlined markdown link in HTML section

### DIFF
--- a/src/content/en/updates/2018/08/offscreen-canvas.md
+++ b/src/content/en/updates/2018/08/offscreen-canvas.md
@@ -84,7 +84,7 @@ OffscreenCanvas will be rendered on the source canvas automatically.
     worker.postMessage({ canvas: offscreen }, [offscreen]);
 
 <div class="key-point">
-OffscreenCanvas is [transferable](https://developer.mozilla.org/en-US/docs/Web/API/Transferable).
+OffscreenCanvas is <a href="https://developer.mozilla.org/en-US/docs/Web/API/Transferable">transferable</a>.
 Apart from specifying it as a field in the message, you need to also pass it as a second argument
 in postMessage (a transfer) so that it can be used in the worker context.
 </div>


### PR DESCRIPTION
<img width="883" alt="screen shot 2018-08-26 at 10 29 09 am" src="https://user-images.githubusercontent.com/105127/44629293-0bae8d00-a91b-11e8-94da-928c77013f5e.png">

cc @devnook 
