### PR TITLE
add video to wndt71

### DIFF
--- a/src/content/en/updates/2018/10/devtools.md
+++ b/src/content/en/updates/2018/10/devtools.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Highlight DOM nodes from Live expressions, store nodes as global variables, and more.
 
-{# wf_updated_on: 2018-11-29 #}
+{# wf_updated_on: 2018-12-02 #}
 {# wf_published_on: 2018-10-10 #}
 {# wf_tags: chrome71,devtools,devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
@@ -20,6 +20,14 @@ New features and major changes coming to Chrome DevTools in Chrome 71 include:
 * [Initiator and priority information now in HAR imports and exports](#HAR)
 * [Access the Command Menu from the Main Menu](#command-menu)
 * [Picture-in-Picture breakpoints](#picture-in-picture)
+
+Read on, or watch the video version of this page:
+
+<div class="video-wrapper-full-width">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="fJxFZO8OEEs"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
 ## Hover over a Live Expression to highlight a DOM node {: #hover }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- add video version of WNDT71 to the page

**Fixes:** N/A

**Target Live Date:** 2018-12-02

- [x] This has been reviewed and approved by @kaycebasques
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
