### PR TITLE
Replace autoplay with play()

### DIFF
--- a/src/content/en/updates/2018/10/watch-video-using-picture-in-picture.md
+++ b/src/content/en/updates/2018/10/watch-video-using-picture-in-picture.md
@@ -245,8 +245,9 @@ const canvas = document.createElement('canvas');
 canvas.getContext('2d').fillRect(0, 0, canvas.width, canvas.height);
 
 const video = document.createElement('video');
-video.autoplay = true;
+video.muted = true;
 video.srcObject = canvas.captureStream();
+video.play();
 
 // Later on, video.requestPictureInPicture();
 ```


### PR DESCRIPTION
According to https://chromium-review.googlesource.com/c/chromium/src/+/1353928, autoplay doesn't work on muted video that are not visible. This PR makes sure we document `play()` instead.

FYI @mounirlamouri