### PR TITLE
Dropped details on Appcache

### DIFF
--- a/src/content/en/ilt/pwa/offline-quickstart.md
+++ b/src/content/en/ilt/pwa/offline-quickstart.md
@@ -45,7 +45,7 @@ Service workers can also use  [IndexedDB](https://developer.mozilla.org/en-US/do
 
 Note: The service worker's approach was driven by the problems the community had with Application Cache (AppCache), where a purely declarative approach to caching proved to be too inflexible. Unlike AppCache, service workers don't provide defaults making all behavior explicit. If a behavior is not written into your service worker, then the behavior does not happen. By explicitly coding behaviors in a service worker, the task of writing and debugging code is made easier.
 
-For an example of working with AppCache and the challenges developers face, see Jake Archibald's <a href="http://alistapart.com/article/application-cache-is-a-douchebag">Application Cache is a Douchebag</a> article. However, using AppCache is highly discouraged because it is in the process of being removed from the Web platform. Use service workers instead.
+Using AppCache is highly discouraged because it is in the process of being removed from the Web platform. Use service workers instead.
 
 
 


### PR DESCRIPTION
No need to go in-depth on a deprecated technology

What's changed, or what was fixed?
- Dropped sentence linking to Jake's original AppCache article (unneeded detail)

- [x] This has been reviewed and approved by (Nick Searle)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
