### PR TITLE
Remove sentence fragment that was completed as subsequent note in section

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-broadcast-cache-update.md
+++ b/src/content/en/tools/workbox/modules/workbox-broadcast-cache-update.md
@@ -87,9 +87,6 @@ updatesChannel.addEventListener('message', async (event) => {
 
 ### Message format
 
-The message that's sent via the Broadcast Channel API adheres to the
-
-
 When a `message` event listener as received in your web app, the
 `event.data` property will have the following format:
 


### PR DESCRIPTION
There is a fragment sentence that seems to have been completed subsequently in the section:

```
 Note: This message format adheres to the
 [Flux standard action format](https://github.com/acdlite/flux-standard-action#introduction),
 though it is not tied in any way to the Flux framework.
```

So this removes the sentence fragment.

**CC:** @jeffposnick
