### PR TITLE
Switch localStorage to IDB in SW recommendations

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: TBD
 
-{# wf_updated_on: 2018-11-18 #}
+{# wf_updated_on: 2018-11-20 #}
 {# wf_published_on: 2018-11-22 #}
 {# wf_blink_components: UI>Browser>Mobile>Settings>DataSaver,Blink>Fonts,Blink>CSS,Blink>JavaScript #}
 
@@ -598,15 +598,12 @@ self.addEventListener("fetch", event => {
 });
 ```
 
-Warning: Because not all browsers support client hints, you’ll need to check
-what values `event.request.headers.get` returns. A possible alternative approach
-is to record JS equivalents such as
+Warning: Because not all browsers support client hints, you’ll need to check what values
+`event.request.headers.get` returns. A possible alternative approach is to record JS equivalents
+such as
 [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)
-or
-[`window.innerWidth`](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth)
-to
-[`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Storage/LocalStorage),
-which is accessible in the service worker scope.
+or [`window.innerWidth`](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth) to
+[`IndexedDB`](/web/ilt/pwa/working-with-indexeddb), which is accessible in the service worker scope.
 
 Any client hint header you opt into can be read in this fashion. Though that’s
 not the only way you can get some of this information. Network-specific hints

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -666,11 +666,10 @@ Hints](https://cloudinary.com/blog/automatic_responsive_images_with_client_hints
 - [Delivering Fast and Light Applications with
 `Save-Data`](/web/fundamentals/performance/optimizing-content-efficiency/save-data/)
 
-_Thank you to [Ilya Grigorik](https://twitter.com/igrigorik), [Eric
-Portis](https://twitter.com/etportis), [Yoav
-Weiss](https://twitter.com/yoavweiss), and [Estelle
-Weyl](https://twitter.com/estellevw) for their valuable feedback and edits on
-this article._
+_Thank you to [Ilya Grigorik](https://twitter.com/igrigorik), [Jeff
+Posnick](https://twitter.com/jeffposnick), [Eric Portis](https://twitter.com/etportis), [Yoav
+Weiss](https://twitter.com/yoavweiss), and [Estelle Weyl](https://twitter.com/estellevw) for their
+valuable feedback and edits on this article._
 
 ## Feedback {: #feedback .hide-from-toc }
 

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -666,8 +666,8 @@ Hints](https://cloudinary.com/blog/automatic_responsive_images_with_client_hints
 - [Delivering Fast and Light Applications with
 `Save-Data`](/web/fundamentals/performance/optimizing-content-efficiency/save-data/)
 
-_Thank you to [Ilya Grigorik](https://twitter.com/igrigorik), [Jeff
-Posnick](https://twitter.com/jeffposnick), [Eric Portis](https://twitter.com/etportis), [Yoav
+_Thank you to [Ilya Grigorik](https://twitter.com/igrigorik), [Eric
+Portis](https://twitter.com/etportis), [Jeff Posnick](https://twitter.com/jeffposnick), [Yoav
 Weiss](https://twitter.com/yoavweiss), and [Estelle Weyl](https://twitter.com/estellevw) for their
 valuable feedback and edits on this article._
 


### PR DESCRIPTION
R: @malchata @petele 

https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints/#client_hints_in_service_workers suggests using `localStorage` inside of a service worker, but it's actually not available there. `IndexedDB` should be used instead.