### PR TITLE
Fix published date for Cookie Store API article

### DIFF
--- a/src/content/en/updates/2018/09/asynchronous-access-to-http-cookies.md
+++ b/src/content/en/updates/2018/09/asynchronous-access-to-http-cookies.md
@@ -2,8 +2,8 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: The Cookie Store API offers asynchronous acesss to HTTP cookies, and opens up the cookie jar to service workers.
 
-{# wf_updated_on: 2018-09-05 #}
-{# wf_published_on: 2018-07-23 #}
+{# wf_updated_on: 2018-09-07 #}
+{# wf_published_on: 2018-09-06 #}
 {# wf_tags: cookie,chrome69 #}
 {# wf_featured_image: /web/updates/images/generic/styles.png #}
 {# wf_featured_snippet: The Cookie Store API offers asynchronous access to HTTP cookies, and opens up the cookie jar to service workers. #}


### PR DESCRIPTION
What's changed, or what was fixed?
- item 1
- item 2

**Target Live Date:** 2018-09-06

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @developit 
