### PR TITLE
Remove duplicate word ("before")

### DIFF
--- a/src/content/en/fundamentals/performance/why-performance-matters/index.md
+++ b/src/content/en/fundamentals/performance/why-performance-matters/index.md
@@ -206,7 +206,7 @@ suggestions:
 
 - If you use Bootstrap or Foundation to build your UI, ask yourself if they're
 necessary. Such abstractions add heaps of CSS the browser must download, parse,
-and apply to a page, all before before your site-specific CSS enters the
+and apply to a page, all before your site-specific CSS enters the
 picture.
 [Flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout)
 and [Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) are


### PR DESCRIPTION
What's changed, or what was fixed?
- Removed repeated word ("before") in "Why Performance Matters" article

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
