### PR TITLE
Workbox guide updates

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -159,7 +159,7 @@ to return a response at all. An example is returning a placeholder image when
 the original image can't be retrieved.
 
 To do this in all versions of Workbox you can use the `handle()` method on strategy to make
-a custom handler function. **Note:** You'll should precache any assets you
+a custom handler function. **Note:** You should precache any assets you
 use for your fallback; in the example below we'd need to make sure that
 `FALLBACK_IMAGE_URL` was already cached.
 

--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Advanced recipes to use with Workbox.
 
-{# wf_updated_on: 2018-04-13 #}
+{# wf_updated_on: 2018-10-11 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: N/A #}
 
@@ -158,17 +158,69 @@ There are scenarios where returning a fallback response is better than failing
 to return a response at all. An example is returning a placeholder image when
 the original image can't be retrieved.
 
-To do this in Workbox you can use the `handle()` method on strategy to make
-a custom handler function. **Note:** You'll need to cache any assets you
-use for your fallback, in the example below we'd need to cache the
-`FALLBACK_IMAGE_URL`.
+To do this in all versions of Workbox you can use the `handle()` method on strategy to make
+a custom handler function. **Note:** You'll should precache any assets you
+use for your fallback; in the example below we'd need to make sure that
+`FALLBACK_IMAGE_URL` was already cached.
 
 ```javascript
 const FALLBACK_IMAGE_URL = '/images/fallback.png';
-const imagesHandler = workbox.strategies.cacheFirst();
-workbox.routing.registerRoute(new RegExp('/images/'), ({event}) => {
-  return imagesHandler.handle({event})
-    .catch(() => caches.match(FALLBACK_IMAGE_URL));
+
+workbox.routing.registerRoute(
+  new RegExp('/images/'),
+  async ({event}) => {
+    try {
+      return await workbox.strategies.cacheFirst().handle({event});
+    } catch (error) {
+      return caches.match(FALLBACK_IMAGE_URL);
+    }
+  }
+});
+```
+
+Starting in Workbox v4, all of the built-in caching strategies reject in a consistent manner when
+there's a network failure and/or a cache miss. This promotes the pattern of
+[setting a global "catch" handler](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing#.setCatchHandler)
+to deal with any failures in a single handler function:
+
+```javascript
+// Use an explicit cache-first strategy and a dedicated cache for images.
+workbox.routing.registerRoute(
+  new RegExp('/images/'),
+  workbox.strategies.cacheFirst({
+    cacheName: 'images',
+    plugins: [...],
+  })
+);
+
+// Use a stale-while-revalidate strategy for all other requests.
+workbox.routing.setDefaultHandler(
+  workbox.strategies.staleWhileRevalidate()
+);
+
+// This "catch" handler is triggered when any of the other routes fail to
+// generate a response.
+workbox.routing.setCatchHandler(({event, request, url}) => {
+  // Use event, request, and url to figure out how to respond.
+  // One approach would be to use request.destination, see
+  // https://medium.com/dev-channel/service-worker-caching-strategies-based-on-request-types-57411dd7652c
+  switch (request.destination) {
+    case 'document':
+      return caches.match(FALLBACK_HTML_URL);
+    break;
+
+    case 'image':
+      return caches.match(FALLBACK_IMAGE_URL);
+    break;
+
+    case 'font':
+      return caches.match(FALLBACK_FONT_URL);
+    break;
+
+    default:
+      // If we don't have a fallback, just return an error response.
+      return Response.error();
+  }
 });
 ```
 
@@ -255,7 +307,7 @@ self.addEventListener('fetch', async (event) => {
   if (event.request.url.endsWith('/complexRequest')) {
     // Configure the strategy in advance.
     const strategy = workbox.strategies.staleWhileRevalidate({cacheName: 'api-cache'});
-    
+
     // Make two requests using the strategy.
     // Because we're passing in event, event.waitUntil() will be called automatically.
     const firstPromise = strategy.makeRequest({event, request: 'https://example.com/api1'});
@@ -263,7 +315,7 @@ self.addEventListener('fetch', async (event) => {
 
     const [firstResponse, secondResponse] = await Promise.all(firstPromise, secondPromise);
     const [firstBody, secondBody] = await Promise.all(firstResponse.text(), secondResponse.text());
-    
+
     // Assume that we just want to concatenate the first API response with the second to create the
     // final response HTML.
     const compositeResponse = new Response(firstBody + secondBody, {

--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -180,7 +180,7 @@ workbox.routing.registerRoute(
 
 Starting in Workbox v4, all of the built-in caching strategies reject in a consistent manner when
 there's a network failure and/or a cache miss. This promotes the pattern of
-[setting a global "catch" handler](https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox.routing#.setCatchHandler)
+[setting a global "catch" handler](/web/tools/workbox/reference-docs/latest/workbox.routing#.setCatchHandler)
 to deal with any failures in a single handler function:
 
 ```javascript

--- a/src/content/en/tools/workbox/guides/common-recipes.md
+++ b/src/content/en/tools/workbox/guides/common-recipes.md
@@ -68,7 +68,6 @@ workbox.routing.registerRoute(
         maxEntries: 60,
         maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
       }),
-      new workbox
     ],
   })
 );

--- a/src/content/en/tools/workbox/guides/common-recipes.md
+++ b/src/content/en/tools/workbox/guides/common-recipes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Common recipes to use with Workbox.
 
-{# wf_updated_on: 2018-08-20 #}
+{# wf_updated_on: 2018-10-11 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -28,15 +28,15 @@ HTTP `Cache-Control` header) and the max entries to 30 (to ensure we don't use
 up too much storage on the user's device).
 
 ```javascript
-// Cache the Google Fonts stylesheets with a stale while revalidate strategy.
+// Cache the Google Fonts stylesheets with a stale-while-revalidate strategy.
 workbox.routing.registerRoute(
   /^https:\/\/fonts\.googleapis\.com/,
   workbox.strategies.staleWhileRevalidate({
     cacheName: 'google-fonts-stylesheets',
-  }),
+  })
 );
 
-// Cache the Google Fonts webfont files with a cache first strategy for 1 year.
+// Cache the underlying font files with a cache-first strategy for 1 year.
 workbox.routing.registerRoute(
   /^https:\/\/fonts\.gstatic\.com/,
   workbox.strategies.cacheFirst({
@@ -50,14 +50,13 @@ workbox.routing.registerRoute(
         maxEntries: 30,
       }),
     ],
-  }),
+  })
 );
 ```
 
 ## Caching Images
 
-You can capture and caching images with a cache first strategy based on
-the extension.
+You might want to use a cache-first images, by matching against a list of known extensions.
 
 ```javascript
 workbox.routing.registerRoute(
@@ -69,22 +68,23 @@ workbox.routing.registerRoute(
         maxEntries: 60,
         maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
       }),
+      new workbox
     ],
-  }),
+  })
 );
 ```
 
 ## Cache CSS and JavaScript Files
 
-You can use a stale while revalidate for CSS and JavaScript files that
-aren't precached.
+You might want to use a stale-while-revalidate strategy for CSS and JavaScript files that aren't
+precached.
 
 ```javascript
 workbox.routing.registerRoute(
   /\.(?:js|css)$/,
   workbox.strategies.staleWhileRevalidate({
     cacheName: 'static-resources',
-  }),
+  })
 );
 ```
 
@@ -96,7 +96,7 @@ like `googleapis.com` and `gstatic.com` with a single route.
 
 ```javascript
 workbox.routing.registerRoute(
-  /.*(?:googleapis|gstatic)\.com.*$/,
+  /.*(?:googleapis|gstatic)\.com/,
   workbox.strategies.staleWhileRevalidate(),
 );
 ```
@@ -106,17 +106,17 @@ store assets in  cache for each origin.
 
 ```javascript
 workbox.routing.registerRoute(
-  /.*(?:googleapis)\.com.*$/,
+  /.*(?:googleapis)\.com/,
   workbox.strategies.staleWhileRevalidate({
     cacheName: 'googleapis',
-  }),
+  })
 );
 
 workbox.routing.registerRoute(
-  /.*(?:gstatic)\.com.*$/,
+  /.*(?:gstatic)\.com/,
   workbox.strategies.staleWhileRevalidate({
     cacheName: 'gstatic',
-  }),
+  })
 );
 ```
 
@@ -128,19 +128,19 @@ up to 5 minutes.
 
 ```javascript
 workbox.routing.registerRoute(
-    'https://hacker-news.firebaseio.com/v0/*',
-    workbox.strategies.cacheFirst({
-        cacheName: 'stories',
-        plugins: [
-          new workbox.expiration.Plugin({
-            maxEntries: 50,
-            maxAgeSeconds: 5 * 60, // 5 minutes
-          }),
-          new workbox.cacheableResponse.Plugin({
-            statuses: [0, 200],
-          }),
-        ],
-    }),
+  'https://hacker-news.firebaseio.com/v0/api',
+  workbox.strategies.cacheFirst({
+      cacheName: 'stories',
+      plugins: [
+        new workbox.expiration.Plugin({
+          maxEntries: 50,
+          maxAgeSeconds: 5 * 60, // 5 minutes
+        }),
+        new workbox.cacheableResponse.Plugin({
+          statuses: [0, 200],
+        }),
+      ],
+  })
 );
 ```
 
@@ -155,17 +155,17 @@ For this, you can use a `NetworkFirst` strategy with the
 
 ```javascript
 workbox.routing.registerRoute(
-    'https://hacker-news.firebaseio.com/v0/*',
-    workbox.strategies.networkFirst({
-        networkTimeoutSeconds: 3,
-        cacheName: 'stories',
-        plugins: [
-          new workbox.expiration.Plugin({
-            maxEntries: 50,
-            maxAgeSeconds: 5 * 60, // 5 minutes
-          }),
-        ],
-    }),
+  'https://hacker-news.firebaseio.com/v0/api',
+  workbox.strategies.networkFirst({
+      networkTimeoutSeconds: 3,
+      cacheName: 'stories',
+      plugins: [
+        new workbox.expiration.Plugin({
+          maxEntries: 50,
+          maxAgeSeconds: 5 * 60, // 5 minutes
+        }),
+      ],
+  })
 );
 ```
 
@@ -173,12 +173,12 @@ workbox.routing.registerRoute(
 
 You can use a regular expression to easily route requests to files in a
 specific directory. If we wanted to route requests to files in `/static/`,
-we could use the regular expression `new RegExp('/static/.*/')`, like so:
+we could use the regular expression `new RegExp('/static/')`, like so:
 
 ```javascript
 workbox.routing.registerRoute(
-  new RegExp('/static/(.*)'),
-  workbox.strategies.staleWhileRevalidate(),
+  new RegExp('/static/'),
+  workbox.strategies.staleWhileRevalidate()
 );
 ```
 
@@ -217,7 +217,7 @@ that were added by the web page itself:
 // Inside service-worker.js:
 
 workbox.routing.registerRoute(
-  new RegExp('^/static/'),
+  new RegExp('/static/'),
   workbox.strategies.staleWhileRevalidate({
     cacheName: 'my-cache', // Use the same cache name as before.
   })

--- a/src/content/en/tools/workbox/guides/route-requests.md
+++ b/src/content/en/tools/workbox/guides/route-requests.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to route requests with Workbox.
 
-{# wf_updated_on: 2018-03-13 #}
+{# wf_updated_on: 2018-10-11 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -40,7 +40,7 @@ workbox.routing.registerRoute(
 
 The only thing to be wary of is that this would only match for requests
 on your origin. If there was a separate site that had the URL
-"https://some-other-origin.com/logo.png", this route wouldn’t match, because
+`https://some-other-origin.com/logo.png`, this route wouldn’t match, because
 in most cases, that’s not what was intended. Instead you’d need to define
 the entire URL to match.
 
