### PR TITLE
Link regex and pwa ilt

### DIFF
--- a/gulp-tasks/wfCodeLabHelper.js
+++ b/gulp-tasks/wfCodeLabHelper.js
@@ -92,7 +92,7 @@ function updateCodeLab(sourceFile, destFile, bookPath, projPath) {
     match = match.replace(re, 'href="$1$2"').replace(/_/g, '-');
     return match;
   });
-  re = /\[(.*?)\]\((.*?)\.md(.*?)\)/g;
+  re = /\[([^\]]*?)\]\(([^\]]*?)\.md(.*?)\)/g;
   markdown = markdown.replace(re, function(match) {
     if (match.indexOf('/') > 0) {
       return match;

--- a/src/content/en/ilt/pwa/challenge-convert-a-news-app-to-a-pwa.md
+++ b/src/content/en/ilt/pwa/challenge-convert-a-news-app-to-a-pwa.md
@@ -55,7 +55,7 @@ Unlike the other labs, this is a self-guided exercise - only the setup is explai
 
 
 
-If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting_up_the_labs.md).
+If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 ### Install project dependencies and explore the app
 

--- a/src/content/en/ilt/pwa/e-commerce-lab-1-create-a-service-worker.md
+++ b/src/content/en/ilt/pwa/e-commerce-lab-1-create-a-service-worker.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2017-06-14 #}
+{# wf_updated_on: 2018-09-11 #}
 {# wf_published_on: 2016-01-01 #}
 
 

--- a/src/content/en/ilt/pwa/e-commerce-lab-2-add-to-homescreen.md
+++ b/src/content/en/ilt/pwa/e-commerce-lab-2-add-to-homescreen.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-04-17 #}
+{# wf_updated_on: 2018-09-11 #}
 {# wf_published_on: 2016-01-01 #}
 
 

--- a/src/content/en/ilt/pwa/e-commerce-lab-3-payment-request-api.md
+++ b/src/content/en/ilt/pwa/e-commerce-lab-3-payment-request-api.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-07-02 #}
+{# wf_updated_on: 2018-09-11 #}
 {# wf_published_on: 2016-01-01 #}
 
 

--- a/src/content/en/ilt/pwa/lab-auditing-with-lighthouse.md
+++ b/src/content/en/ilt/pwa/lab-auditing-with-lighthouse.md
@@ -44,7 +44,7 @@ This lab shows you how you can use  [Lighthouse](/web/tools/lighthouse/), an  [o
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-build-a-progressive-web-amp.md
+++ b/src/content/en/ilt/pwa/lab-build-a-progressive-web-amp.md
@@ -51,7 +51,7 @@ This lab walks you through implementing two different AMP + PWA patterns: 1) tra
 
 
 
-If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting_up_the_labs.md).
+If you have not downloaded the  [repository](https://github.com/google-developer-training/pwa-training-labs) and installed  [the LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `amp-pwa-lab/project/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-caching-files-with-service-worker.md
+++ b/src/content/en/ilt/pwa/lab-caching-files-with-service-worker.md
@@ -48,7 +48,7 @@ This lab covers the basics of caching files with the service worker. The technol
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `cache-api-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-fetch-api.md
+++ b/src/content/en/ilt/pwa/lab-fetch-api.md
@@ -51,7 +51,7 @@ Note: Although the Fetch API is  [not currently supported in all browsers](http:
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open your computer's command line. Navigate into the `fetch-api-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-gulp-setup.md
+++ b/src/content/en/ilt/pwa/lab-gulp-setup.md
@@ -48,7 +48,7 @@ This lab shows you how you can automate tasks with  [gulp](https://gulpjs.com/),
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open the `gulp-lab/project/` folder in your preferred text editor. The `project/` folder is where you will be building the lab.
 

--- a/src/content/en/ilt/pwa/lab-indexeddb.md
+++ b/src/content/en/ilt/pwa/lab-indexeddb.md
@@ -50,7 +50,7 @@ This lab builds a furniture store app,  *Couches-n-Things* , to demonstrate the 
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-integrating-analytics.md
+++ b/src/content/en/ilt/pwa/lab-integrating-analytics.md
@@ -52,7 +52,7 @@ This lab shows you how to integrate Google Analytics into your Progressive Web A
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `google-analytics-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-integrating-web-push.md
+++ b/src/content/en/ilt/pwa/lab-integrating-web-push.md
@@ -50,7 +50,7 @@ This lab shows you the basics of sending, receiving, and displaying push notific
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open your computer's command line. Navigate into the `push-notification-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-migrating-to-workbox-from-sw-precache-and-sw-toolbox.md
+++ b/src/content/en/ilt/pwa/lab-migrating-to-workbox-from-sw-precache-and-sw-toolbox.md
@@ -55,7 +55,7 @@ This lab shows you how to take an existing PWA that uses `sw-precache` and `sw-t
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 In `sw-precache-workbox-lab/`, open the `project/` folder in your preferred text editor. The `project/` folder is where you do the work in this lab.
 

--- a/src/content/en/ilt/pwa/lab-offline-quickstart.md
+++ b/src/content/en/ilt/pwa/lab-offline-quickstart.md
@@ -47,7 +47,7 @@ In this lab you'll use  [Lighthouse](/web/tools/lighthouse/) to audit a website 
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `offline-quickstart-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-promises.md
+++ b/src/content/en/ilt/pwa/lab-promises.md
@@ -47,7 +47,7 @@ This lab shows you how to use JavaScript  [Promises](https://developer.mozilla.o
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Open your computer's command line interface. Navigate into the `promises-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-responsive-design.md
+++ b/src/content/en/ilt/pwa/lab-responsive-design.md
@@ -45,7 +45,7 @@ This lab shows you how to style your content to make it responsive.
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-responsive-images.md
+++ b/src/content/en/ilt/pwa/lab-responsive-images.md
@@ -44,7 +44,7 @@ This lab shows you how to make images on your web page look good on all devices.
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 If you don't have a preferred local development server, install the Node.js `http-server` package:
 

--- a/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
+++ b/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -46,7 +46,7 @@ This lab walks you through creating a simple service worker and explains the ser
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 Navigate into the `service-worker-lab/app/` directory and start a local development server:
 

--- a/src/content/en/ilt/pwa/lab-workbox.md
+++ b/src/content/en/ilt/pwa/lab-workbox.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-08-30 #}
+{# wf_updated_on: 2018-09-19 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -55,7 +55,7 @@ In this lab, you'll use the `workbox-sw.js` library and the `workbox-build` Node
 
 
 
-If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs.md).
+If you have not downloaded the repository and installed the  [LTS version of Node.js](https://nodejs.org/en/), follow the instructions in [Setting up the labs](setting-up-the-labs).
 
 ### 1.1 Install project dependencies and start the server
 

--- a/src/data/ilt-pwa/e-commerce-lab-1-create-a-service-worker/codelab.json
+++ b/src/data/ilt-pwa/e-commerce-lab-1-create-a-service-worker/codelab.json
@@ -4,7 +4,7 @@
   "format": "md",
   "prefix": "../../",
   "mainga": "UA-49880327-14",
-  "updated": "2017-06-14T20:26:34Z",
+  "updated": "2018-09-11T20:02:04Z",
   "id": "e-commerce-lab-1-create-a-service-worker",
   "duration": 0,
   "title": "E-Commerce Lab 1: Create a Service Worker",

--- a/src/data/ilt-pwa/e-commerce-lab-2-add-to-homescreen/codelab.json
+++ b/src/data/ilt-pwa/e-commerce-lab-2-add-to-homescreen/codelab.json
@@ -4,7 +4,7 @@
   "format": "md",
   "prefix": "../../",
   "mainga": "UA-49880327-14",
-  "updated": "2018-04-17T20:26:32Z",
+  "updated": "2018-09-11T20:02:15Z",
   "id": "e-commerce-lab-2-add-to-homescreen",
   "duration": 0,
   "title": "E-Commerce Lab 2: Add to Homescreen",

--- a/src/data/ilt-pwa/e-commerce-lab-3-payment-request-api/codelab.json
+++ b/src/data/ilt-pwa/e-commerce-lab-3-payment-request-api/codelab.json
@@ -4,7 +4,7 @@
   "format": "md",
   "prefix": "../../",
   "mainga": "UA-49880327-14",
-  "updated": "2018-07-02T17:17:06Z",
+  "updated": "2018-09-11T20:02:20Z",
   "id": "e-commerce-lab-3-payment-request-api",
   "duration": 0,
   "title": "E-Commerce Lab 3: Payment Request API",

--- a/src/data/ilt-pwa/lab-scripting-the-service-worker/codelab.json
+++ b/src/data/ilt-pwa/lab-scripting-the-service-worker/codelab.json
@@ -4,7 +4,7 @@
   "format": "md",
   "prefix": "../../",
   "mainga": "UA-49880327-14",
-  "updated": "2018-08-30T20:25:23Z",
+  "updated": "2018-09-19T17:40:27Z",
   "id": "lab-scripting-the-service-worker",
   "duration": 0,
   "title": "Lab: Scripting the Service Worker",

--- a/src/data/ilt-pwa/lab-workbox/codelab.json
+++ b/src/data/ilt-pwa/lab-workbox/codelab.json
@@ -4,7 +4,7 @@
   "format": "md",
   "prefix": "../../",
   "mainga": "UA-49880327-14",
-  "updated": "2018-08-30T20:27:10Z",
+  "updated": "2018-09-19T18:05:43Z",
   "id": "lab-workbox",
   "duration": 0,
   "title": "Lab: Workbox",


### PR DESCRIPTION
What's changed, or what was fixed?
- updated `tools/wfCodeLabHelper.js` regex expression to be more narrow when searching for markdown links
- fixed all broken markdown links in PWA-ILT content

**Fixes:** #6640

- [x] This has been reviewed and approved by (dscales)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label. (I think so? not sure if "Infrastructure" applies here)
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele - please note that this changes not only content but also a clean up regex. I've tested successfully on all our content. 

The issue was that the existing regex, `/\[(.*?)\]\((.*?)\.md(.*?)\)/g`, was too broad and in the paragraph:

```
If you have not downloaded the repository and installed the 
[LTS version of Node.js](https://nodejs.org/en/), follow the instructions 
in [Setting up the labs](setting-up-the-labs.md).
```

matched all of 

```
[LTS version of Node.js](https://nodejs.org/en/), follow the instructions 
in [Setting up the labs](setting-up-the-labs.md)
```

instead of just 

```
[Setting up the labs](setting-up-the-labs.md)
```

Props to @nasearle for help debugging. 
