### PR TITLE
 Web Bluetooth is now supported in Chrome Stable for Windows 10.

### DIFF
--- a/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
+++ b/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A Web API has been added to Chrome that makes it possible for websites to discover and communicate with devices over the Bluetooth 4 wireless standard using GATT.
 
-{# wf_updated_on: 2018-10-17 #}
+{# wf_updated_on: 2018-10-18 #}
 {# wf_published_on: 2015-07-21 #}
 {# wf_tags: news,iot,webbluetooth,physicalweb,origintrials #}
 {# wf_featured_image: /web/updates/images/2015-07-22-interact-with-ble-devices-on-the-web/featured.png #}
@@ -41,7 +41,8 @@ finalized yet, the Chrome Team is actively looking for enthusiastic developers
 [feedback on the implementation](https://bugs.chromium.org/p/chromium/issues/entry?components=Blink%3EBluetooth).
 
 A subset of the Web Bluetooth API is available in Chrome OS,
-Chrome for Android M, Mac, and Windows 10. This means you should be able to
+Chrome for Android M, Mac (Chrome 56) and Windows 10 (Chrome 70). 
+This means you should be able to
 [request](#request_bluetooth_devices) and [connect to](#connect_to_a_bluetooth_device)
 nearby Bluetooth devices,
 [read](#read_a_bluetooth_characteristic)/[write](#write_to_a_bluetooth_characteristic)


### PR DESCRIPTION
This simply states that Web Bluetooth is supported in Windows 10.