### PR TITLE
Fix punctuation mark typo

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/animations/animations-and-performance.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animations-and-performance.md
@@ -44,7 +44,7 @@ Now the browsers that support it, [currently Chrome, Firefox, and Opera](http://
 
 There are many pages and comments threads around the web that discuss the relative merits of CSS and JavaScript animations from a performance perspective. Here are a few points to keep in mind:
 
-* CSS-based animations, and Web Animations where supported natively, are typically handled on a thread known as the "compositor thread." This is different from the browser's "main thread", where styling, layout, painting, and JavaScript are executed. This means that if the browser is running some expensive tasks on the main thread, these animations can keep going without being interrupted.
+* CSS-based animations, and Web Animations where supported natively, are typically handled on a thread known as the "compositor thread". This is different from the browser's "main thread", where styling, layout, painting, and JavaScript are executed. This means that if the browser is running some expensive tasks on the main thread, these animations can keep going without being interrupted.
 
 * Other changes to transforms and opacity can, in many cases, also be handled by the compositor thread.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Fix a typo of punctuation mark 

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
