### PR TITLE
Fix run-on sentence

### DIFF
--- a/src/content/en/fundamentals/app-install-banners/index.md
+++ b/src/content/en/fundamentals/app-install-banners/index.md
@@ -117,7 +117,7 @@ shown and the user has responded to it.
         });
     });
 
-You can only call `prompt()` on the deferred event once, if the user dismissed
+You can only call `prompt()` on the deferred event once. If the user dismisses
 it, you'll need to wait until the `beforeinstallprompt` event is fired on
 the next page navigation.
 


### PR DESCRIPTION
Hey @petele, 

Another issue to be fixed on this page: we should mention that on Chrome OS, there's no mini-infobar (or any default A2HS affordance). See [this](https://docs.google.com/presentation/d/1hBKxbAt8Lv6fjHyp97PqLamCIXlSIF_sMmWyZnMob7M/edit#slide=id.g3993e26dac_9_62) and [this](https://groups.google.com/a/google.com/forum/#!msg/desktop-pwa-discuss/oF9Qp8I58wc/VzXf_gAhBgAJ).