### PR TITLE
Fix typos

### DIFF
--- a/src/content/en/updates/2018/09/inside-browser-part1.md
+++ b/src/content/en/updates/2018/09/inside-browser-part1.md
@@ -110,7 +110,7 @@ application, the process also goes away and the Operating System frees up the me
     <img src="/web/updates/images/inside-browser/part1/memory.png" alt="process and memory">
   </a>
   <b>
-    <span class="material-icons">play_circle_outline</span>click on the image to see annimation
+    <span class="material-icons">play_circle_outline</span>click on the image to see animation
   </b>
   <figcaption>
     Figure 5: Diagram of a process using memory space and storing application data
@@ -129,7 +129,7 @@ without stopping other processes which are running different parts of the applic
       alt="worker process and IPC">
   </a>
   <b>
-    <span class="material-icons">play_circle_outline</span>click on the image to see annimation
+    <span class="material-icons">play_circle_outline</span>click on the image to see animation
   </b>
   <figcaption>
     Figure 6: Diagram of separate processes communicating over IPC
@@ -228,7 +228,7 @@ the tabs are unresponsive. That’s sad.
     <img src="/web/updates/images/inside-browser/part1/tabs.png" alt="multiple renderer for tabs">
   </a>
   <b>
-    <span class="material-icons">play_circle_outline</span>click on the image to see annimation
+    <span class="material-icons">play_circle_outline</span>click on the image to see animation
   </b>
   <figcaption>
     Figure 10: Diagram showing multiple processes running each tab
@@ -264,7 +264,7 @@ processes for less memory usage have been used on platform like Android before t
       alt="Chrome servicfication">
   </a>
   <b>
-    <span class="material-icons">play_circle_outline</span>click on the image to see annimation
+    <span class="material-icons">play_circle_outline</span>click on the image to see animation
   </b>
   <figcaption>
    Figure 11: Diagram of Chrome’s servicification moving different services into multiple processes 

--- a/src/content/en/updates/2018/09/reportingapi.md
+++ b/src/content/en/updates/2018/09/reportingapi.md
@@ -74,7 +74,7 @@ to report errors to:
 Report-To: {
              "max_age": 10886400,
              "endpoints": [{
-               "url": "https://analytics.provider.com/browser-errors"
+               "url": "https://example.com/browser-errors"
              }]
            }
 ```
@@ -292,8 +292,8 @@ Report-To: {
 ```
 
 For backwards compatibility, continue to use `report-uri` along with `report-to`.
-In other words: `Content-Security-Policy: ...; report-uri https://endpoint.com; report-to groupname`.
-Browsers that support `report-to` will use it instead of the former.
+In other words: `Content-Security-Policy: ...; report-uri https://example.com/csp-reports; report-to groupname`.
+Browsers that support `report-to` will use it instead of the `report-uri`.
 {: .key-point }
 
 ### Network errors {: #nel }
@@ -319,7 +319,7 @@ Report-To: {
 ```
 
 Next, send the `NEL` response header to start collecting errors. Since NEL
-is opt-in for an origin*, you only need to send the header once. Both `NEL` and
+is opt-in for an origin, you only need to send the header once. Both `NEL` and
 `Report-To` will apply to future requests to the same origin and will continue
 to collect errors according to the `max_age` value that was used to set up
 the collector.

--- a/src/content/en/updates/2018/09/reportingapi.md
+++ b/src/content/en/updates/2018/09/reportingapi.md
@@ -74,7 +74,7 @@ to report errors to:
 Report-To: {
              "max_age": 10886400,
              "endpoints": [{
-               "url": "https://example.com/browser-errors"
+               "url": "https://analytics.provider.com/browser-errors"
              }]
            }
 ```
@@ -85,7 +85,7 @@ Access-Control-Allow-Methods: GET,PUT,POST,DELETE,OPTIONS; Access-Control-Allow-
 
 In the example, sending this response header with your main page
 configures the browser to report browser-generated warnings
-to the endpoint `https://example.com/browser-errors` for `max_age` seconds.
+to the endpoint `https://analytics.provider.com/browser-errors` for `max_age` seconds.
 It's important to note that all subsequent HTTP requests made by the page
 (for images, scripts, etc.) are ignored. Configuration is setup during
 the response of the main page.
@@ -293,7 +293,7 @@ Report-To: {
 
 For backwards compatibility, continue to use `report-uri` along with `report-to`.
 In other words: `Content-Security-Policy: ...; report-uri https://example.com/csp-reports; report-to groupname`.
-Browsers that support `report-to` will use it instead of the `report-uri`.
+Browsers that support `report-to` will use it instead of `report-uri`.
 {: .key-point }
 
 ### Network errors {: #nel }


### PR DESCRIPTION
Fix typos for the Reporting API article.

What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
