### PR TITLE
add bonus tip to wndt71

### DIFF
--- a/src/content/en/updates/2018/10/devtools.md
+++ b/src/content/en/updates/2018/10/devtools.md
@@ -20,6 +20,7 @@ New features and major changes coming to Chrome DevTools in Chrome 71 include:
 * [Initiator and priority information now in HAR imports and exports](#HAR)
 * [Access the Command Menu from the Main Menu](#command-menu)
 * [Picture-in-Picture breakpoints](#picture-in-picture)
+* [(Bonus Tip) Run monitorEvents() in the Console to watch an element's events fire](#bonus)
 
 Read on, or watch the video version of this page:
 
@@ -183,6 +184,12 @@ fires. DevTools pauses on the first line of the handler.
     <b>Figure 16</b>. Picture-in-Picture events in the Event Listener Breakpoints pane
   </figcaption>
 </figure>
+
+## (Bonus Tip) Run monitorEvents() in the Console to watch an element's events fire {: #bonus }
+
+Suppose you wanted to add a red border around a button after focusing it and pressing `R`, `E`, `D`,
+but you don't know what events to add listeners to. Use `monitorEvents()` to log all of the
+element's events to the Console.
 
 ## Feedback {: #feedback }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- add monitorEvents bonus tip to the doc

**Fixes:** N/A

**Target Live Date:** 2018-12-03

- [x] This has been reviewed and approved by @kaycebasques 
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
