### PR TITLE
Fix typo in web push protocol

### DIFF
--- a/src/content/en/fundamentals/push-notifications/web-push-protocol.md
+++ b/src/content/en/fundamentals/push-notifications/web-push-protocol.md
@@ -306,8 +306,8 @@ When we want to send a push message to a user with a payload, there are three in
 We've seen the `auth` and `p256dh` values being retrieved from a `PushSubscription` but for a
 quick reminder, given a subscription we'd need these values:
 
-    subscription.joJSON().keys.auth
-    subscription.joJSON().keys.p256dh
+    subscription.toJSON().keys.auth
+    subscription.toJSON().keys.p256dh
 
     subscription.getKey('auth')
     subscription.getKey('p256dh')


### PR DESCRIPTION
What's changed, or what was fixed?
- Two typos in web push protocol markdown

**Target Live Date:** N/A

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
