### PR TITLE
Update links to V8 website

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-javascript/tree-shaking/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-javascript/tree-shaking/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Knowing where to begin optimizing your application's JavaScript can be daunting. If you're taking advantage of modern tooling such as webpack, however, tree shaking might be a good place to start!
 
-{# wf_updated_on: 2018-08-01 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2018-06-14 #}
 {# wf_blink_components: Blink>JavaScript #}
 
@@ -46,7 +46,7 @@ rel="noopener">source</a>).</figcaption>
 </figure>
 
 [While improvements are continually being
-made](https://v8project.blogspot.com/2018/03/background-compilation.html) to
+made](https://v8.dev/blog/background-compilation) to
 [improve the efficiency of JavaScript
 engines](https://blog.mozilla.org/javascript/2017/12/12/javascript-startup-bytecode-cache/),
 improving JavaScript performance is, as always, a task fit for developers. After

--- a/src/content/en/fundamentals/primers/modules.md
+++ b/src/content/en/fundamentals/primers/modules.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-09-21 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2018-06-18 #}
 {# wf_blink_components: N/A #}
 
@@ -351,7 +351,7 @@ preference.
 Not only does this keep your source code nice and simple, it also reduces the need for dead-code
 elimination as performed by bundlers. If one of the modules in your source tree is unused, then it
 never gets imported, and so the browser never downloads it. The modules that _do_ get used can be
-individually [code-cached](https://v8project.blogspot.com/2018/04/improved-code-caching.html) by
+individually [code-cached](https://v8.dev/blog/improved-code-caching) by
 the browser. (The infrastructure to make this happen already landed in V8, and [work is
 underway](https://bugs.chromium.org/p/chromium/issues/detail?id=841466) to enable it in Chrome as
 well.)

--- a/src/content/en/updates/2017/03/devtools-release-notes.md
+++ b/src/content/en/updates/2017/03/devtools-release-notes.md
@@ -2,11 +2,12 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: New features and changes coming to DevTools in Chrome 58.
 
-{# wf_updated_on: 2018-07-02 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2017-03-06 #}
 {# wf_tags: chrome58,devtools #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
 {# wf_featured_snippet: New features and changes coming to DevTools in Chrome 58. #}
+{# wf_blink_components: Platform>DevTools #}
 
 {% include "web/tools/chrome-devtools/_shared/styles.html" %}
 
@@ -62,7 +63,7 @@ V8][heap] for more information.
   </figcaption>
 </figure>
 
-[heap]: https://v8project.blogspot.com/2017/02/one-small-step-for-chrome-one-giant.html
+[heap]: https://v8.dev/blog/heap-size-limit
 
 ### Breakpoints on canvas creation {: #canvas-creation-breakpoints }
 

--- a/src/content/en/updates/2017/07/upcoming-regexp-features.md
+++ b/src/content/en/updates/2017/07/upcoming-regexp-features.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: An overview of the exciting new features coming to JavaScript regular expressions, including named captures, the dotAll flag, Unicode property escapes, and lookbehind assertions.
 
-{# wf_updated_on: 2018-09-27 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2017-07-10 #}
 {# wf_tags: javascript,regex #}
 {# wf_blink_components: Blink>JavaScript>Language #}
@@ -12,7 +12,7 @@ description: An overview of the exciting new features coming to JavaScript regul
 {% include "web/tools/chrome-devtools/_shared/styles.html" %}
 
 
-# Upcoming Regular Expression Features {: .page-title }
+# Upcoming regular expression features {: .page-title }
 
 {% include "web/_shared/contributors/jgruber.html" %}
 {% include "web/_shared/contributors/yangguo.html" %}
@@ -37,7 +37,7 @@ follow along with the upcoming examples, enable experimental JavaScript
 features at `chrome://flags/#enable-javascript-harmony`.
 
 
-## Named Captures
+## Named captures
 
 Regular expressions can contain so-called captures (or groups), which can
 capture a portion of the matched text. So far, developers could only refer to
@@ -99,7 +99,7 @@ Full details of this new feature are available in the [specification
 proposal](https://github.com/tc39/proposal-regexp-named-groups).
 
 
-## dotAll Flag
+## dotAll flag
 
 By default, the `.` atom in regular expressions matches any character except
 for line terminators:
@@ -119,7 +119,7 @@ Full details of this new feature are available in the [specification
 proposal](https://github.com/tc39/proposal-regexp-dotall-flag).
 
 
-## Unicode Property Escapes
+## Unicode property escapes
 
 With Unicode awareness introduced in ES2015, there are suddenly many more
 characters that could be considered numbers, for example the circled digit one:
@@ -161,7 +161,7 @@ For more examples, take a look at [this informative
 article](https://mathiasbynens.be/notes/es-unicode-property-escapes).
 
 
-## Lookbehind Assertions
+## Lookbehind assertions
 
 Lookahead assertions have been part of JavaScript’s regular expression syntax
 from the start. Their counterpart, lookbehind assertions, are finally being
@@ -180,7 +180,7 @@ comes in both matching and non-matching flavors:
 ```
 
 For more details, check out our [previous blog
-post](https://v8project.blogspot.com/2016/02/regexp-lookbehind-assertions.html)
+post](https://v8.dev/blog/regexp-lookbehind-assertions)
 dedicated to lookbehind assertions, and examples in related [V8 test
 cases](https://github.com/v8/v8/blob/master/test/mjsunit/harmony/regexp-lookbehind.js).
 

--- a/src/content/en/updates/2018/02/meltdown-spectre.md
+++ b/src/content/en/updates/2018/02/meltdown-spectre.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Implications for Web Developers and Chrome’s mitigations.
 
-{# wf_updated_on: 2018-07-11 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2018-02-06 #}
 {# wf_tags: security #}
 {# wf_featured_image: /web/updates/images/generic/encryption.png #}
@@ -201,7 +201,7 @@ decided to disable SharedArrayBuffer until other mitigations are in place.
 
 To exploit Spectre, a specifically crafted sequence of CPU instructions is
 needed. [The V8 team has implemented
-mitigations](https://github.com/v8/v8/wiki/Untrusted-code-mitigations) for
+mitigations](https://v8.dev/docs/untrusted-code-mitigations) for
 known attack proofs of concept, and is working on changes in TurboFan, their
 optimizing compiler, that make its generated code safe even when these attacks
 are triggered. However, these code generation changes may come at a performance

--- a/src/content/en/updates/2018/04/loading-wasm.md
+++ b/src/content/en/updates/2018/04/loading-wasm.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: When working with WebAssembly, you often want to download a module, compile it, instantiate it, and then use whatever it exports in JavaScript. This post explains our recommended approach for optimal efficiency.
 
-{# wf_updated_on: 2018-04-12 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2018-04-12 #}
 {# wf_tags: javascript, webassembly #}
 {# wf_featured_image: /web/updates/images/generic/timer.png #}
@@ -73,7 +73,7 @@ free](https://twitter.com/mathias/status/978549917332500480), we can use the asy
 ```
 
 Let’s get back to the `compile` optimization I hinted at earlier. With [streaming
-compilation](https://v8project.blogspot.com/2018/02/v8-release-65.html), the browser can already
+compilation](https://v8.dev/blog/v8-release-65), the browser can already
 start to compile the WebAssembly module while the module bytes are still downloading. Since download
 and compilation happen in parallel, this is faster — especially for large payloads.
 
@@ -136,7 +136,7 @@ See how we compile the response into a module, and then instantiate it immediate
   const fetchPromise = fetch('fibonacci.wasm');
   const { module, instance } = await WebAssembly.instantiateStreaming(fetchPromise);
   // To create a new instance later:
-  const otherInstance = await WebAssembly.instantiate(module); 
+  const otherInstance = await WebAssembly.instantiate(module);
   const result = instance.exports.fibonacci(42);
   console.log(result);
 })();

--- a/src/content/en/updates/2018/05/bigint.md
+++ b/src/content/en/updates/2018/05/bigint.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: BigInts are a new numeric primitive in JavaScript that can represent integers with arbitrary precision. This article walks through some use cases and explains the new functionality in Chrome 67 by comparing BigInts to Numbers in JavaScript.
 
-{# wf_updated_on: 2018-07-11 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2018-05-01 #}
 {# wf_tags: javascript #}
 {# wf_featured_image: /web/updates/images/generic/new-in-chrome.png #}
@@ -294,7 +294,7 @@ The `BigUint64Array` flavor does the same using the unsigned 64-bit limit instea
 
 If you’re interested in how `BigInt`s work behind the scenes (e.g. how they are represented in
 memory, and how operations on them are performed), [read our V8 blog post with implementation
-details](https://v8project.blogspot.com/2018/05/bigint.html).
+details](https://v8.dev/blog/bigint).
 
 Have fun with `BigInt`s!
 

--- a/src/content/zh-cn/updates/2017/03/devtools-release-notes.md
+++ b/src/content/zh-cn/updates/2017/03/devtools-release-notes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Chrome 58 中添加到 DevTools 的新功能和变更。
 
-{# wf_updated_on: 2017-03-06 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2017-03-06 #}
 {# wf_tags: chrome58,devtools #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -58,7 +58,7 @@ description: Chrome 58 中添加到 DevTools 的新功能和变更。
   </figcaption>
 </figure>
 
-[heap]: https://v8project.blogspot.com/2017/02/one-small-step-for-chrome-one-giant.html
+[heap]: https://v8.dev/blog/heap-size-limit
 
 ### Canvas 被创建的断点 {: #canvas-creation-breakpoints }
 

--- a/src/content/zh-tw/updates/2017/03/devtools-release-notes.md
+++ b/src/content/zh-tw/updates/2017/03/devtools-release-notes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Chrome 58 中添加到 DevTools 的新功能和變更。
 
-{# wf_updated_on: 2017-03-06 #}
+{# wf_updated_on: 2018-10-23 #}
 {# wf_published_on: 2017-03-06 #}
 {# wf_tags: chrome58,devtools #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -58,7 +58,7 @@ description: Chrome 58 中添加到 DevTools 的新功能和變更。
   </figcaption>
 </figure>
 
-[heap]: https://v8project.blogspot.com/2017/02/one-small-step-for-chrome-one-giant.html
+[heap]: https://v8.dev/blog/heap-size-limit
 
 ### Canvas 被創建的斷點 {: #canvas-creation-breakpoints }
 


### PR DESCRIPTION
What's changed, or what was fixed?
Updates links to old V8 web properties to the new home at v8.dev.

**Target Live Date:** asap

- [ ] This has been reviewed and approved by ?
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
