### PR TITLE
Adding missing fields

### DIFF
--- a/src/templates/shows/podcast.xml
+++ b/src/templates/shows/podcast.xml
@@ -3,6 +3,7 @@
 <channel>
   <title>{{ title }}</title>
   <link>{{ baseUrl }}</link>
+  <description>{{ summary }}</description>
   <language>en</language>
   <copyright>Google</copyright>
   <itunes:subtitle>{{ subtitle }}</itunes:subtitle>
@@ -13,12 +14,16 @@
     <itunes:email>{{ author.email }}</itunes:email>
   </itunes:owner>
   <itunes:image href="{{ image }}" />
+  <image><url>{{ image }}</url></image>
   <itunes:category text="Technology"/>
   {{#each articles}}
   <item>
     <title>{{ title }}</title>
     <itunes:author>{{ ../author.name }}</itunes:author>
     <itunes:subtitle>{{ podcast.subtitle }}</itunes:subtitle>
+    <description>
+      {{{ description }}}
+    </description>
     <itunes:summary>
       {{{ description }}}
     </itunes:summary>


### PR DESCRIPTION
The podcast feed was missing some fields, making it invalid (particularly `<description>`). Spotify's validator won't accept it.

**Target Live Date:** Whenever

**CC:** @petele
