### PR TITLE
Update Firefox and Edge browser support

### DIFF
--- a/src/content/en/fundamentals/web-components/customelements.md
+++ b/src/content/en/fundamentals/web-components/customelements.md
@@ -977,12 +977,11 @@ article](http://www.html5rocks.com/en/tutorials/webcomponents/customelements/){:
 
 ### Browser support
 
-Chrome 54 ([status](https://www.chromestatus.com/features/4696261944934400)) and
-Safari 10.1 ([status](https://webkit.org/status/#feature-custom-elements)) have
-Custom Elements v1. Edge has [begun
-prototyping](https://twitter.com/AaronGustafson/status/717028669948977153).
-Mozilla has an [open bug](https://bugzilla.mozilla.org/show_bug.cgi?id=889230)
-to implement.
+Chrome 54 ([status](https://www.chromestatus.com/features/4696261944934400)),
+Safari 10.1 ([status](https://webkit.org/status/#feature-custom-elements)), and
+Firefox 63 ([status](https://platform-status.mozilla.org/#custom-elements)) have
+Custom Elements v1. Edge has [begun 
+development](https://developer.microsoft.com/microsoft-edge/platform/status/customelements/).
 
 To feature detect custom elements, check for the existence of
 `window.customElements`:


### PR DESCRIPTION
What's changed, or what was fixed?
- Firefox marked as supporting CE in 63
- Edge marked as in developmemnt

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
