### PR TITLE
Docs for opaque responses in DevTools

### DIFF
--- a/src/content/en/tools/chrome-devtools/progressive-web-apps.md
+++ b/src/content/en/tools/chrome-devtools/progressive-web-apps.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Use the Application panel to inspect, modify, and debug web app manifests, service workers, and service worker caches.
 
-{# wf_updated_on: 2018-10-29 #}
+{# wf_updated_on: 2018-10-30 #}
 {# wf_published_on: 2016-07-25 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -181,8 +181,8 @@ If you've got two or more caches open, you'll see them listed below the
 ## Opaque responses {:#opaque-responses}
 
 Some responses within the Cache Storage pane may be flagged as being
-"[opaque](/web/fundamentals/glossary#o)". This refers to a response retrieved from a different
-origin, like from a [CDN](/web/fundamentals/glossary#CDN) or remote API, when
+"[opaque](/web/fundamentals/glossary#opaque-response)". This refers to a response retrieved from a
+different origin, like from a [CDN](/web/fundamentals/glossary#CDN) or remote API, when
 [CORS](https://fetch.spec.whatwg.org/#http-cors-protocol) is not enabled.
 
 In order to avoid leakage of cross-domain information, there's significant padding added to the size

--- a/src/content/en/tools/chrome-devtools/progressive-web-apps.md
+++ b/src/content/en/tools/chrome-devtools/progressive-web-apps.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Use the Application panel to inspect, modify, and debug web app manifests, service workers, and service worker caches.
 
-{# wf_updated_on: 2018-07-27 #}
+{# wf_updated_on: 2018-10-29 #}
 {# wf_published_on: 2016-07-25 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -177,6 +177,32 @@ If you've got two or more caches open, you'll see them listed below the
 [sw-cache]: https://developer.mozilla.org/en-US/docs/Web/API/Cache
 [sw-cache-pane]: images/sw-cache.png
 [multiple-caches]: images/multiple-caches.png
+
+## Opaque responses {:#opaque-responses}
+
+Some responses within the Cache Storage pane may be flagged as being
+"[opaque](/web/fundamentals/glossary#o)". This refers to a response retrieved from a different
+origin, like from a [CDN](/web/fundamentals/glossary#CDN) or remote API, when
+[CORS](https://fetch.spec.whatwg.org/#http-cors-protocol) is not enabled.
+
+In order to avoid leakage of cross-domain information, there's significant padding added to the size
+of an opaque response used for calculating storage quota limits (i.e. whether a `QuotaExceeded`
+exception is thrown) and reported by the [`navigator.storage`
+API](/web/updates/2017/08/estimating-available-storage-space).
+
+The details of this padding vary from browser to browser, but for Google Chrome, this means that the
+*minimum* size that any single cached opaque response contributes to the overall storage usage is
+[approximately 7 megabytes](https://bugs.chromium.org/p/chromium/issues/detail?id=796060#c17). You
+should keep this in mind when determining how many opaque responses you want to cache, since you
+could easily exceeded storage quota limitations much sooner than you'd otherwise expect based on the
+actual size of the opaque resources.
+
+Related Guides:
+
+* [Stack Overflow: What limitations apply to opaque
+  responses?](https://stackoverflow.com/q/39109789/385997)
+* [Workbox: Understanding Storage
+  Quota](/web/tools/workbox/guides/storage-quota#beware_of_opaque_responses)
 
 ## Clear storage {:#clear-storage}
 

--- a/src/data/glossary.yaml
+++ b/src/data/glossary.yaml
@@ -42,7 +42,7 @@
   description: "A CDN is a network of geographically distributed servers that cooperate to satisfy requests for content. CDNs optimize content delivery by distributing copies of files (such as videos, images, HTML, CSS and JavaScript) to multiple servers. This reduces latency by placing the content closer to the requestor. For example, if a user in India requests a web page from a Brazilian website, the request could be rerouted to deliver assets served from a local CDN server in Mumbai."
   acronym: CDN
   see:
-    title: Content deliver network on Wikipedia
+    title: Content delivery network on Wikipedia
     link: https://en.wikipedia.org/wiki/Content_delivery_network
 
 - term: custom element
@@ -152,6 +152,19 @@
   links:
   - title: OL in the HTML Specification
     link: https://html.spec.whatwg.org/#event-load
+
+- term: "opaque response"
+  description: "Opaque responses represent the result of a request made to a remote origin when CORS is not enabled."
+  see:
+    title: "The Fetch API Specification"
+    link: https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
+  links:
+    - title: "Cross-Origin Resource Sharing (CORS)"
+      link: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    - title: "What limitations apply to opaque responses?"
+      link: https://stackoverflow.com/q/39109789/385997
+    - title: "Workbox: Understanding Storage Quota"
+      link: /web/tools/workbox/guides/storage-quota#beware_of_opaque_responses
 
 - term: Progressive Web App
   acronym: PWA


### PR DESCRIPTION
R: @petele @kaycebasques 

Adds some more formal opaque response info, suitable for [linking to from the DevTools interface](https://bugs.chromium.org/p/chromium/issues/detail?id=847462#c13).