### PR TITLE
add homepage and toc links

### DIFF
--- a/src/content/en/tools/chrome-devtools/_toc.yaml
+++ b/src/content/en/tools/chrome-devtools/_toc.yaml
@@ -5,6 +5,8 @@ toc:
   section:
   - title: HTML and the DOM
     path: /web/tools/chrome-devtools/beginners/html
+  - title: CSS
+    path: /web/tools/chrome-devtools/beginners/css
 - title: View and Change CSS
   section:
   - title: Get Started with Viewing and Changing CSS

--- a/src/content/en/tools/chrome-devtools/index.md
+++ b/src/content/en/tools/chrome-devtools/index.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Get started with Google Chrome's built-in web developer tools.
 
-{# wf_updated_on: 2018-08-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-03-28 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -24,10 +24,11 @@ demonstrates.
 
 ## DevTools for Beginners {: #beginners }
 
-DevTools for Beginners teaches you the basics of developing websites and using DevTools.
+DevTools for Beginners teaches you the **fundamentals of web development** as well as the basics of DevTools.
+Check out [Get started](#get-started) below if you'd prefer tutorials that focus on DevTools.
 
-* [Get Started with HTML and the DOM](/web/tools/chrome-devtools/beginners/html). In this first tutorial,
-  you set up your code, add content to your page with HTML, and use DevTools to experiment with content changes.
+* [Get Started with HTML and the DOM](/web/tools/chrome-devtools/beginners/html)
+* [Get Started with CSS](/web/tools/chrome-devtools/beginners/css)
 
 ## Get started {: #get-started }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- link to the css tutorial from the ToC and homepage

**Target Live Date:** 2018-09-27

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
