### PR TITLE
Remove AV1 from media updates post

### DIFF
--- a/src/content/en/updates/2018/08/chrome-69-media-updates.md
+++ b/src/content/en/updates/2018/08/chrome-69-media-updates.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the audio/video updates in Chrome 69: AV1 and HDCP policy check.
 
-{# wf_updated_on: 2018-08-07 #}
+{# wf_updated_on: 2018-09-06 #}
 {# wf_published_on: 2018-08-01 #}
 {# wf_tags: news,chrome69,media,removals #}
 {# wf_featured_image: /web/updates/images/generic/play-outline.png #}
@@ -23,18 +23,10 @@ description: A round up of the audio/video updates in Chrome 69: AV1 and HDCP po
 - Android Go users can [open downloaded audio, video and images in Chrome](#media_intent_handler).
 - [Stalled events](#stalled) for media elements using MSE are removed.
 
-## AV1 video decoder behind a flag {: #av1 }
+## AV1 video decoder {: #av1 }
 
-AV1 is a next generation codec developed by the [Alliance for Open Media] which
-[improves compression efficiency by 30%] over the current state-of-the-art
-video codec, VP9.
-
-Chrome 69 adds an AV1 decoder to Chrome Desktop (Windows, Mac, Linux, ChromeOS)
-based on the [official bitstream specification]. At this time, support is
-limited to "Main" [profile 0] and does not include encoding capabilities. The
-supported container is [ISO-BMFF (MP4)]. See [From raw video to web ready] for
-a brief explanation of containers. To enable this feature use the 
-`chrome://flags/#enable-av1-decoder` flag.
+Note: AV1 video decoder support had to be pushed back to Chrome 70 because of
+changes to the MP4 binding.
 
 [Chromestatus Tracker](https://www.chromestatus.com/features/5729898442260480) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=838380)


### PR DESCRIPTION
This removes AV1 from the Audio/Video Updates in Chrome 69 post as this was pushed back to Chrome. 70