### PR TITLE
[devtools] make the ToC less wordy

### DIFF
--- a/src/content/en/tools/chrome-devtools/_toc.yaml
+++ b/src/content/en/tools/chrome-devtools/_toc.yaml
@@ -1,5 +1,5 @@
 toc:
-- title: Overview
+- title: Home
   path: /web/tools/chrome-devtools/
 - title: DevTools for Beginners
   section:
@@ -7,13 +7,13 @@ toc:
     path: /web/tools/chrome-devtools/beginners/html
   - title: CSS
     path: /web/tools/chrome-devtools/beginners/css
-- title: View and Change CSS
+- title: CSS
   section:
   - title: Get Started with Viewing and Changing CSS
     path: /web/tools/chrome-devtools/css/
   - title: CSS Reference
     path: /web/tools/chrome-devtools/css/reference
-- title: View and Change JavaScript
+- title: JavaScript
   section:
   - title: Get Started
     path: /web/tools/chrome-devtools/javascript/
@@ -40,11 +40,9 @@ toc:
     path: /web/tools/chrome-devtools/sources
   - title: Keyboard Shortcuts Reference
     path: /web/tools/chrome-devtools/shortcuts
-- title: Optimize Website Speed
-  path: /web/tools/chrome-devtools/speed/get-started
-- title: Accessibility Reference
+- title: Accessibility
   path: /web/tools/chrome-devtools/accessibility/reference
-- title: Simulate Mobile Devices with Device Mode
+- title: Simulate Mobile Devices
   section:
   - title: Overview
     path: /web/tools/chrome-devtools/device-mode/
@@ -54,7 +52,7 @@ toc:
     path: /web/tools/chrome-devtools/device-mode/device-input-and-sensors
   - title: Emulate and Test Other Browsers
     path: /web/tools/chrome-devtools/device-mode/testing-other-browsers
-- title: Remote-Debug Android Devices
+- title: Remote Debug Android Devices
   section:
   - title: Get Started
     path: /web/tools/chrome-devtools/remote-debugging/
@@ -62,7 +60,7 @@ toc:
     path: /web/tools/chrome-devtools/remote-debugging/local-server
   - title: Remote Debugging WebViews
     path: /web/tools/chrome-devtools/remote-debugging/webviews
-- title: Log Messages and Run JavaScript in the Console
+- title: Console
   section:
   - title: Overview
     path: /web/tools/chrome-devtools/console/
@@ -84,10 +82,12 @@ toc:
     path: /web/tools/chrome-devtools/console/events
   - title: Command Line Reference
     path: /web/tools/chrome-devtools/console/command-line-reference
-- title: Analyze Runtime Performance
+- title: Performance
   section:
   - title: Get Started
     path: /web/tools/chrome-devtools/evaluate-performance/
+  - title: Optimize Website Speed
+    path: /web/tools/chrome-devtools/speed/get-started
   - title: Overview
     path: /web/tools/chrome-devtools/rendering-tools/
   - title: Performance Analysis Reference
@@ -102,7 +102,7 @@ toc:
   - title: Diagnose Forced Synchronous Layouts
     path: /web/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts
     status: deprecated
-- title: Analyze Network Performance
+- title: Network
   section:
   - title: Get Started
     path: /web/tools/chrome-devtools/network-performance/
@@ -113,7 +113,7 @@ toc:
   - title: Resource Loading
     path: /web/tools/chrome-devtools/network-performance/resource-loading
     status: deprecated
-- title: Analyze Memory Problems
+- title: Memory
   section:
   - title: Overview
     path: /web/tools/chrome-devtools/memory-problems/
@@ -123,15 +123,15 @@ toc:
     path: /web/tools/chrome-devtools/memory-problems/heap-snapshots
   - title: Use the Allocation Profiler
     path: /web/tools/chrome-devtools/memory-problems/allocation-profiler
-- title: Save Changes To Disk With Workspaces
+- title: Workspaces
   path: /web/tools/chrome-devtools/workspaces/
-- title: Debug Progressive Web Apps
+- title: Progressive Web Apps
   path: /web/tools/chrome-devtools/progressive-web-apps
-- title: Analyze Security Problems
+- title: Security
   path: /web/tools/chrome-devtools/security
-- title: Run Snippets of JavaScript From Any Page
+- title: Snippets
   path: /web/tools/chrome-devtools/snippets
-- title: View and Change HTML
+- title: HTML
   section:
   - title: Overview
     path: /web/tools/chrome-devtools/inspect-styles/
@@ -142,7 +142,7 @@ toc:
   - title: Edit Styles
     path: /web/tools/chrome-devtools/inspect-styles/edit-styles
     status: deprecated
-- title: View and Change Storage and Resources
+- title: Storage and Resources
   section:
   - title: Inspect and Manage Storage, Databases, and Caches
     path: /web/tools/chrome-devtools/manage-data/local-storage


### PR DESCRIPTION
What's changed, or what was fixed?
- Removes words from the DevTools ToC to make it more skimmable

**Fixes:** N/A

**Target Live Date:** 2018-11-21

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
