### PR TITLE
Podcast image fix

### DIFF
--- a/src/templates/shows/podcast.xml
+++ b/src/templates/shows/podcast.xml
@@ -22,7 +22,7 @@
     <itunes:summary>
       {{{ description }}}
     </itunes:summary>
-    <itunes:image href="{{ image }}" />
+    <itunes:image href="{{ ../host }}{{ image }}" />
     <itunes:explicit>no</itunes:explicit>
     <enclosure url="{{ podcast.audioUrl }}" length="{{podcast.fileSize}}" type="audio/mpeg"/>
     <guid isPermaLink="true">{{ ../host }}{{ url }}</guid>


### PR DESCRIPTION
The image urls need to be absolute, especially when we're using feedburner.

**Target Live Date:** Whenever

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
