### PR TITLE
Typo fix in Workbox reference

### DIFF
--- a/src/content/en/tools/workbox/reference-docs/latest/workbox.routing.Route.html
+++ b/src/content/en/tools/workbox/reference-docs/latest/workbox.routing.Route.html
@@ -193,7 +193,7 @@
                               </td>
                               <td>
                                 <p class="details-table-types">FetchEvent</p>
-                                <p>The service worker<code>s</code>fetch` event.
+                                <p>The service worker's <code>fetch</code> event.
                                 </p>
                               </td>
                             </tr>


### PR DESCRIPTION
What's changed, or what was fixed?
- Corrects "The service workersfetch' event." to read "The service worker's fetch event."

**Target Live Date:** 2018-11-15

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
