### PR TITLE
[lighthouse] Reframe Fast 3G in more generic terms

### DIFF
--- a/src/content/en/tools/lighthouse/audits/fast-3g.md
+++ b/src/content/en/tools/lighthouse/audits/fast-3g.md
@@ -1,6 +1,6 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Reference documentation for the "Page Load Is Fast Enough On 3G" Lighthouse audit.
+description: Reference documentation for the "Page load is fast enough on mobile networks" Lighthouse audit.
 
 {# wf_updated_on: 2018-07-23 #}
 {# wf_published_on: 2017-06-14 #}
@@ -10,8 +10,8 @@ description: Reference documentation for the "Page Load Is Fast Enough On 3G" Li
 
 ## Overview {: #overview }
 
-Many mobile users of your page experience the equivalent of a slow 4G network
-connection. Ensuring that your page loads fast over a simulated mobile network
+Many users of your page visit over a slow cellular network connection. 
+Ensuring that your page loads fast over a simulated mobile network
 ensures that your page loads in a reasonable amount of time for your mobile
 users.
 

--- a/src/content/en/tools/lighthouse/audits/fast-3g.md
+++ b/src/content/en/tools/lighthouse/audits/fast-3g.md
@@ -6,17 +6,17 @@ description: Reference documentation for the "Page Load Is Fast Enough On 3G" Li
 {# wf_published_on: 2017-06-14 #}
 {# wf_blink_components: N/A #}
 
-# Page Load Is Fast Enough On 3G  {: .page-title }
+# Page Load Is Fast Enough On Mobile  {: .page-title }
 
 ## Overview {: #overview }
 
-Many mobile users of your page experience the equivalent of a 3G network
-connection. Ensuring that your page loads fast over a simulated 3G network
+Many mobile users of your page experience the equivalent of a slow 4G network
+connection. Ensuring that your page loads fast over a simulated mobile network
 ensures that your page loads in a reasonable amount of time for your mobile
 users.
 
-Note: A fast page load on 3G is a baseline requirement for a site to be
-considered a Progressive Web App. See [Baseline Progressive Web App
+Note: A fast page load on a mobile network is a baseline requirement for a site
+to be considered a Progressive Web App. See [Baseline Progressive Web App
 Checklist](/web/progressive-web-apps/checklist#baseline).
 
 ## Recommendations {: #recommendations }
@@ -49,9 +49,8 @@ Performance][RP] for strategies.
 
 ## More information {: #more-info }
 
-Lighthouse throttles the page if the network connection is faster than
-3G and then measures the time to first interactive. If the time to first
-interactive is less than 10s, the audit passes.
+Lighthouse computes what time to interactive would be on a slow 4G network 
+connection. If the time to interactive is less than 10s, the audit passes.
 
 ## Feedback {: #feedback }
 


### PR DESCRIPTION
What's changed, or what was fixed?

- Converts the language in Lighthouse's fast-3g document to be more generic about mobile networks and restates what Lighthouse does as computing the time on a "slow 4G" network.

@kaycebasques not sure what to do about the document title being `fast-3g`. IMO, it's not a big deal to leave it.


**Fixes:** https://github.com/GoogleChrome/lighthouse/issues/4594

**Target Live Date:** 2018-10-18

- [ ] This has been reviewed and approved by (@kaycebasques)
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @kaycebasques @paulirish 
