### PR TITLE
Fixing typo in documentation for network-only strategies.

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-strategies.md
+++ b/src/content/en/tools/workbox/modules/workbox-strategies.md
@@ -93,7 +93,7 @@ workbox.routing.registerRoute(
 ![Network Only Diagram](../images/modules/workbox-strategies/network-only.png)
 
 If you require specific requests to be fulfilled from the network, the
-[network first](/web/fundamentals/instant-and-offline/offline-cookbook/#network-only)
+[network only](/web/fundamentals/instant-and-offline/offline-cookbook/#network-only)
 is the strategy to use.
 
 ```javascript


### PR DESCRIPTION
As described in title.