### PR TITLE
Change link on security index page to use cleaner grammar.

### DIFF
--- a/src/content/en/fundamentals/security/index.md
+++ b/src/content/en/fundamentals/security/index.md
@@ -23,7 +23,7 @@ Security is a big topic, here are a few things to get you started.
 
 <img src="/web/images/content-https-2x.jpg" class="attempt-right">
 
-One of the most critical security features, one that is required for many modern APIs and [progressive web apps](/web/progressive-web-apps/) is [Secure HTTP also called HTTPS](encrypt-in-transit/why-https). A common misconception about HTTPS is that the only websites that need it are those that handle sensitive communications. If privacy and security weren't reason enough to protect your users, many new browser features such as service workers the Payment Request API require HTTPS.
+One of the most critical security features, one that is required for many modern APIs and [progressive web apps](/web/progressive-web-apps/) is [HTTPS](encrypt-in-transit/why-https) (secure HTTP). A common misconception about HTTPS is that the only websites that need it are those that handle sensitive communications. If privacy and security weren't reason enough to protect your users, many new browser features such as service workers the Payment Request API require HTTPS.
 
 [Enabling HTTPS on Your Servers](/web/fundamentals/security/encrypt-in-transit/enable-https)
 

--- a/src/content/en/fundamentals/security/index.md
+++ b/src/content/en/fundamentals/security/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Security is a big topic, learn about HTTPS, why it's important and how you can deploy it to your servers.
 
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2018-10-30 #}
 {# wf_published_on: 2015-09-08 #}
 {# wf_blink_components: Blink>SecurityFeature,Internals>Network>SSL #}
 
@@ -23,7 +23,19 @@ Security is a big topic, here are a few things to get you started.
 
 <img src="/web/images/content-https-2x.jpg" class="attempt-right">
 
-One of the most critical security features, one that is required for many modern APIs and [progressive web apps](/web/progressive-web-apps/) is [HTTPS](encrypt-in-transit/why-https) (secure HTTP). A common misconception about HTTPS is that the only websites that need it are those that handle sensitive communications. If privacy and security weren't reason enough to protect your users, many new browser features such as service workers the Payment Request API require HTTPS.
+One of the most critical security features, and one that is required for many modern
+APIs and [progressive web apps](/web/progressive-web-apps/) is
+[**HTTPS**](encrypt-in-transit/why-https), sometimes referred to as secure HTTP.
+
+Some people mistakenly believe that the only sites that need HTTPS are sites that handle
+some level of sensitive communication, like personal or financial data. But this isn't
+true. Every site should be using HTTPS, HTTPS helps to prevents people from listening
+into what's crossing the wire, and helps prevent it from being tampered with while in
+transit. Do you want your ISP or school to know every site you were looking at?
+
+And if privacy and security weren't enough of a reason to protect your users, many new
+browser features like service workers, the Payment Request API, and even some older
+APIs like GeoLocation now require HTTPS.
 
 [Enabling HTTPS on Your Servers](/web/fundamentals/security/encrypt-in-transit/enable-https)
 


### PR DESCRIPTION
This also change the focus to `HTTPS` (an abbreviation that is often used) instead of "Secure HTTP" (which is not quite its formal name, and isn't used as often).
