### PR TITLE
add "was this page helpful?" widget to the rest of the fundamentals docs

### DIFF
--- a/src/content/en/fundamentals/accessibility/a11y-for-teams.md
+++ b/src/content/en/fundamentals/accessibility/a11y-for-teams.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: How to incorporate accessibility into your team's process.
 
 
-{# wf_updated_on: 2017-10-06 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-08-01 #}
 {# wf_blink_components: Blink>Accessibility #}
 
@@ -334,4 +334,6 @@ To learn more about accessibility, be sure to check out [our free Udacity
 course](https://bit.ly/web-a11y) and browse [the accessibility docs](/web/fundamentals/accessibility/)
 available here on Web Fundamentals.
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/accessible-styles.md
+++ b/src/content/en/fundamentals/accessibility/accessible-styles.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Using proper styling to improve accessibility
 
 
-{# wf_updated_on: 2018-05-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 {# wf_blink_components: Blink>CSS #}
 
@@ -357,3 +357,7 @@ should be fine when it comes to supporting high-contrast mode. But for added
 peace of mind, consider installing the Chrome High Contrast extension and giving
 your page a once-over just to check that everything works, and looks, as
 expected.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/focus/dom-order-matters.md
+++ b/src/content/en/fundamentals/accessibility/focus/dom-order-matters.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: The importance of the default DOM order
 
-
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/focus/dom-order-matters.md
+++ b/src/content/en/fundamentals/accessibility/focus/dom-order-matters.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: The importance of the default DOM order
 
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # DOM Order Matters {: .page-title }
@@ -92,3 +92,7 @@ sequence. If it does, you should make sure you are appropriately hiding
 offscreen content with `display: none` or `visibility: hidden`, or that you
 rearrange elements' physical positions in the DOM so they are in a logical
 order.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/focus/index.md
+++ b/src/content/en/fundamentals/accessibility/focus/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Overview of screen focus in accessibility
 
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Introduction to Focus {: .page-title }
@@ -133,3 +133,6 @@ used in the form are native HTML tags with implicit focus, the form works fine
 with the keyboard, and you don't have to write any code to add or manage focus
 behavior.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/focus/index.md
+++ b/src/content/en/fundamentals/accessibility/focus/index.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Overview of screen focus in accessibility
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/focus/using-tabindex.md
+++ b/src/content/en/fundamentals/accessibility/focus/using-tabindex.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Modifying the DOM order with tabindex
 
 
-{# wf_updated_on: 2018-03-19 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 {# wf_blink_components: N/A #}
 
@@ -419,3 +419,6 @@ code](https://github.com/udacity/ud891/blob/gh-pages/lesson2-focus/07-modals-and
 and view a live example from a [completed
 page](http://udacity.github.io/ud891/lesson2-focus/07-modals-and-keyboard-traps/solution/index.html){: .external }.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/how-to-review.md
+++ b/src/content/en/fundamentals/accessibility/how-to-review.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: How to review your site for accessibility issues.
 
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-03-12 #}
 {# wf_blink_components: Blink>Accessibility #}
 
@@ -293,3 +293,7 @@ your site. Remember, good accessibility equals good UX!
 - [Web Accessibility by Google](https://bit.ly/web-a11y)
 - [Accessibility Fundamentals](/web/fundamentals/accessibility/)
 - [A11ycasts](https://www.youtube.com/playlist?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g)
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/index.md
+++ b/src/content/en/fundamentals/accessibility/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Improving accessibility for web pages
 
 
-{# wf_updated_on: 2017-07-19 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-26 #}
 
 # Accessibility {: .page-title }
@@ -375,3 +375,6 @@ of creating accessible web sites. However, we'll give you enough information to
 get started, and point you to some good places where you can learn more about
 each topic.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/index.md
+++ b/src/content/en/fundamentals/accessibility/index.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Improving accessibility for web pages
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-26 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Using ARIA labels to create accessible element descriptions
 
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # ARIA Labels and Relationships {: .page-title }
@@ -140,3 +140,7 @@ use dynamic HTML techniques to ensure that the user can explore the full list on
 demand.
 
 ![using aria-posinset and aria-setsize to establish a relationship in a list](imgs/aria-posinset.jpg)
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Using ARIA labels to create accessible element descriptions
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-aria/hiding-and-updating-content.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/hiding-and-updating-content.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Hiding content from assistive technology
 
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Hiding and Updating Content {: .page-title }
@@ -160,3 +160,6 @@ temporarily ignore changes to an element, such as when things are loading. Once
 everything is in place, `aria-busy` should be set to false to normalize the
 reader's operation.
  
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/semantics-aria/hiding-and-updating-content.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/hiding-and-updating-content.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Hiding content from assistive technology
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-aria/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Introduction to ARIA and non-native HTML semantics
 
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Introduction to ARIA {: .page-title }
@@ -159,3 +159,6 @@ the [Landmark Roles Design
 Patterns](https://www.w3.org/TR/wai-aria-practices-1.1#kbd_layout_landmark_XHTML){: .external }
 spec for more information.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/semantics-aria/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/index.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Introduction to ARIA and non-native HTML semantics
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/index.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Introduction to semantics and assistive technology
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Introduction to semantics and assistive technology
 
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Introduction to Semantics {: .page-title }
@@ -170,3 +170,7 @@ this.
 
 ![a screen reader uses the DOM to create accessible
 nodes](imgs/nativecodetoacc.png)
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/navigating-content.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/navigating-content.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: The role of semantics in page navigation
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/navigating-content.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/navigating-content.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: The role of semantics in page navigation
 
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Semantics and Navigating Content {: .page-title }
@@ -156,4 +156,6 @@ Semantic structural elements replace multiple, repetitive `div` blocks, and
 provide a clearer, more descriptive way to intuitively express page structure
 for both authors and readers.
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/text-alternatives-for-images.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/text-alternatives-for-images.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Using the alt attribute to provide text alternatives for images
 
 
-{# wf_updated_on: 2018-04-06 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 {# wf_blink_components: N/A #}
 
@@ -89,3 +89,7 @@ To summarize, all images should have an `alt` attribute, but they need not all
 have text. Important images should have descriptive alt text that succinctly
 describes what the image is, while decorative images should have empty alt
 attributes &mdash; that is, `alt=""`.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Introduction to the Accessibility Tree
 
 
+{# wf_blink_components: Blink>Accessibility #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 

--- a/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Introduction to the Accessibility Tree
 
 
-{# wf_updated_on: 2016-10-04 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-04 #}
 
 # The Accessibility Tree {: .page-title }
@@ -187,4 +187,6 @@ Success: You can actually use the screen reader to find improperly-associated
 labels by tabbing through the page and verifying the spoken roles, states, and
 names.
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/architecture/app-shell.md
+++ b/src/content/en/fundamentals/architecture/app-shell.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Application shell architecture keeps your UI local and loads content dynamically without sacrificing the linkability and discoverability of the web. 
 
-{# wf_updated_on: 2018-07-20 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-09-27 #}
 {# wf_blink_components: N/A #}
 
@@ -285,3 +285,6 @@ offline and populate its content using JavaScript.
 On repeat visits, this allows you to get meaningful pixels on the screen without
 the network, even if your content eventually comes from there.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/animating-between-views.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animating-between-views.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to animate between two views in your apps.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/animating-between-views.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animating-between-views.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to animate between two views in your apps.
 
-{# wf_updated_on: 2016-08-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Animating Between Views {: .page-title }
@@ -145,4 +145,6 @@ For a larger screen, you should keep the list view around all the time rather th
 
 
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/animating-modal-views.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animating-modal-views.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to animate modal views in your apps.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/animating-modal-views.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animating-modal-views.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to animate modal views in your apps.
 
-{# wf_updated_on: 2016-08-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Animating Modal Views {: .page-title }
@@ -104,4 +104,6 @@ The duration is pretty short, though, but it's ideal for when the user dismisses
 Now the modal view takes 0.3 seconds to come onto the screen, which is a bit less aggressive, but it is dismissed quickly, which the user will appreciate.
 
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/animations-and-performance.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animations-and-performance.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Animations must perform well, otherwise they will negatively impact the user experience.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/animations-and-performance.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animations-and-performance.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Animations must perform well, otherwise they will negatively impact the user experience.
 
-{# wf_updated_on: 2016-08-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Animations and Performance {: .page-title }
@@ -51,4 +51,6 @@ There are many pages and comments threads around the web that discuss the relati
 
 For more information about which work is triggered by animating a given property, see [CSS Triggers](http://csstriggers.com).
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/asymmetric-animation-timing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/asymmetric-animation-timing.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Breaking symmetry provides contrast and appeal to your projects. Learn when and how to apply this to your projects.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/asymmetric-animation-timing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/asymmetric-animation-timing.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Breaking symmetry provides contrast and appeal to your projects. Learn when and how to apply this to your projects.
 
-{# wf_updated_on: 2014-10-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Asymmetric animation timing {: .page-title }
@@ -26,3 +26,7 @@ The general rule of thumb, then, is the following:
 
 * For UI animations triggered by a user’s interaction, such as view transitions or showing an element, have a fast intro (short duration), but a slow outro (longer duration).
 * For UI animations triggered by your code, such as errors or modal views, have a slower intro (longer duration), but a fast outro (short duration).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/choosing-the-right-easing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/choosing-the-right-easing.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Choose the appropriate easing for your project, whether that's easing in, out, or both. Maybe even use bounces for extra fun!
 
-{# wf_updated_on: 2016-08-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Choosing the Right Easing {: .page-title }
@@ -39,4 +39,6 @@ It is important that any animation added to your project has the correct duratio
 
 Of course, these are just guidelines. Experiment with your own eases and choose what feels right for your projects.
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/choosing-the-right-easing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/choosing-the-right-easing.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Choose the appropriate easing for your project, whether that's easing in, out, or both. Maybe even use bounces for extra fun!
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/css-vs-javascript.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/css-vs-javascript.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: You can animate with CSS or JavaScript. Which should you use, and why?
 
-{# wf_updated_on: 2016-08-25 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # CSS Versus JavaScript Animations {: .page-title }
@@ -158,3 +158,7 @@ By default, Web Animations only modify the presentation of an element. If you'd 
 The Web Animations API is a new standard from the W3C. It is supported natively in Chrome and Opera, and is in [active development for Firefox](https://birtles.github.io/areweanimatedyet/){: .external }. For other modern browsers, [a polyfill is available](https://github.com/web-animations/web-animations-js).
 
 With JavaScript animations, you're in total control of an element's styles at every step. This means you can slow down animations, pause them, stop them, reverse them, and manipulate elements as you see fit. This is especially useful if you're building complex, object-oriented applications, because you can properly encapsulate your behavior.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/css-vs-javascript.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/css-vs-javascript.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: You can animate with CSS or JavaScript. Which should you use, and why?
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/custom-easing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/custom-easing.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Go offroad and create totally custom animations for your projects.
 
-{# wf_updated_on: 2016-08-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Custom Easing {: .page-title }
@@ -82,4 +82,6 @@ After the script is in place, you can call TweenMax against your element and tel
 The [TweenMax documentation](https://greensock.com/docs/#/HTML5/GSAP/TweenMax/) highlights all the options you have here, so it's well worth a read.
 
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/custom-easing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/custom-easing.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Go offroad and create totally custom animations for your projects.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/index.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/index.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Get a better understanding of animations and their use in modern apps and sites.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/animations/index.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Get a better understanding of animations and their use in modern apps and sites.
 
-{# wf_updated_on: 2016-08-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Animations {: .page-title }
@@ -33,3 +33,7 @@ The only thing worse than animations that are poorly placed are those that cause
 Some properties are more expensive to change than others, and are therefore more likely to make things stutter. So, for example, changing the `box-shadow` of an element requires a much more expensive paint operation than changing, say, its text color. Similarly, changing the `width` of an element is likely to be more expensive than changing its `transform`.
 
 You can read more about the performance considerations of animations in the [Animations and Performance](animations-and-performance) guide, but if you want the TL;DR, stick to transforms and opacity changes, and use `will-change`. If you want to know exactly which work is triggered by animating a given property, see [CSS Triggers](http://csstriggers.com).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/the-basics-of-easing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/the-basics-of-easing.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to soften and give weighting to your animations.
 
-{# wf_updated_on: 2016-08-23 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 
 # The Basics of Easing {: .page-title }
@@ -129,4 +129,6 @@ To get an ease-in-out animation, you can use the `ease-in-out` CSS keyword:
     transition: transform 500ms ease-in-out;
     
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/animations/the-basics-of-easing.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/the-basics-of-easing.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to soften and give weighting to your animations.
 
+{# wf_blink_components: Blink>Animation #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-08 #}
 

--- a/src/content/en/fundamentals/design-and-ux/browser-customization/index.md
+++ b/src/content/en/fundamentals/design-and-ux/browser-customization/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Modern browsers make it easy to customize certain components, like icons, the address bar color, and even add things like custom tiles. These simple tweaks can increase engagement and bring users back to your site.
 
 
-{# wf_updated_on: 2015-09-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-09-21 #}
 
 # Icons & Browser Colors {: .page-title }
@@ -147,4 +147,6 @@ more height, but obstructs the top.  Here’s the code required:
 
 <div style="clear:both;"></div>
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/browser-customization/index.md
+++ b/src/content/en/fundamentals/design-and-ux/browser-customization/index.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Modern browsers make it easy to customize certain components, like icons, the address bar color, and even add things like custom tiles. These simple tweaks can increase engagement and bring users back to your site.
 
 
+{# wf_blink_components: N/A #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-09-21 #}
 

--- a/src/content/en/fundamentals/design-and-ux/input/forms/index.md
+++ b/src/content/en/fundamentals/design-and-ux/input/forms/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Forms are hard to fill out on mobile. The best forms are the ones with the fewest inputs.
 
-{# wf_updated_on: 2018-08-05 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-30 #}
 {# wf_blink_components: N/A #}
 
@@ -795,3 +795,6 @@ JavaScript to only show invalid styling when the user has visited the field.
 
 Success: You should show the user all of the issues on the form at once, rather than showing them one at a time.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/input/touch/index.md
+++ b/src/content/en/fundamentals/design-and-ux/input/touch/index.md
@@ -4,6 +4,7 @@ description: Touchscreens are available on more and more devices,  from phones u
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-01-01 #}
+{# wf_blink_components: Blink>Input #}
 
 # Add Touch to Your Site {: .page-title }
 

--- a/src/content/en/fundamentals/design-and-ux/input/touch/index.md
+++ b/src/content/en/fundamentals/design-and-ux/input/touch/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Touchscreens are available on more and more devices,  from phones up to desktop screens. Your app should respond to their touch  in intuitive and beautiful ways.
 
-{# wf_updated_on: 2014-01-06 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-01-01 #}
 
 # Add Touch to Your Site {: .page-title }
@@ -621,3 +621,7 @@ elements in the page, alleviating some of the performance concerns.
         }
       }
     };
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/principles/index.md
+++ b/src/content/en/fundamentals/design-and-ux/principles/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Google and AnswerLab undertook a study examining how users interact with a diverse set of mobile sites. The goal was to answer the question, 'What makes a good mobile site?'
 
 {# wf_published_on: 2014-08-08 #}
-{# wf_updated_on: 2018-08-05 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: N/A #}
 
 # What Makes a Good Mobile Site? {: .page-title }
@@ -473,3 +473,7 @@ populate them through a clear call-to-action like “Find Near Me”.
 </div>
 
 <div style="clear:both;"></div>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/responsive/content.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/content.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Consider content as well as layout and graphic design when building for a range of users and devices.
 
+{# wf_blink_components: N/A #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-05-10 #}
 

--- a/src/content/en/fundamentals/design-and-ux/responsive/content.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/content.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Consider content as well as layout and graphic design when building for a range of users and devices.
 
-{# wf_updated_on: 2016-05-10 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-05-10 #}
 
 # Multi-Device Content {: .page-title }
@@ -254,3 +254,7 @@ Bear in mind that this doesn't take into account affordability relative to incom
 Page weight isn't just a problem for emerging markets. In many countries, people use mobile plans with limited data, and will avoid your site or app if they perceive it to be heavy and expensive. Even "unlimited" cell and wifi data plans generally have a data limit beyond which they are blocked or throttled.
 
 The bottom line: page weight affects performance and costs money. [Optimizing content efficiency](/web/fundamentals/performance/optimizing-content-efficiency/) shows how to reduce that cost.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/responsive/images.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/images.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: A picture is worth 1000 words, and images play an integral part of every page. But they also often account for most of the downloaded bytes.  With responsive web design not only can our layouts change based on device characteristics, but images as well.
 
-{# wf_updated_on: 2018-07-02 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-29 #}
 
 # Images {: .page-title }
@@ -866,3 +866,7 @@ ipsum lectus, hendrerit malesuada sapien eget, venenatis tempus purus.
 Keep in mind that using these techniques does require rendering cycles, which
 can be significant on mobile.  If over-used, you'll lose any benefit you may
 have gained and it may hinder performance.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/responsive/images.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/images.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: A picture is worth 1000 words, and images play an integral part of every page. But they also often account for most of the downloaded bytes.  With responsive web design not only can our layouts change based on device characteristics, but images as well.
 
 {# wf_updated_on: 2018-09-20 #}
+{# wf_blink_components: Blink>Image #}
 {# wf_published_on: 2014-04-29 #}
 
 # Images {: .page-title }

--- a/src/content/en/fundamentals/design-and-ux/responsive/index.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/index.md
@@ -4,6 +4,7 @@ description: Much of the web isn't optimized for those multi-device experiences.
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-29 #}
+{# wf_blink_components: Blink>CSS #}
 
 # Responsive Web Design Basics {: .page-title }
 

--- a/src/content/en/fundamentals/design-and-ux/responsive/index.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Much of the web isn't optimized for those multi-device experiences. Learn the fundamentals to get your site working on mobile, desktop, or anything else with a screen.
 
-{# wf_updated_on: 2014-04-29 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-29 #}
 
 # Responsive Web Design Basics {: .page-title }
@@ -510,3 +510,7 @@ query is active. Right-click on a bar to jump to the media query's
 definition. See 
 [Media queries](/web/tools/chrome-devtools/device-mode/emulate-mobile-viewports#media-queries)
 for more help.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/responsive/patterns.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/patterns.md
@@ -4,6 +4,7 @@ description: Responsive web design patterns are quickly evolving, but there are 
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-29 #}
+{# wf_blink_components: Blink>CSS #}
 
 # Responsive Web Design Patterns {: .page-title }
 

--- a/src/content/en/fundamentals/design-and-ux/responsive/patterns.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/patterns.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Responsive web design patterns are quickly evolving, but there are a handful of established patterns that work well across the desktop and mobile devices
 
-{# wf_updated_on: 2014-10-20 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-29 #}
 
 # Responsive Web Design Patterns {: .page-title }
@@ -163,3 +163,7 @@ Sites using this pattern include:
 <pre class="prettyprint">
 {% includecode content_path="web/fundamentals/design-and-ux/responsive/_code/off-canvas.html" region_tag="ocanvas" adjust_indentation="auto" %}
 </pre>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/typography/variable-fonts/index.md
+++ b/src/content/en/fundamentals/design-and-ux/typography/variable-fonts/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: We will look at what variable fonts are, how we can use them in our work.
 
-{# wf_updated_on: 2018-03-01 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2018-02-19 #}
 {# wf_blink_components: Blink>Fonts #}
 
@@ -347,3 +347,7 @@ people:
 * Laurence Penney, developer of [axis-praxis.org](https://axis-praxis.org){: .external}
 * [Mandy Michael](https://twitter.com/Mandy_Kerr){: .external}
 * Dave Crossland, Program Manager, Google Fonts
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/design-and-ux/ux-basics/index.md
+++ b/src/content/en/fundamentals/design-and-ux/ux-basics/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: A step-by-step guide to the basics of UX design.
 
-{# wf_updated_on: 2018-07-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-01 #}
 {# wf_blink_components: N/A #}
 
@@ -378,3 +378,7 @@ This article should now give you a basic grounding in UX and its importance. UX
 isn’t something that should be looked upon as a role for a designer or
 researcher. It is actually the responsibility of everyone involved in a project
 so I would recommend involvement at every opportunity.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/discovery/search-optimization/index.md
+++ b/src/content/en/fundamentals/discovery/search-optimization/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Websites are visited not only by humans, but also by search engine web crawlers. Learn how to improve search accuracy and ranking for your website.
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-30 #}
 
 # Search Optimization {: .page-title }
@@ -356,3 +356,6 @@ Check out concrete steps at the respective search engine's help pages:
 * [Bing](http://www.bing.com/webmaster/help/which-crawlers-does-bing-use-8c184ec0)
 * [Yandex](https://help.yandex.com/search/robots/logs.xml)
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/discovery/search-optimization/index.md
+++ b/src/content/en/fundamentals/discovery/search-optimization/index.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Websites are visited not only by humans, but also by search engine web crawlers. Learn how to improve search accuracy and ranking for your website.
 
+{# wf_blink_components: N/A #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-08-30 #}
 

--- a/src/content/en/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/en/fundamentals/discovery/social-discovery/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: You can influence the way your site appears when shared via social media by adding a few lines of code to each page. This can help bring more people to your site by providing previews with richer information than would otherwise be available.
 
-{# wf_updated_on: 2017-10-31 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-10-07 #}
 
 # Social Discovery {: .page-title }
@@ -227,3 +227,6 @@ reusing `meta` tag with `property="og:image"`
 Lastly, make sure to validate that your web page appears as expected on each
 social site before publishing.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/en/fundamentals/discovery/social-discovery/index.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: You can influence the way your site appears when shared via social media by adding a few lines of code to each page. This can help bring more people to your site by providing previews with richer information than would otherwise be available.
 
+{# wf_blink_components: N/A #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-10-07 #}
 

--- a/src/content/en/fundamentals/instant-and-offline/offline-cookbook/index.md
+++ b/src/content/en/fundamentals/instant-and-offline/offline-cookbook/index.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-09-12 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-12-09 #}
 {# wf_blink_components: N/A #}
 
@@ -729,3 +729,7 @@ before I hit "publish".
 [is_sw_ready]: https://jakearchibald.github.io/isserviceworkerready/
 [sw_primer]: /web/fundamentals/getting-started/primers/service-workers
 [caches_api]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/instant-and-offline/offline-ux.md
+++ b/src/content/en/fundamentals/instant-and-offline/offline-ux.md
@@ -4,6 +4,7 @@ description: A guide to designing web experiences for slow networks and offline.
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-11-10 #}
+{# wf_blink_components: N/A #}
 
 # Offline UX Considerations {: .page-title }
 

--- a/src/content/en/fundamentals/instant-and-offline/offline-ux.md
+++ b/src/content/en/fundamentals/instant-and-offline/offline-ux.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: A guide to designing web experiences for slow networks and offline.
 
-{# wf_updated_on: 2018-09-16 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-11-10 #}
 
 # Offline UX Considerations {: .page-title }
@@ -445,3 +445,7 @@ When designing for unstable network connections, use these:
 * Utilize language, icons, imagery, typography and color to express ideas to the 
   user collectively.
 * Provide reassurance and feedback to help the user.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/instant-and-offline/web-storage/cache-api.md
+++ b/src/content/en/fundamentals/instant-and-offline/web-storage/cache-api.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to use the Cache API to make your application data available offline
 
-{# wf_updated_on: 2017-10-11 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-10-03 #}
 {# wf_blink_components: Blink>Storage>CacheStorage #}
 
@@ -249,3 +249,6 @@ Where request can be a `Request` or a URL string. This method also takes the sam
 To delete a cache, call `caches.delete(name)`. This function returns a `Promise` that resolves to
 `true` if the cache existed and was deleted, or `false` otherwise.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/instant-and-offline/web-storage/index.md
+++ b/src/content/en/fundamentals/instant-and-offline/web-storage/index.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-10-04 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-09-28 #}
 {# wf_blink_components: Blink>Storage #}
 
@@ -232,3 +232,7 @@ of interest:
 
 * [Offline Storage Recommendations for Progressive Web Apps](offline-for-pwa)
 * [Deep Dive: Cache API](cache-api)
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/instant-and-offline/web-storage/indexeddb-best-practices.md
+++ b/src/content/en/fundamentals/instant-and-offline/web-storage/indexeddb-best-practices.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn best practices for syncing application state between IndexedDB an popular state management libraries.
 
-{# wf_updated_on: 2017-10-03 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-08 #}
 {# wf_tags: javascript,indexeddb #}
 {# wf_blink_components: Blink>Storage>IndexedDB #}
@@ -200,3 +200,7 @@ unhappy users.
 Since client storage involves many factors outside of your control, it's
 critical your code is well tested and properly handles errors, even those that
 may initially seem unlikely to occur.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/instant-and-offline/web-storage/offline-for-pwa.md
+++ b/src/content/en/fundamentals/instant-and-offline/web-storage/offline-for-pwa.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to store data locally for improved response time and offline support.
 
-{# wf_updated_on: 2018-09-04 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-09-29 #}
 {# wf_blink_components: Blink>Storage #}
 
@@ -309,3 +309,7 @@ synchronization)
 [BlinkOn talk](https://docs.google.com/presentation/d/11CJnf77N45qPFAhASwnfRNeEMJfR-E_x05v1Z6Rh5HA/edit)
 heavily inspired this article), Jake Archibald, Dru Knox and others for their
 previous work in the web storage space.**
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/integration/webapks.md
+++ b/src/content/en/fundamentals/integration/webapks.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: When the user adds your Progressive Web App to their home screen on Android, Chrome automatically generates an APK for you, which we sometimes call a WebAPK. Being installed via an APK makes it possible for your app to show up in the app launcher, in Android's app settings and to register a set of intent filters.
 
-{# wf_updated_on: 2018-05-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-05-21 #}
 {# wf_blink_components: Mobile>WebAPKs #}
 {# wf_previous_url: /web/updates/2017/02/improved-add-to-home-screen #}
@@ -234,3 +234,6 @@ to delete site data.
 
 </dl>
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/capturing-images/index.md
+++ b/src/content/en/fundamentals/media/capturing-images/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Most browsers can get access to the user's camera.
 
-{# wf_updated_on: 2017-08-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-08-23 #}
 {# wf_blink_components: Blink>ImageCapture #}
 
@@ -351,3 +351,7 @@ More information about mobile and desktop browser implementation:
 
 We also recommend using the [adapter.js](https://github.com/webrtc/adapter) shim to protect apps
 from WebRTC spec changes and prefix differences.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/eme.md
+++ b/src/content/en/fundamentals/media/eme.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Enabling HTTPS on your servers is critical to securing your webpages.
 
-{# wf_updated_on: 2018-03-20 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-01-16 #}
 {# wf_blink_components: Blink>Media #}
 
@@ -551,3 +551,7 @@ Clear Key demo: [simpl.info/ck](http://simpl.info/eme/clearkey)
 [Media Source Extensions (MSE) demo](http://simpl.info/mse)
 Google's [Shaka Player](https://github.com/google/shaka-player)
 implements a DASH client with EME support
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/fast-playback-with-video-preload.md
+++ b/src/content/en/fundamentals/media/fast-playback-with-video-preload.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Preload video and audio for faster playback.
 
 {# wf_published_on: 2017-08-17 #}
-{# wf_updated_on: 2018-03-20 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Media #}
 
 # Fast Playback with Video Preload {: .page-title }
@@ -591,3 +591,7 @@ requests.
 [Delivering Fast and Light Applications with Save-Data]: /web/updates/2016/02/save-data
 [Network Information sample]: https://googlechrome.github.io/samples/network-information/
 [in Chrome]: https://github.com/whatwg/fetch/issues/569
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/manipulating/applications.md
+++ b/src/content/en/fundamentals/media/manipulating/applications.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Much media work requires changing characteristics of media files. In this section, I intend to provide an easy onramp into that world.
 
-{# wf_updated_on: 2017-07-25 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-09 #}
 
 # Application Primers {: .page-title }
@@ -200,3 +200,7 @@ So that's a few bits about media manipulation software in a nutshell. Now jump
 next door to the
 [cheat sheet](cheatsheet). Check back every few weeks as we continue to add new
 content about media for the web.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/manipulating/applications.md
+++ b/src/content/en/fundamentals/media/manipulating/applications.md
@@ -4,6 +4,7 @@ description: Much media work requires changing characteristics of media files. I
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-09 #}
+{# wf_blink_components: Blink>Media #}
 
 # Application Primers {: .page-title }
 

--- a/src/content/en/fundamentals/media/manipulating/cheatsheet.md
+++ b/src/content/en/fundamentals/media/manipulating/cheatsheet.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: A summary of commands used to convert a raw mov file to an encrypted full HD file for web playback.
 
-{# wf_updated_on: 2018-07-02 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-09 #}
 
 # Media Manipulation Cheat Sheet  {: .page-title }
@@ -341,3 +341,7 @@ ffmpeg when I need to.
     ```  --hls_base_url="http://localhost:1000/" \```<br/>
     ```  --enable_fixed_key_encryption --enable_fixed_key_decryption \```<br/>
     ```  -key INSERT_KEY_HERE -key_id INSERT_KEY_ID_HERE \```<br/>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/manipulating/cheatsheet.md
+++ b/src/content/en/fundamentals/media/manipulating/cheatsheet.md
@@ -4,6 +4,7 @@ description: A summary of commands used to convert a raw mov file to an encrypte
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-09 #}
+{# wf_blink_components: Blink>Media #}
 
 # Media Manipulation Cheat Sheet  {: .page-title }
 

--- a/src/content/en/fundamentals/media/manipulating/files.md
+++ b/src/content/en/fundamentals/media/manipulating/files.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Let's take a raw video file off a camera and transform it into an encrypted resource that you can play back using a video library such as Google's Shaka Player on a mobile device.
 
-{# wf_updated_on: 2017-08-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-30 #}
 
 # From Raw Video to Web Ready {: .page-title }
@@ -359,3 +359,7 @@ This does not cover everything you could do to a media file before posting it to
 the web, not by a longshot. To be fair, this subject is one deserving of its own
 website. I'm hoping this introduction will give you enough to help you find your
 own answers to questions.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/manipulating/files.md
+++ b/src/content/en/fundamentals/media/manipulating/files.md
@@ -4,6 +4,7 @@ description: Let's take a raw video file off a camera and transform it into an e
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-30 #}
+{# wf_blink_components: Blink>Media #}
 
 # From Raw Video to Web Ready {: .page-title }
 

--- a/src/content/en/fundamentals/media/manipulating/live-effects.md
+++ b/src/content/en/fundamentals/media/manipulating/live-effects.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Many of today's most popular apps let you apply filters and effects to images or video. This article shows how to implement these features on the open web.
 
-{# wf_updated_on: 2017-08-08 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-08-08 #}
 {# wf_blink_components: Blink>WebGL, Blink>Canvas #}
 
@@ -399,3 +399,7 @@ applied. When animated, however, delays of only 16ms can cause visible jerkiness
   kernels with interactive demos.
 - [Transformations](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Transformations):
   MDN article about 2D canvas transformations
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/mobile-web-video-playback.md
+++ b/src/content/en/fundamentals/media/mobile-web-video-playback.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Create the best mobile media experience on the Web by following these best practises.
 
 {# wf_published_on: 2017-04-07 #}
-{# wf_updated_on: 2017-07-25 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Media #}
 
 # Mobile Web Video Playback {: .page-title }
@@ -647,3 +647,7 @@ shows up on lock screens.
 [Page Visibility API]: https://www.w3.org/TR/page-visibility/
 [Intersection Observer API]: /web/updates/2016/04/intersectionobserver
 [Media Session API]: /web/updates/2017/02/media-session
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/mse/basics.md
+++ b/src/content/en/fundamentals/media/mse/basics.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Media Source Extensions (MSE) is a JavaScript API that lets you build streams for playback from segments of audio or video.
 
 {# wf_published_on: 2017-02-08 #}
-{# wf_updated_on: 2018-03-20 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Internals>Media #}
 
 # Media Source Extensions {: .page-title }
@@ -365,3 +365,7 @@ Source Extensions.
           sourceBuffer.appendBuffer(arrayBuffer);
         });
     }
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/mse/seamless-playback.md
+++ b/src/content/en/fundamentals/media/mse/seamless-playback.md
@@ -5,6 +5,7 @@ description: Media Source Extensions (MSE) provide extended buffering and playba
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-06-11 #}
 {# wf_tags: news,audio,codecs,mse #}
+{# wf_blink_components: Blink>Media #}
 
 # Media Source Extensions for Audio {: .page-title }
 

--- a/src/content/en/fundamentals/media/mse/seamless-playback.md
+++ b/src/content/en/fundamentals/media/mse/seamless-playback.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Media Source Extensions (MSE) provide extended buffering and playback control for the HTML5 audio and video elements. While originally developed to facilitate Dynamic Adaptive Streaming over HTTP (DASH) based video players, MSE can be used for audio; specifically for gapless playback.
 
-{# wf_updated_on: 2017-04-07 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-06-11 #}
 {# wf_tags: news,audio,codecs,mse #}
 
@@ -517,3 +517,7 @@ representative of mobile devices.
 Garbage collection only impacts data added to `SourceBuffers`; there are no
 limits on how much data you can keep buffered in JavaScript variables. You may
 also reappend the same data in the same position if necessary.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/recording-audio/index.md
+++ b/src/content/en/fundamentals/media/recording-audio/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Most browsers can get access to the user's microphone.
 
-{# wf_updated_on: 2017-09-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-08-23 #}
 {# wf_blink_components: Blink>GetUserMedia #}
 
@@ -263,3 +263,7 @@ interface to accommodate the actions that the user needs to take.
 
       };
     });
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/recording-video/index.md
+++ b/src/content/en/fundamentals/media/recording-video/index.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Most browsers can get access to the user's camera.
 
-{# wf_updated_on: 2017-09-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-09-24 #}
 {# wf_blink_components: Blink>GetUserMedia #}
 
@@ -247,3 +247,7 @@ interface to accommodate the actions that the user needs to take.
 
       };
     });
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/media/video.md
+++ b/src/content/en/fundamentals/media/video.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn about the simplest ways to add video to your site and ensure users get the best possible experience on any device.
 
-{# wf_updated_on: 2017-06-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-04-15 #}
 {# wf_blink_components: Blink>Media #}
 
@@ -754,4 +754,6 @@ page on the Mozilla Developer Network for a complete listing.
   </tbody>
 </table>
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/native-hardware/click-to-call/index.md
+++ b/src/content/en/fundamentals/native-hardware/click-to-call/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: On devices with phone capabilities, make it easy for users to directly connect with you by simply tapping a phone number, more commonly known as click to call.
 
-{# wf_updated_on: 2016-08-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-06-17 #}
 
 # Click to Call {: .page-title }
@@ -84,3 +84,7 @@ following meta tag to the top of the page:
 In addition to the `tel:` schema, some modern browsers also support the `sms:`
 and `mms:` schemas, though support is not as consistent, and some
 features like setting the message body don't always work. 
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/native-hardware/click-to-call/index.md
+++ b/src/content/en/fundamentals/native-hardware/click-to-call/index.md
@@ -4,6 +4,7 @@ description: On devices with phone capabilities, make it easy for users to direc
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-06-17 #}
+{# wf_blink_components: Blink>Input #}
 
 # Click to Call {: .page-title }
 

--- a/src/content/en/fundamentals/native-hardware/device-orientation/index.md
+++ b/src/content/en/fundamentals/native-hardware/device-orientation/index.md
@@ -4,6 +4,7 @@ description: Device motion and orientation events provide access to the built-in
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-06-17 #}
+{# wf_blink_components: Blink>Sensor>DeviceOrientation #}
 
 # Device Orientation & Motion {: .page-title }
 

--- a/src/content/en/fundamentals/native-hardware/device-orientation/index.md
+++ b/src/content/en/fundamentals/native-hardware/device-orientation/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Device motion and orientation events provide access to the built-in accelerometer, gyroscope, and compass in mobile devices.
 
-{# wf_updated_on: 2016-08-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-06-17 #}
 
 # Device Orientation & Motion {: .page-title }
@@ -332,3 +332,7 @@ jumping?
 After tapping the Go! button, the user is told to jump. During that time,
 the page stores the maximum (and minimum) acceleration values, and after the
 jump, tells the user their maximum acceleration.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/native-hardware/fullscreen/index.md
+++ b/src/content/en/fundamentals/native-hardware/fullscreen/index.md
@@ -4,6 +4,7 @@ description: Going fullscreen.
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-01 #}
+{# wf_blink_components: Blink>Fullscreen #}
 
 # Making Fullscreen Experiences {: .page-title }
 

--- a/src/content/en/fundamentals/native-hardware/fullscreen/index.md
+++ b/src/content/en/fundamentals/native-hardware/fullscreen/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Going fullscreen.
 
-{# wf_updated_on: 2017-10-06 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-10-01 #}
 
 # Making Fullscreen Experiences {: .page-title }
@@ -502,3 +502,7 @@ be considerate to the user.
 While we don't have a fully standardized and implemented API, using some of the
 guidance presented in this article you can easily build experiences that take
 advantage of the user's entire screen, irrespective of the client.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/native-hardware/user-location/index.md
+++ b/src/content/en/fundamentals/native-hardware/user-location/index.md
@@ -4,6 +4,7 @@ description: Most browsers and devices have access to the user's geographic loca
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-01-01 #}
+{# wf_blink_components: Blink>Location #}
 
 # User Location {: .page-title }
 

--- a/src/content/en/fundamentals/native-hardware/user-location/index.md
+++ b/src/content/en/fundamentals/native-hardware/user-location/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Most browsers and devices have access to the user's geographic location. Learn how to work with the user's location in your site and apps.
 
-{# wf_updated_on: 2016-08-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2014-01-01 #}
 
 # User Location {: .page-title }
@@ -420,3 +420,7 @@ and click the **Sensors** option to show the Sensors Drawer.
 From here you can override the location to a preset major city,
 enter a custom location, or disable geolocation by setting the override
 to **Location unavailable**.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/basics/how-payment-ecosyste-works.md
+++ b/src/content/en/fundamentals/payments/basics/how-payment-ecosyste-works.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: About the Ecosystem page for the W3C Payment APIs doc set.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2018-09-19 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # How the payment ecosystem works {: .page-title }
@@ -170,3 +170,6 @@ but is not listed here.
 Learn about the Payment Request API's fields and methods in [How the Payment Request API 
 Works](/web/fundamentals/payments/basics/how-payment-request-api-works).
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/basics/how-payment-request-api-works.md
+++ b/src/content/en/fundamentals/payments/basics/how-payment-request-api-works.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Payment Request API page for the W3C Payment APIs doc set.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2018-09-11 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # How Payment Request API Works {: .page-title }
@@ -169,3 +169,7 @@ Methods](/web/fundamentals/payments/basics/payment-method-basics).
 To learn more about the Payment Request API itself, checkout [Deep Dive into the
 Payment Request
 API](/web/fundamentals/payments/merchant-guide/deep-dive-into-payment-request).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/basics/payment-method-basics.md
+++ b/src/content/en/fundamentals/payments/basics/payment-method-basics.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Payment Methods page for the W3C Payment APIs doc set.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2018-09-19 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Payment Method Basics {: .page-title }
@@ -157,3 +157,7 @@ guide](/web/fundamentals/payments/payment-apps-developer-guide/android-payment-a
 or [web based payment apps developer
 guide](/web/fundamentals/payments/payment-apps-developer-guide/web-payment-apps)
 to learn how to implement them.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/index.md
+++ b/src/content/en/fundamentals/payments/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Overview page to the W3C Payment APIs doc set.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2018-09-19 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # W3C Payment APIs {: .page-title }
@@ -99,3 +99,7 @@ app](/web/fundamentals/payments/payment-apps-developer-guide/android-payment-app
 or [web-based payment
 app](/web/fundamentals/payments/payment-apps-developer-guide/web-payment-apps)
 by reading respective section.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/merchant-guide/deep-dive-into-payment-request.md
+++ b/src/content/en/fundamentals/payments/merchant-guide/deep-dive-into-payment-request.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: How to implement and take full advantage of the Payment Request API.
 
 {# wf_published_on: 2017-04-21 #}
-{# wf_updated_on: 2018-08-16 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Deep Dive into the Payment Request API {: .page-title }
@@ -1757,3 +1757,7 @@ releases of Chrome.
 
 We also provide a 
 [PaymentRequest wrapper for Apple Pay JS](https://github.com/GoogleChrome/appr-wrapper).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/merchant-guide/payment-request-ux-considerations.md
+++ b/src/content/en/fundamentals/payments/merchant-guide/payment-request-ux-considerations.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-09-10 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-28 #}
 {# wf_blink_components: Blink>Payments #}
 
@@ -529,3 +529,6 @@ on [caniuse.com](https://caniuse.com/#search=payments).
 To create your own flows, you can download the Payment Request API 
 sticker sheet from [our GitHub Repo](https://goo.gl/daxhRa).
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/android-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/android-payment-apps.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: About the Ecosystem page for the Web Payments doc set.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2018-09-11 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Android payment apps developer guide {: .page-title }
@@ -704,3 +704,7 @@ in Android web browsers, because browsers cannot be expected to support every
 possible payment app SDK. Thus the method described here allows any Android
 payment app to work with any Android web browser, giving users more flexibility
 in making payments.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: About the Ecosystem page for the Web Payments doc set.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2018-09-11 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Web based payment apps developer guide {: .page-title }
@@ -641,3 +641,7 @@ act as a payment app by integration into a website that uses the Payment Request
 API. By implementing these related specifications, you can produce a clean,
 browser-based UI that makes user purchases as smooth and seamless as a native
 app.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/primers/service-workers/high-performance-loading.md
+++ b/src/content/en/fundamentals/primers/service-workers/high-performance-loading.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Ensure you're getting the best performance out of your service worker implementation.
 
-{# wf_updated_on: 2017-11-30 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-09-21 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -238,3 +238,7 @@ used by client-side code after the page has loaded. The
 "[Speed up Service Worker with Navigation Preloads](/web/updates/2017/02/navigation-preload)"
 article has all the details you'd need to configure your service worker
 accordingly.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/primers/service-workers/index.md
+++ b/src/content/en/fundamentals/primers/service-workers/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Rich offline experiences, periodic background syncs, push notifications&mdash;functionality that would normally require a native application&mdash;are coming to the web. Service workers provide the technical foundation that all these features rely on.
 
 {# wf_published_on: 2014-12-01 #}
-{# wf_updated_on: 2018-03-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
 # Service Workers: an Introduction {: .page-title }
@@ -488,3 +488,7 @@ that you may find useful.
 If you get stuck then please post your questions on StackOverflow and use the
 '[service-worker](http://stackoverflow.com/questions/tagged/service-worker)'
 tag so that we can keep a track of issues and try and help as much as possible.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/primers/service-workers/lifecycle.md
+++ b/src/content/en/fundamentals/primers/service-workers/lifecycle.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: A deep-dive into the service worker lifecycle.
 
-{# wf_updated_on: 2018-06-07 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-09-29 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -826,3 +826,7 @@ So, to enable as many patterns as we can, the whole update cycle is observable:
 
 Phew! That was a lot of technical theory. Stay tuned in the coming weeks where
 we'll dive into some practical applications of the above.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/primers/service-workers/registration.md
+++ b/src/content/en/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Best practices for timing your service worker registration.
 
-{# wf_updated_on: 2016-11-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-11-28 #}
 {# wf_blink_components: Blink>ServiceWorker #}
 
@@ -199,3 +199,7 @@ registration until after the first page has loaded is to use the following:
         navigator.serviceWorker.register('/service-worker.js');
       });
     }
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/common-issues-and-reporting-bugs.md
+++ b/src/content/en/fundamentals/push-notifications/common-issues-and-reporting-bugs.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: There are right ways of using notifications, and ways of using them better. Learn what makes a good notification. We won't just show you what to do. We'll show you how to do it.
 
-{# wf_updated_on: 2017-03-30 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-03-30 #}
 
 # Web Push: Common Issues and Reporting Bugs {: .page-title }
@@ -270,3 +270,7 @@ To provide a good bug report you should provide the following details:
 
 If you can provide a reproducible example, either source code or a hosted web
 site, it often speeds up diagnosing and solving the problem.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/common-issues-and-reporting-bugs.md
+++ b/src/content/en/fundamentals/push-notifications/common-issues-and-reporting-bugs.md
@@ -4,6 +4,7 @@ description: There are right ways of using notifications, and ways of using them
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-03-30 #}
+{# wf_blink_components: Blink>PushAPI #}
 
 # Web Push: Common Issues and Reporting Bugs {: .page-title }
 

--- a/src/content/en/fundamentals/push-notifications/common-notification-patterns.md
+++ b/src/content/en/fundamentals/push-notifications/common-notification-patterns.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
+{# wf_blink_components: Blink>PushAPI #}
 
 # Common Notification Patterns {: .page-title }
 

--- a/src/content/en/fundamentals/push-notifications/common-notification-patterns.md
+++ b/src/content/en/fundamentals/push-notifications/common-notification-patterns.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-03-03 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Common Notification Patterns {: .page-title }
@@ -372,3 +372,7 @@ you'll need before showing your notification.
 
 For more information check out this [introduction to service workers
 post](/web/fundamentals/getting-started/primers/service-workers).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/display-a-notification.md
+++ b/src/content/en/fundamentals/push-notifications/display-a-notification.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
+{# wf_blink_components: Blink>PushAPI #}
 
 # Displaying a Notification {: .page-title }
 

--- a/src/content/en/fundamentals/push-notifications/display-a-notification.md
+++ b/src/content/en/fundamentals/push-notifications/display-a-notification.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Displaying a Notification {: .page-title }
@@ -390,3 +390,7 @@ With this, we could change the notification we display to our users.
 
 With the other options, just do the same as above, replacing 'actions' with the desired
 parameter name.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/faq.md
+++ b/src/content/en/fundamentals/push-notifications/faq.md
@@ -3,6 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
+{# wf_blink_components: Blink>PushAPI #}
 
 # FAQ {: .page-title }
 

--- a/src/content/en/fundamentals/push-notifications/faq.md
+++ b/src/content/en/fundamentals/push-notifications/faq.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-03-03 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # FAQ {: .page-title }
@@ -148,3 +148,7 @@ This uses web push behind the scenes, but its goal is to abstract it away.
 Like I said in the previous question, if you consider web push as just a browser and push
 service, then you can consider the Messaging SDK in Firebase as a library to simplify
 implementing web push.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/handling-messages.md
+++ b/src/content/en/fundamentals/push-notifications/handling-messages.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-03-03 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Push Events {: .page-title }
@@ -178,3 +178,7 @@ Just remember - if you see that notification, check your promise chains and `eve
 
 In the next section we're going to look at what we can do to style notifications and
 what content we can display.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/handling-messages.md
+++ b/src/content/en/fundamentals/push-notifications/handling-messages.md
@@ -1,6 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/how-push-works.md
+++ b/src/content/en/fundamentals/push-notifications/how-push-works.md
@@ -1,6 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/how-push-works.md
+++ b/src/content/en/fundamentals/push-notifications/how-push-works.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # How Push Works {: .page-title }
@@ -156,3 +156,7 @@ can make analytics calls, cache pages offline and show notifications.
 receives a push event.](./images/svgs/push-service-to-sw-event.svg)
 
 That's the whole flow for push messaging. Lets go through each step in more detail.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/index.md
+++ b/src/content/en/fundamentals/push-notifications/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Push notifications are one of the most valuable capabilities of native apps, and this capability is now available on the web. To get the most out of them, notifications need to be timely, precise, and relevant.
 
-{# wf_updated_on: 2017-06-14 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Web Push Notifications: Timely, Relevant, and Precise {: .page-title }
@@ -88,3 +88,7 @@ and Mozilla's [Push Payload Demo](https://serviceworke.rs/push-payload_demo.html
 Note: Unless you're using localhost, the Push API requires HTTPS.
 
 <<../../_common-links.md>>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/index.md
+++ b/src/content/en/fundamentals/push-notifications/index.md
@@ -2,6 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Push notifications are one of the most valuable capabilities of native apps, and this capability is now available on the web. To get the most out of them, notifications need to be timely, precise, and relevant.
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/notification-behaviour.md
+++ b/src/content/en/fundamentals/push-notifications/notification-behaviour.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-07-26 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Notification Behaviour {: .page-title }
@@ -252,3 +252,7 @@ what they are doing to dismiss your notification can be frustrating.
 
 In the next section we are going to look at some of the common patterns used on the web for
 managing notifications and performing actions such as opening pages when a notification is clicked.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/notification-behaviour.md
+++ b/src/content/en/fundamentals/push-notifications/notification-behaviour.md
@@ -1,6 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/permission-ux.md
+++ b/src/content/en/fundamentals/push-notifications/permission-ux.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-03-03 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Permission UX {: .page-title }
@@ -177,3 +177,7 @@ offers no UI for disabling push notifications is astounding.
 
 Your site should explain to your users how they can disable push. If you don't, users are
 likely to take the nuclear option and block permission permanently.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/permission-ux.md
+++ b/src/content/en/fundamentals/push-notifications/permission-ux.md
@@ -1,6 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/sending-messages-with-web-push-libraries.md
+++ b/src/content/en/fundamentals/push-notifications/sending-messages-with-web-push-libraries.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-05-01 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 {# wf_blink_components: Blink>PushAPI #}
 # Sending Messages with Web Push Libraries {: .page-title }
@@ -290,3 +290,7 @@ Regardless of your backend (Node, PHP, Python, ...) the steps for implementing p
 to be the same.
 
 Next up, what exactly are these web-push libraries doing for us?
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/subscribing-a-user.md
+++ b/src/content/en/fundamentals/push-notifications/subscribing-a-user.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-07-02 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 {# wf_blink_components: Blink>PushAPI #}
 
@@ -394,3 +394,7 @@ as well?
 Unfortunately not. A user must register for push on each browser they wish to
 receive messages on. It's also worth noting that this will require
 the user granting permission on each device.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/video.md
+++ b/src/content/en/fundamentals/push-notifications/video.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2016-06-30 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # Video: Web Push Notifications (I/O 2016) {: .page-title }
@@ -18,3 +18,7 @@ Push notifications are an incredibly effective way to build deeper user
 engagement with your application, and are now available on the web. In this
 video, we'll take a look at how they work and deep-dive into how to
 implement push notifications in web applications, from beginning to end.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/push-notifications/video.md
+++ b/src/content/en/fundamentals/push-notifications/video.md
@@ -1,6 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/web-push-protocol.md
+++ b/src/content/en/fundamentals/push-notifications/web-push-protocol.md
@@ -1,6 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
+{# wf_blink_components: Blink>PushAPI #}
 {# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 

--- a/src/content/en/fundamentals/push-notifications/web-push-protocol.md
+++ b/src/content/en/fundamentals/push-notifications/web-push-protocol.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-09-27 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-30 #}
 
 # The Web Push Protocol {: .page-title }
@@ -629,3 +629,7 @@ href="https://tools.ietf.org/html/draft-ietf-webpush-protocol-10#section-7.2">40
 (or 4kb).</td>
   </tr>
 </table>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/credential-management/index.md
+++ b/src/content/en/fundamentals/security/credential-management/index.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-03-14 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-11-08 #}
 {# wf_blink_components: Blink>SecurityFeature>CredentialManagement #}
 
@@ -94,3 +94,7 @@ shared devices, without having to re-enter their sign-in information.
 
 Learn more in
 [Sign out](/web/fundamentals/security/credential-management/retrieve-credentials#sign-out).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/credential-management/retrieve-credentials.md
+++ b/src/content/en/fundamentals/security/credential-management/retrieve-credentials.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-03-14 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-11-08 #}
 {# wf_blink_components: Blink>SecurityFeature>CredentialManagement #}
 
@@ -416,3 +416,6 @@ To resume auto sign-in, a user can choose to intentionally sign-in
 by choosing the account they wish to sign in with, from the account chooser.
 Then the user is always signed back in until they explicitly sign out.
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/credential-management/save-forms.md
+++ b/src/content/en/fundamentals/security/credential-management/save-forms.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-03-14 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-11-08 #}
 {# wf_blink_components: Blink>SecurityFeature>CredentialManagement #}
 
@@ -180,3 +180,7 @@ or proceed to the personalized page.
         showError('Sign-in Failed');
       });
     });
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/csp/index.md
+++ b/src/content/en/fundamentals/security/csp/index.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Content Security Policy can significantly reduce the risk and impact of cross-site scripting attacks in modern browsers.
 
 {# wf_published_on: 2012-06-15 #}
-{# wf_updated_on: 2017-08-11 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>SecurityFeature #}
 
 # Content Security Policy {: .page-title }
@@ -545,3 +545,7 @@ has already begun work on the specification's next iteration,
 If you're interested in the discussion around these upcoming features,
 [skim the public-webappsec@ mailing list archives](http://lists.w3.org/Archives/Public/public-webappsec/),
 or join in yourself.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Enabling HTTPS on your servers is critical to securing your webpages.
 
-{# wf_updated_on: 2018-03-05 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-03-27 #}
 {# wf_blink_components: Blink>SecurityFeature,Internals>Network>SSL #}
 
@@ -430,3 +430,7 @@ should ask advertisers that do not serve HTTPS at all to at least start.
 You may wish to defer completing
 [Make IntraSite URLs relative](#make-intrasite-urls-relative) until enough
 advertisers interoperate properly.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/encrypt-in-transit/intro-to-security-terminology.md
+++ b/src/content/en/fundamentals/security/encrypt-in-transit/intro-to-security-terminology.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Two of the hurdles developers face when migrating to HTTPS are concepts and terminology. This guide provides a brief overview of both.
 
-{# wf_updated_on: 2016-08-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-03-27 #}
 {# wf_blink_components: Blink>SecurityFeature #}
 
@@ -63,3 +63,7 @@ to have a CA vouch for your web server's public key, you send the CA a CSR. The
 CA validates the information in the CSR and uses it to generate a certificate.
 The CA then sends you the final certificate, and you install that certificate (or,
 more likely, a certificate chain) and your private key on your web server.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/encrypt-in-transit/why-https.md
+++ b/src/content/en/fundamentals/security/encrypt-in-transit/why-https.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: You should always protect all of your websites with HTTPS, even if they don’t handle sensitive communications. HTTPS provides critical security and data integrity both for your websites and for the people that entrust your websites with their personal information.
 
-{# wf_updated_on: 2016-08-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-11-23 #}
 {# wf_blink_components: Internals>Network>SSL #}
 
@@ -78,4 +78,6 @@ features and updated APIs.
 
 
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/FAQs_for_hacked_sites.md
+++ b/src/content/en/fundamentals/security/hacked/FAQs_for_hacked_sites.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -49,3 +49,7 @@ has an active group of Googlers and technical contributors that can help you
 with additional feedback. Also, most major Content Management System (CMS)
 providers have detailed documentation on how to resolve hacked cases. You
 can also seek help from a trusted security professional.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/_fixing-additional-files.md
+++ b/src/content/en/fundamentals/security/hacked/_fixing-additional-files.md
@@ -20,3 +20,7 @@ which PHP files are suspicious:
 
 Note: Attackers commonly inject scripts into the following files:
 `index.php`, `wp-load.php`, `404.php`, and `view.php`.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/_fixing-additional-resources.md
+++ b/src/content/en/fundamentals/security/hacked/_fixing-additional-resources.md
@@ -30,3 +30,7 @@ and let us know.
 
 
 <div class="clearfix"></div>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/clean_site.md
+++ b/src/content/en/fundamentals/security/hacked/clean_site.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-01-08 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -266,3 +266,7 @@ Make sure you can answer "yes" to the following questions:
 * Do I have a plan to keep my site secure?
 
 ### 9. Bring your site back online
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/fixing_the_cloaked_keywords_hack.md
+++ b/src/content/en/fundamentals/security/hacked/fixing_the_cloaked_keywords_hack.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -147,3 +147,7 @@ and delete the suspicious files.
 <<_fixing-prevent.md>>
 
 <<_fixing-additional-resources.md>>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/fixing_the_gibberish_hack.md
+++ b/src/content/en/fundamentals/security/hacked/fixing_the_gibberish_hack.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -170,3 +170,6 @@ and delete the suspicious files.
 
 <<_fixing-additional-resources.md>>
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/fixing_the_japanese_keyword_hack.md
+++ b/src/content/en/fundamentals/security/hacked/fixing_the_japanese_keyword_hack.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-02-12 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -136,3 +136,7 @@ of text, making it look smaller than it actually is.
 <<_fixing-prevent.md>>
 
 <<_fixing-additional-resources.md>>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/glossary_for_hacked_sites.md
+++ b/src/content/en/fundamentals/security/hacked/glossary_for_hacked_sites.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -162,3 +162,7 @@ access over a server.
 Webspam is blackhat search engine optimization (SEO) tactics or spam
 content that attempts to boost the ranking or popularity of a site by
 deceiving and manipulating search engines.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/hacked_with_malware.md
+++ b/src/content/en/fundamentals/security/hacked/hacked_with_malware.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-01-08 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -153,3 +153,7 @@ If your site is online, you can take it back offline for this step.
 
 5. If you have a database, investigate record by record using a tool like
    [phpMyAdmin](https://www.phpmyadmin.net/home_page/index.php).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/hacked_with_spam.md
+++ b/src/content/en/fundamentals/security/hacked/hacked_with_spam.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -32,3 +32,7 @@ the guide.
 * [Fixing the Japanese Keyword Hack](fixing_the_japanese_keyword_hack)
 * [Fixing the Gibberish Hack](fixing_the_gibberish_hack)
 * [Fixing the Cloaked Keywords and Links Hack](fixing_the_cloaked_keywords_hack)
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/how_do_I_know_if_site_hacked.md
+++ b/src/content/en/fundamentals/security/hacked/how_do_I_know_if_site_hacked.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -42,3 +42,7 @@ After you’ve double checked your pages, if you still think think your site
 was incorrectly flagged, please post in the
 [Webmaster Help Forums](https://productforums.google.com/forum/#!forum/webmasters).
 Otherwise, start building your [support team](support_team).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/index.md
+++ b/src/content/en/fundamentals/security/hacked/index.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -40,3 +40,6 @@ This video covers:
 * Approximate time to fix the site
 * Fixing it yourself or hiring a professional
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/quarantine_site.md
+++ b/src/content/en/fundamentals/security/hacked/quarantine_site.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -66,3 +66,7 @@ understand the scope of the problem.
 * Change the passwords for all site users and accounts. This includes logins
   for FTP, database access, system administrators, and content management
   system (CMS) accounts.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/request_review.md
+++ b/src/content/en/fundamentals/security/hacked/request_review.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-02-09 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -163,3 +163,7 @@ caution to protect users.
   modifications or new files created by the hacker. Alternatively, you
   can consider requesting more help from
   [specialists in your support team](support_team).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/support_team.md
+++ b/src/content/en/fundamentals/security/hacked/support_team.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -58,3 +58,7 @@ If you feel ill-equipped to recover your site on your own, try the following opt
 * Transfer your site to new hoster who specializes in site recovery and can
   recover your site as part of the transfer.
 
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/top_ways_websites_get_hacked_by_spammers.md
+++ b/src/content/en/fundamentals/security/hacked/top_ways_websites_get_hacked_by_spammers.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -131,3 +131,7 @@ you do happen to discover any sensitive information displayed on your
 site that urgently needs to be removed from Google Search results, you
 can use the [URL removal tool](https://www.google.com/webmasters/tools/removals)
 to remove individual URLs from Google Search.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/use_search_console.md
+++ b/src/content/en/fundamentals/security/hacked/use_search_console.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -135,3 +135,7 @@ steps:
       password, or financial details, often by masquerading as a trustworthy
       site. Since the cleanup for phishing is similar to spam, please continue
       to [Assess spam damage](hacked_with_spam).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/hacked/vulnerability.md
+++ b/src/content/en/fundamentals/security/hacked/vulnerability.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2017-12-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-01-01 #}
 {# wf_blink_components: N/A #}
 
@@ -128,3 +128,7 @@ it’s possible that your site was compromised by a SQL injection.
   escaped or perhaps strongly typed so they can't be executed as code. if
   user input isn't checked before database processing, SQL injection may be
   a root-cause vulnerability on your site.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/index.md
+++ b/src/content/en/fundamentals/security/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Security is a big topic, learn about HTTPS, why it's important and how you can deploy it to your servers.
 
-{# wf_updated_on: 2017-05-22 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-09-08 #}
 {# wf_blink_components: Blink>SecurityFeature,Internals>Network>SSL #}
 
@@ -59,4 +59,6 @@ One of the most critical security features, one that is required for many modern
 * [Understand Security Issues](/web/tools/chrome-devtools/security)
 
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/prevent-mixed-content/fixing-mixed-content.md
+++ b/src/content/en/fundamentals/security/prevent-mixed-content/fixing-mixed-content.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Finding and fixing mixed content is an important task, but it can be time-consuming. This guide discusses some tools that are available to help with the process.
 
 {# wf_published_on: 2015-09-28 #}
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_blink_components: Blink>SecurityFeature #}
 
 # Preventing Mixed Content {: .page-title }
@@ -309,3 +309,7 @@ across your site for you, such as
 [HTTPSChecker](https://httpschecker.net/how-it-works#httpsChecker){: .external }
 or
 [Mixed Content Scan](https://github.com/bramus/mixed-content-scan){: .external }
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/security/prevent-mixed-content/what-is-mixed-content.md
+++ b/src/content/en/fundamentals/security/prevent-mixed-content/what-is-mixed-content.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Mixed occurs when initial HTML is loaded over a secure HTTPS connection, but other resources are loaded over an insecure HTTP connection.
 
-{# wf_updated_on: 2018-02-12 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2015-09-25 #}
 {# wf_blink_components: Blink>SecurityFeature #}
 
@@ -281,4 +281,6 @@ information published by the vendors directly.
 
 Note: Your users are counting on you to protect them when they visit your website. It is important to fix your mixed content issues to protect <b>all</b> your visitors, including those on older browsers.
 
+## Feedback {: #feedback }
 
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/vr/adding-input-to-a-webvr-scene/index.md
+++ b/src/content/en/fundamentals/vr/adding-input-to-a-webvr-scene/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Discover how to use the Ray Input library to add input to your WebVR scene.
 
-{# wf_updated_on: 2018-04-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
@@ -189,3 +189,7 @@ There are some things to keep in mind as you add input to your experiences.
 Adding input to your scene is vital to making an immersive experience, and with [Ray Input](https://github.com/borismus/ray-input) it’s much easier to get going.
 
 Let us know how you get on!
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/vr/getting-started-with-webvr/index.md
+++ b/src/content/en/fundamentals/vr/getting-started-with-webvr/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Learn how to take a WebGL scene in Three.js and add WebVR capabilities.
 
-{# wf_updated_on: 2018-04-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
@@ -212,3 +212,7 @@ While we’re here, there are plenty of resources out there to give you a flying
 * **[Ray-Input](https://github.com/borismus/ray-input)**. A library to help you handle the various types of input for VR- and non-VR-devices, such as mouse, touch, and VR Gamepad controllers.
 
 Now go and make some awesome VR!
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/vr/index.md
+++ b/src/content/en/fundamentals/vr/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: WebVR
 
-{# wf_updated_on: 2018-04-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
@@ -120,3 +120,7 @@ experiences, and ensure that you’re providing the best possible experience no
 matter what setup your users have.
 
 For more, read our guide on [adding input to a WebVR scene](./adding-input-to-a-webvr-scene/).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/vr/status/index.md
+++ b/src/content/en/fundamentals/vr/status/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Get the latest info on WebVR and AR's status, as well as things to keep in mind when building WebVR experiences.
 
-{# wf_updated_on: 2018-06-20 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-12-12 #}
 {# wf_blink_components: Blink>WebVR #}
 
@@ -74,3 +74,7 @@ Here are things to remember when building WebVR experiences today.
 * **For some types of sessions, users must click a button before
   AR or VR are available to your code**. See the [Immersive Web Early Adopters
   Guide](https://immersive-web.github.io/webxr-reference/) for more information.
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/vr/vr-perspective/index.md
+++ b/src/content/en/fundamentals/vr/vr-perspective/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Find out more about how creating content for WebVR is different from creating regular web content.
 
-{# wf_updated_on: 2018-04-28 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-06-05 #}
 {# wf_blink_components: Blink>WebVR #}
 
@@ -132,3 +132,7 @@ could use code like:
         }
       }
     }
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/web-app-manifest/index.md
+++ b/src/content/en/fundamentals/web-app-manifest/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: The web app manifest is a JSON file that gives you the ability to control how your web app or site appears to the user in areas where they would expect to see native apps (for example, a device's home screen), direct what the user can launch, and define its appearance at launch.
 
-{# wf_updated_on: 2018-05-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-02-11 #}
 {# wf_blink_components: Manifest #}
 
@@ -286,3 +286,7 @@ displays the results in a report.
 * If you want feature descriptions from the engineers who created web app
   manifests, you can read the
   [W3C Web App Manifest Spec](http://www.w3.org/TR/appmanifest/).
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/web-components/best-practices.md
+++ b/src/content/en/fundamentals/web-components/best-practices.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Custom elements let you construct your own HTML tags. This checklist covers best practices to help you build high quality elements.
 
-{# wf_updated_on: 2017-08-21 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-08-14 #}
 {# wf_blink_components: Blink>DOM #}
 
@@ -538,3 +538,7 @@ attributeChangedCallback(name, oldValue, newValue) {
   }
 }
 ```
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/web-components/customelements.md
+++ b/src/content/en/fundamentals/web-components/customelements.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Custom elements allow web developers to define new HTML tags, extend existing ones, and create reusable web components.
 
-{# wf_updated_on: 2018-07-11 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-06-28 #}
 {# wf_blink_components: Blink>DOM #}
 
@@ -1058,3 +1058,7 @@ picture of Web Components:
 
 [spec]: https://html.spec.whatwg.org/multipage/scripting.html#custom-elements
 [sd_spec]: http://w3c.github.io/webcomponents/spec/shadow/
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/web-components/index.md
+++ b/src/content/en/fundamentals/web-components/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Components are the building blocks of modern web applications. What best practices should you follow when building your own components so they can stand the test of time?
 
-{# wf_updated_on: 2017-08-14 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2017-08-14 #}
 {# wf_blink_components: Blink>DOM #}
 
@@ -80,3 +80,7 @@ the test of time?
 </div>
 
 <div style="clear:both;"></div>
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}

--- a/src/content/en/fundamentals/web-components/shadowdom.md
+++ b/src/content/en/fundamentals/web-components/shadowdom.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Shadow DOM allows web developers to create compartmentalized DOM and CSS for web components
 
-{# wf_updated_on: 2017-08-14 #}
+{# wf_updated_on: 2018-09-20 #}
 {# wf_published_on: 2016-08-01 #}
 {# wf_blink_components: Blink>DOM #}
 
@@ -1261,3 +1261,7 @@ See [Closed shadow roots](#closed).
 [sd_spec_whatwg]: https://dom.spec.whatwg.org/#shadow-trees
 [differences]: http://hayato.io/2016/shadowdomv1/
 [css_props]: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables
+
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- adds the widget to all docs under /web/fundamentals
- adds wf_blink_component tags

**Fixes:** N/A

**Target Live Date:** 2018-09-27

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
