### PR TITLE
fix the dead link to the Shadow DOM specification

### DIFF
--- a/src/content/en/fundamentals/web-components/shadowdom.md
+++ b/src/content/en/fundamentals/web-components/shadowdom.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Shadow DOM allows web developers to create compartmentalized DOM and CSS for web components
 
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2018-10-29 #}
 {# wf_published_on: 2016-08-01 #}
 {# wf_blink_components: Blink>DOM #}
 
@@ -166,7 +166,7 @@ create shadow DOM for an element, call `element.attachShadow()`:
 I'm using `.innerHTML` to fill the shadow root, but you could also use other DOM
 APIs. This is the web. We have choice.
 
-The spec [defines a list of elements](http://w3c.github.io/webcomponents/spec/shadow/#h-methods)
+The spec [defines a list of elements](https://dom.spec.whatwg.org/#dom-element-attachshadow)
 that can't host a shadow tree. There are several reasons an element might be
 on the list:
 


### PR DESCRIPTION
the section where the past link referring the list of elements which cannot host Shadow DOM are gone from the Shadow DOM spec; they're migrated to the WHATWG DOM spec [1].

https://github.com/whatwg/dom/commit/169949553da85cfee6b03df361ed3e8142ddc54e#diff-a467e681501e456ce8c1ef31425e1b41R5601

What's changed, or what was fixed?
- fixed dead pointer to the Shadow DOM spec by linking to the WHATWG DOM spec

**Fixes:** N/A

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
