### PR TITLE
Remove extra bracket from snippet

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Advanced recipes to use with Workbox.
 
-{# wf_updated_on: 2018-10-11 #}
+{# wf_updated_on: 2018-10-17 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: N/A #}
 
@@ -175,7 +175,7 @@ workbox.routing.registerRoute(
       return caches.match(FALLBACK_IMAGE_URL);
     }
   }
-});
+);
 ```
 
 Starting in Workbox v4, all of the built-in caching strategies reject in a consistent manner when


### PR DESCRIPTION
What's changed, or what was fixed?
- Remove typo from a snippet in the Workbox Advanced Recipes page.

**Fixes:** GoogleChrome/workbox#1713

- [x] This has been reviewed and approved by (@philipwalton)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

After running the site locally, the typo is corrected:
![image](https://user-images.githubusercontent.com/11748696/47107522-28768b00-d20f-11e8-8f0a-32b9a61ba99f.png)

**CC:** @philipwalton 