@@ -53,48 +53,63 @@ workbox.routing.registerRoute(
 
 ## Matching a Route with a Regular Expression
 
-When you have a set of URLs that you want to route as a group, Regular
-Expressions are the best way to go.
+When you have a set of URLs that you want to route as a group, regular
+expressions are the best way to go.
 
-The regular expression needs to match part of the URL to be treated as a
-match for that route. This provides a lot of flexibility as to how you use it.
+The regular expression provided is tested against the full URL. If there's a match, the route will
+be triggered. This provides a lot of flexibility as to how you use it.
 If we wanted to route specific file extensions we could write routes such as:
 
 ```javascript
 workbox.routing.registerRoute(
-  new RegExp('.*\.js'),
+  new RegExp('\\.js$'),
   jsHandler
 );
 
 workbox.routing.registerRoute(
-  new RegExp('.*\.css'),
+  new RegExp('\\.css$'),
   cssHandler
 );
 ```
 
-Or you can write regular expressions that test for a specific URL format, for
-example a blog that follows the format `/blog/<year>/<month>/<post title slug>`.
+Or you can write regular expressions that test for a specific URL format: for
+example, a blog that follows the format `/blog/<year>/<month>/<post title slug>`:
 
 ```javascript
 workbox.routing.registerRoute(
-  /\/blog\/\d\d\d\d\/\d\d\/.+/,
+  new RegExp('/blog/\\d{4}/\\d{2}/.+'),
   handler
 );
 ```
 
-Just like the string matching, requests for different origins are treated
-differently. Instead of needing match a part of the URL, it must match from
-the beginning of the URL. For example,
-`https://some-other-origin.com/blog/<year>/<month>/<post title slug>` would
-need to match against "https://some-other-origin.com" as well as the path
-name. So we’d have to change our regular expression to something like the
-following if we wanted to capture both same origin and third party origin
-requests:
+Just like with string matching, requests for different origins are treated differently. Instead of
+matching against any part of the URL, the regular expression must match from
+the beginning of the URL in order to trigger a route when there's a cross-origin request.
+
+For example, the previous regular expression `new RegExp('/blog/\\d{4}/\\d{2}/.+')` would not match
+a request for `https://some-other-origin.com/blog/<year>/<month>/<post title slug>`. If we wanted a
+route that would match that general path pattern made against both same- and cross-origin requests,
+using a regular expression with a wildcard (`.+`)at the start is one approach:
 
 ```javascript
 workbox.routing.registerRoute(
-  /(?:https:\/\/.*)?\/blog\/\d\d\d\d\/\d\d\/.+/,
+  new RegExp('.+/blog/\\d{4}/\\d{2}/.+'),
   handler
+);
+```
+
+Similarly, if we wanted to take the previous examples that matched CSS or JS URLs and have them
+apply to both same- and cross-origin requests, they can be modified to add in a wildcard:
+
+```javascript
+workbox.routing.registerRoute(
+  new RegExp('.+\\.js$'),
+  jsHandler
+);
+
+workbox.routing.registerRoute(
+  new RegExp('.+\\.css$'),
+  cssHandler
 );
 ```
 


### PR DESCRIPTION
R: @philipwalton 

I found a bunch of typos on the Workbox guides related to routing; mostly this had to do with extra `,` characters in the `registerRoute()` call, or incorrect `RegExp` usage.

I also added a recipe about using `workbox.routing.setCatchHandler()` that's particularly relevant for Workbox v4, as a way of providing fallback content when an existing route would otherwise return an error. (This includes a shout-out to @tomayac's [`request.destination` article](https://medium.com/dev-channel/service-worker-caching-strategies-based-on-request-types-57411dd7652c).)

CC: @petele 