### PR TITLE
[lighthouse] remove framebox

### DIFF
--- a/src/content/en/tools/lighthouse/audits/preload.md
+++ b/src/content/en/tools/lighthouse/audits/preload.md
@@ -62,18 +62,8 @@ as soon as possible.
   </figcaption>
 </figure>
 
-The table below lists browser support for preload links.
-
-{% framebox width="auto" height="auto" enable_widgets="true" %}
-  <p class="ciu_embed" data-feature="link-rel-preload"
-     data-periods="future_2,future_1,current,past_1,past_2"
-     data-accessible-colours="false">
-    See <a href="http://caniuse.com/#feat=link-rel-preload">Can I Use link-rel-preload?</a>
-    to see browser support for preload links.
-  </p>
-  <script src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed/caniuse-embed.min.js"
-          onload="devsite.framebox.AutoSizeClient.updateSize()"></script>
-{% endframebox %}
+See <a href="http://caniuse.com/#feat=link-rel-preload">Can I Use link-rel-preload?</a>
+to see browser support for preload links.
 
 ## More information {: #more-info }
 

--- a/src/content/en/tools/lighthouse/audits/preload.md
+++ b/src/content/en/tools/lighthouse/audits/preload.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Preload key requests" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2018-11-13 #}
 {# wf_published_on: 2018-03-28 #}
 {# wf_blink_components: Platform>DevTools #}
 


### PR DESCRIPTION
embedding the caniuse widget violates security policy

What's changed, or what was fixed?
- remove framebox and link to the page instead

**Fixes:** N/A

**Target Live Date:** 2018-11-13

- [x] This has been reviewed and approved by @kaycebasques 
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
