### PR TITLE
[lighthouse] minor updates to metrics docs

### DIFF
--- a/src/content/en/tools/_redirects.yaml
+++ b/src/content/en/tools/_redirects.yaml
@@ -1,5 +1,8 @@
 redirects:
 
+- from: /web/tools/lighthouse/audits/first-interactive
+  to: /web/tools/lighthouse/audits/first-cpu-idle
+
 - from: /web/tools/lighthouse/audits/consistently-interactive
   to: /web/tools/lighthouse/audits/time-to-interactive
 

--- a/src/content/en/tools/lighthouse/_toc.yaml
+++ b/src/content/en/tools/lighthouse/_toc.yaml
@@ -22,8 +22,8 @@ toc:
     path: /web/tools/lighthouse/audits/estimated-input-latency
   - title: First Contentful Paint
     path: /web/tools/lighthouse/audits/first-contentful-paint
-  - title: First Interactive
-    path: /web/tools/lighthouse/audits/first-interactive
+  - title: First CPU Idle
+    path: /web/tools/lighthouse/audits/first-cpu-idle
   - title: First Meaningful Paint
     path: /web/tools/lighthouse/audits/first-meaningful-paint
   - title: Has Enormous Network Payloads

--- a/src/content/en/tools/lighthouse/audits/first-cpu-idle.md
+++ b/src/content/en/tools/lighthouse/audits/first-cpu-idle.md
@@ -1,16 +1,19 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "First Interactive" Lighthouse audit.
+description: Reference documentation for the "First CPU Idle" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2018-10-01 #}
 {# wf_published_on: 2017-06-23 #}
 {# wf_blink_components: N/A #}
 
-# First Interactive {: .page-title }
+# First CPU Idle {: .page-title }
 
 ## Overview {: #overview }
 
-The First Interactive metric measures when a page is *minimally* interactive:
+Note: This audit used to be called First Interactive. It changed to First CPU Idle
+in Lighthouse 3.0 to more clearly describe how it works.
+
+The First CPU Idle metric measures when a page is *minimally* interactive:
 
 * *Most*, but maybe not all, UI elements on the screen are interactive.
 * The page responds, *on average*, to most user input in a reasonable amount
@@ -34,7 +37,7 @@ There are two general strategies for improving load time:
 ## More information {: #more-info }
 
 The score is a lognormal distribution of some complicated calculations based on
-the definition of the First Interactive metric. See [First Interactive And
+the definition of the First CPU Idle metric. See [First Interactive And
 Consistently Interactive][FIACI] for definitions.
 
 [FIACI]: https://docs.google.com/document/d/1GGiI9-7KeY3TPqS3YT271upUVimo-XiL5mwWorDUD4c

--- a/src/content/en/tools/lighthouse/audits/time-to-interactive.md
+++ b/src/content/en/tools/lighthouse/audits/time-to-interactive.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Time to Interactive" Lighthouse audit.
 
-{# wf_updated_on: 2018-08-17 #}
+{# wf_updated_on: 2018-10-01 #}
 {# wf_published_on: 2018-08-16 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -26,7 +26,7 @@ The Time to Interactive (TTI) metric measures how long it takes a page to become
 * Event handlers are registered for most visible page elements.
 * The page responds to user interactions within 50 milliseconds.
 
-[FMP]: /web/tools/lighthouse/audits/first-contentful-paint
+[FCP]: /web/tools/lighthouse/audits/first-contentful-paint
 
 Some sites optimize content visibility at the expense of interactivity. This can create a frustrating
 user experience. The site appears to be ready, but when the user tries to interact with it, nothing happens.


### PR DESCRIPTION
What's changed, or what was fixed?

- fix a broken link
- rename first interactive to first cpu idle

**Fixes:** N/A

**Target Live Date:** 2018-10-08

- [x] This has been reviewed and approved by @kaycebasques 
- [x] I have run `npm test` locally and all tests pass.
- [x ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
