### PR TITLE
Fix broken 'setting up the labs' links

### DIFF
--- a/src/content/en/ilt/pwa/challenge-convert-a-news-app-to-a-pwa.md
+++ b/src/content/en/ilt/pwa/challenge-convert-a-news-app-to-a-pwa.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-09-05 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -55,7 +55,7 @@ Unlike the other labs, this is a self-guided exercise - only the setup is explai
 
 
 
-If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting_up_the_labs.md).
+If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 ### Install project dependencies and explore the app
 

--- a/src/content/en/ilt/pwa/lab-auditing-with-lighthouse.md
+++ b/src/content/en/ilt/pwa/lab-auditing-with-lighthouse.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -44,7 +44,7 @@ This lab shows you how you can use  [Lighthouse](/web/tools/lighthouse/), an  [o
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-build-a-progressive-web-amp.md
+++ b/src/content/en/ilt/pwa/lab-build-a-progressive-web-amp.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-09-05 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -51,7 +51,7 @@ This lab walks you through implementing two different AMP + PWA patterns: 1) tra
 
 
 
-If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting_up_the_labs.md).
+If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `amp-pwa-lab/project/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-caching-files-with-service-worker.md
+++ b/src/content/en/ilt/pwa/lab-caching-files-with-service-worker.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -48,7 +48,7 @@ This lab covers the basics of caching files with the service worker. The technol
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `cache-api-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-fetch-api.md
+++ b/src/content/en/ilt/pwa/lab-fetch-api.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -51,7 +51,7 @@ Note: Although the Fetch API is  [not currently supported in all browsers](http:
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open your computer's command line. Navigate into the `fetch-api-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-gulp-setup.md
+++ b/src/content/en/ilt/pwa/lab-gulp-setup.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -48,7 +48,7 @@ This lab shows you how you can automate tasks with  [gulp](https://gulpjs.com/),
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open the `gulp-lab/project/` folder in your preferred text editor. The `project/` folder is where you will be building the lab.
 

--- a/src/content/en/ilt/pwa/lab-indexeddb.md
+++ b/src/content/en/ilt/pwa/lab-indexeddb.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -50,7 +50,7 @@ This lab builds a furniture store app,  *Couches-n-Things* , to demonstrate the 
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-integrating-analytics.md
+++ b/src/content/en/ilt/pwa/lab-integrating-analytics.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -52,7 +52,7 @@ This lab shows you how to integrate Google Analytics into your Progressive Web A
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `google-analytics-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-integrating-web-push.md
+++ b/src/content/en/ilt/pwa/lab-integrating-web-push.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -50,7 +50,7 @@ This lab shows you the basics of sending, receiving, and displaying push notific
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open your computer's command line. Navigate into the `push-notification-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-migrating-to-workbox-from-sw-precache-and-sw-toolbox.md
+++ b/src/content/en/ilt/pwa/lab-migrating-to-workbox-from-sw-precache-and-sw-toolbox.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -55,7 +55,7 @@ This lab shows you how to take an existing PWA that uses `sw-precache` and `sw-t
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 In `sw-precache-workbox-lab/`, open the `project/` folder in your preferred text editor. The `project/` folder is where you do the work in this lab.
 

--- a/src/content/en/ilt/pwa/lab-offline-quickstart.md
+++ b/src/content/en/ilt/pwa/lab-offline-quickstart.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -47,7 +47,7 @@ In this lab you'll use  [Lighthouse](/web/tools/lighthouse/) to audit a website 
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `offline-quickstart-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-promises.md
+++ b/src/content/en/ilt/pwa/lab-promises.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -47,7 +47,7 @@ This lab shows you how to use JavaScript  [Promises](https://developer.mozilla.o
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open your computer's command line interface. Navigate into the `promises-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-responsive-design.md
+++ b/src/content/en/ilt/pwa/lab-responsive-design.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -45,7 +45,7 @@ This lab shows you how to style your content to make it responsive.
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-responsive-images.md
+++ b/src/content/en/ilt/pwa/lab-responsive-images.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -44,7 +44,7 @@ This lab shows you how to make images on your web page look good on all devices.
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
+++ b/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -46,7 +46,7 @@ This lab walks you through creating a simple service worker and explains the ser
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `service-worker-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-workbox.md
+++ b/src/content/en/ilt/pwa/lab-workbox.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -55,7 +55,7 @@ In this lab, you'll use the `workbox-sw.js` library and the `workbox-build` Node
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 ### 1.1 Install project dependencies and start the server
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Fix broken 'setting up the labs' links on various pages

**Fixes:** #6640 

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally ~~and all tests pass~~.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

Note: I get 5 errors when running `npm test` but these errors does not seem related to any of my changes. Not sure if i should adress these errors?

**CC:** @petele
