### PR TITLE
Fix link in promises.md

### DIFF
--- a/src/content/en/fundamentals/primers/promises.md
+++ b/src/content/en/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: "Promises simplify deferred and asynchronous computations. A promise represents an operation that hasn't completed yet."
 
 {# wf_published_on: 2013-12-16 #}
-{# wf_updated_on: 2018-11-01 #}
+{# wf_updated_on: 2018-12-14 #}
 {# wf_blink_components: Blink>JavaScript #}
 
 # JavaScript Promises: an Introduction {: .page-title }
@@ -160,7 +160,7 @@ A promise can be:
 * **settled** - Has fulfilled or rejected
 
 
-[The spec](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects)
+[The spec](http://www.ecma-international.org/ecma-262/#sec-promise-objects)
 also uses the term **thenable** to describe an object that is promise-like,
 in that it has a `then` method. This term reminds me of ex-England Football
 Manager [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) so

--- a/src/content/en/fundamentals/primers/promises.md
+++ b/src/content/en/fundamentals/primers/promises.md
@@ -160,7 +160,7 @@ A promise can be:
 * **settled** - Has fulfilled or rejected
 
 
-[The spec](http://www.ecma-international.org/ecma-262/#sec-promise-objects)
+[The spec](https://www.ecma-international.org/ecma-262/#sec-promise-objects)
 also uses the term **thenable** to describe an object that is promise-like,
 in that it has a `then` method. This term reminds me of ex-England Football
 Manager [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) so

--- a/src/content/es/fundamentals/primers/promises.md
+++ b/src/content/es/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ Una promesa puede ser de estas clases:
 * **settled (finalizada)**: se completa o se rechaza.
 
 
-En [las especificaciones](http://www.ecma-international.org/ecma-262/#sec-promise-objects), también aparece el término **thenable** para describir un objeto parecido a una promesa porque tiene un método `then`. Este término me recuerda a [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables), un ex entrenador de fútbol de Inglaterra, así que lo usaré lo menos posible.
+En [las especificaciones](https://www.ecma-international.org/ecma-262/#sec-promise-objects), también aparece el término **thenable** para describir un objeto parecido a una promesa porque tiene un método `then`. Este término me recuerda a [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables), un ex entrenador de fútbol de Inglaterra, así que lo usaré lo menos posible.
 
 
 ## ¡Llegaron las promesas a JavaScript!

--- a/src/content/es/fundamentals/primers/promises.md
+++ b/src/content/es/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: "Las promesas simplifican cómputos diferidos y asincrónicos. Una promesa representa una operación que aún no se completó."
 
 {# wf_published_on: 2013-12-16 #}
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2018-12-14 #}
 
 # Promesas de JavaScript: introducción {: .page-title }
 
@@ -120,7 +120,7 @@ Una promesa puede ser de estas clases:
 * **settled (finalizada)**: se completa o se rechaza.
 
 
-En [las especificaciones](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects), también aparece el término **thenable** para describir un objeto parecido a una promesa porque tiene un método `then`. Este término me recuerda a [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables), un ex entrenador de fútbol de Inglaterra, así que lo usaré lo menos posible.
+En [las especificaciones](http://www.ecma-international.org/ecma-262/#sec-promise-objects), también aparece el término **thenable** para describir un objeto parecido a una promesa porque tiene un método `then`. Este término me recuerda a [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables), un ex entrenador de fútbol de Inglaterra, así que lo usaré lo menos posible.
 
 
 ## ¡Llegaron las promesas a JavaScript!

--- a/src/content/id/fundamentals/primers/promises.md
+++ b/src/content/id/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ Sebuah promise bisa berupa:
 * **settled** - sudah terlaksana atau ditolak
 
 
-[Spesifikasi](http://www.ecma-international.org/ecma-262/#sec-promise-objects) juga menggunakan istilah **thenable** untuk menjelaskan objek yang mirip promise, karena ia memiliki metode `then`. Istilah ini mengingatkan saya pada mantan Manajer Sepak Bola England [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) jadi saya akan menggunakannya sesedikit mungkin.
+[Spesifikasi](https://www.ecma-international.org/ecma-262/#sec-promise-objects) juga menggunakan istilah **thenable** untuk menjelaskan objek yang mirip promise, karena ia memiliki metode `then`. Istilah ini mengingatkan saya pada mantan Manajer Sepak Bola England [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) jadi saya akan menggunakannya sesedikit mungkin.
 
 
 ## Promise hadir di JavaScript!

--- a/src/content/id/fundamentals/primers/promises.md
+++ b/src/content/id/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: "Promise menyederhanakan komputasi yang ditangguhkan dan asinkron. Sebuah promise mewakili sebuah operasi yang belum selesai."
 
 {# wf_published_on: 2013-12-16 #}
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2018-12-14 #}
 
 # Promise JavaScript: Pengantar {: .page-title }
 
@@ -120,7 +120,7 @@ Sebuah promise bisa berupa:
 * **settled** - sudah terlaksana atau ditolak
 
 
-[Spesifikasi](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects) juga menggunakan istilah **thenable** untuk menjelaskan objek yang mirip promise, karena ia memiliki metode `then`. Istilah ini mengingatkan saya pada mantan Manajer Sepak Bola England [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) jadi saya akan menggunakannya sesedikit mungkin.
+[Spesifikasi](http://www.ecma-international.org/ecma-262/#sec-promise-objects) juga menggunakan istilah **thenable** untuk menjelaskan objek yang mirip promise, karena ia memiliki metode `then`. Istilah ini mengingatkan saya pada mantan Manajer Sepak Bola England [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) jadi saya akan menggunakannya sesedikit mungkin.
 
 
 ## Promise hadir di JavaScript!

--- a/src/content/ja/fundamentals/primers/promises.md
+++ b/src/content/ja/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: "Promise は、延期された非同期の計算を簡素化します。Promise はまだ完了していない操作を表します。"
 
 {# wf_published_on:2013-12-16 #}
-{# wf_updated_on:2014-01-29 #}
+{# wf_updated_on:2018-12-14 #}
 
 # JavaScript の Promise: 概要 {: .page-title }
 
@@ -120,7 +120,7 @@ Promise の状態は次のいずれかです。
 * **完了** - 解決または棄却された
 
 
-[仕様](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects)では、`then` メソッドを持っているという点で Promise に似ているオブジェクトを示すために **thenable** という用語も使用されています。この用語はイングランド サッカーの前のマネージャーである [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) を思い出させるので、できるだけ使わないようにします。
+[仕様](http://www.ecma-international.org/ecma-262/#sec-promise-objects)では、`then` メソッドを持っているという点で Promise に似ているオブジェクトを示すために **thenable** という用語も使用されています。この用語はイングランド サッカーの前のマネージャーである [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) を思い出させるので、できるだけ使わないようにします。
 
 
 ## JavaScript に Promise がやってきた

--- a/src/content/ja/fundamentals/primers/promises.md
+++ b/src/content/ja/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ Promise の状態は次のいずれかです。
 * **完了** - 解決または棄却された
 
 
-[仕様](http://www.ecma-international.org/ecma-262/#sec-promise-objects)では、`then` メソッドを持っているという点で Promise に似ているオブジェクトを示すために **thenable** という用語も使用されています。この用語はイングランド サッカーの前のマネージャーである [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) を思い出させるので、できるだけ使わないようにします。
+[仕様](https://www.ecma-international.org/ecma-262/#sec-promise-objects)では、`then` メソッドを持っているという点で Promise に似ているオブジェクトを示すために **thenable** という用語も使用されています。この用語はイングランド サッカーの前のマネージャーである [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables) を思い出させるので、できるだけ使わないようにします。
 
 
 ## JavaScript に Promise がやってきた

--- a/src/content/ko/fundamentals/primers/promises.md
+++ b/src/content/ko/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: '프라미스(promise)는 지연된 비동기 계산을 단순화합니다. 프라미스는 아직 완료되지 않은 작업을 나타냅니다.'
 
 {# wf_published_on: 2013-12-16 #}
-{# wf_updated_on: 2014-01-29 #}
+{# wf_updated_on: 2018-12-14 #}
 
 # 자바스크립트 프라미스: 소개 {: .page-title }
 
@@ -120,7 +120,7 @@ description: '프라미스(promise)는 지연된 비동기 계산을 단순화�
 * **해결됨(settled)** - 처리되거나 거부되었습니다.
 
 
-[사양](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects)에서도 **thenable**라는 용어를 사용하여, `then` 메서드를 포함한다는 점에서 프라미스와 유사한 객체를 설명합니다. 이 용어를 보면 영국 축구 감독을 역임한 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)가 떠올라서 가급적 이 용어를 사용하지 않을 것입니다.
+[사양](http://www.ecma-international.org/ecma-262/#sec-promise-objects)에서도 **thenable**라는 용어를 사용하여, `then` 메서드를 포함한다는 점에서 프라미스와 유사한 객체를 설명합니다. 이 용어를 보면 영국 축구 감독을 역임한 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)가 떠올라서 가급적 이 용어를 사용하지 않을 것입니다.
 
 
 ## 프라미스를 자바스크립트에 도입!

--- a/src/content/ko/fundamentals/primers/promises.md
+++ b/src/content/ko/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ description: '프라미스(promise)는 지연된 비동기 계산을 단순화�
 * **해결됨(settled)** - 처리되거나 거부되었습니다.
 
 
-[사양](http://www.ecma-international.org/ecma-262/#sec-promise-objects)에서도 **thenable**라는 용어를 사용하여, `then` 메서드를 포함한다는 점에서 프라미스와 유사한 객체를 설명합니다. 이 용어를 보면 영국 축구 감독을 역임한 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)가 떠올라서 가급적 이 용어를 사용하지 않을 것입니다.
+[사양](https://www.ecma-international.org/ecma-262/#sec-promise-objects)에서도 **thenable**라는 용어를 사용하여, `then` 메서드를 포함한다는 점에서 프라미스와 유사한 객체를 설명합니다. 이 용어를 보면 영국 축구 감독을 역임한 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)가 떠올라서 가급적 이 용어를 사용하지 않을 것입니다.
 
 
 ## 프라미스를 자바스크립트에 도입!

--- a/src/content/pt-br/fundamentals/primers/promises.md
+++ b/src/content/pt-br/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: "As promessas simplificam cálculos postergados e assíncronos. Uma promessa representa uma operação ainda não concluída."
 
 {# wf_published_on: 2013-12-16 #}
-{# wf_updated_on: 2014-01-29 #}
+{# wf_updated_on: 2018-12-14 #}
 
 # Promessas em JavaScript: uma introdução {: .page-title }
 
@@ -120,7 +120,7 @@ Uma promessa pode ser:
 * **definida** - a ação foi atendida ou rejeitada
 
 
-[A especificação](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects) também usa o termo **thenable** para descrever um objeto semelhante à promessa, no sentido de que tem um método `then`. Esse termo me lembra do ex-dirigente do futebol inglês, [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables). Por isso, vou usá-lo o menos possível.
+[A especificação](http://www.ecma-international.org/ecma-262/#sec-promise-objects) também usa o termo **thenable** para descrever um objeto semelhante à promessa, no sentido de que tem um método `then`. Esse termo me lembra do ex-dirigente do futebol inglês, [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables). Por isso, vou usá-lo o menos possível.
 
 
 ## As promessas chegaram ao JavaScript!

--- a/src/content/pt-br/fundamentals/primers/promises.md
+++ b/src/content/pt-br/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ Uma promessa pode ser:
 * **definida** - a ação foi atendida ou rejeitada
 
 
-[A especificação](http://www.ecma-international.org/ecma-262/#sec-promise-objects) também usa o termo **thenable** para descrever um objeto semelhante à promessa, no sentido de que tem um método `then`. Esse termo me lembra do ex-dirigente do futebol inglês, [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables). Por isso, vou usá-lo o menos possível.
+[A especificação](https://www.ecma-international.org/ecma-262/#sec-promise-objects) também usa o termo **thenable** para descrever um objeto semelhante à promessa, no sentido de que tem um método `then`. Esse termo me lembra do ex-dirigente do futebol inglês, [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables). Por isso, vou usá-lo o menos possível.
 
 
 ## As promessas chegaram ao JavaScript!

--- a/src/content/zh-cn/fundamentals/primers/promises.md
+++ b/src/content/zh-cn/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description:"Promise 可简化延迟和异步计算。Promise 代表一个尚未完成的操作。"
 
 {# wf_published_on:2013-12-16 #}
-{# wf_updated_on:2014-01-29 #}
+{# wf_updated_on:2018-12-14 #}
 
 # JavaScript Promise：简介 {: .page-title }
 
@@ -120,7 +120,7 @@ promise 可以是：
 * **已解决** - 已执行或拒绝
 
 
-[本规范](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects)还使用术语 **thenable** 来描述类似于 promise 的对象，并使用 `then` 方法。该术语让我想起前英格兰国家队教练 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我将尽可能不用这个术语。
+[本规范](http://www.ecma-international.org/ecma-262/#sec-promise-objects)还使用术语 **thenable** 来描述类似于 promise 的对象，并使用 `then` 方法。该术语让我想起前英格兰国家队教练 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我将尽可能不用这个术语。
 
 
 ##  Promise 在 JavaScript 中受支持！

--- a/src/content/zh-cn/fundamentals/primers/promises.md
+++ b/src/content/zh-cn/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ promise 可以是：
 * **已解决** - 已执行或拒绝
 
 
-[本规范](http://www.ecma-international.org/ecma-262/#sec-promise-objects)还使用术语 **thenable** 来描述类似于 promise 的对象，并使用 `then` 方法。该术语让我想起前英格兰国家队教练 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我将尽可能不用这个术语。
+[本规范](https://www.ecma-international.org/ecma-262/#sec-promise-objects)还使用术语 **thenable** 来描述类似于 promise 的对象，并使用 `then` 方法。该术语让我想起前英格兰国家队教练 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我将尽可能不用这个术语。
 
 
 ##  Promise 在 JavaScript 中受支持！

--- a/src/content/zh-tw/fundamentals/primers/promises.md
+++ b/src/content/zh-tw/fundamentals/primers/promises.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description:"Promise 可簡化延遲和異步計算。Promise 代表一個尚未完成的操作。"
 
 {# wf_published_on:2013-12-16 #}
-{# wf_updated_on:2014-01-29 #}
+{# wf_updated_on:2018-12-14 #}
 
 # JavaScript Promise：簡介 {: .page-title }
 
@@ -120,7 +120,7 @@ promise 可以是：
 * **已解決** - 已執行或拒絕
 
 
-[本規範](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects)還使用術語 **thenable** 來描述類似於 promise 的對象，並使用 `then` 方法。該術語讓我想起前英格蘭國家隊教練 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我將盡可能不用這個術語。
+[本規範](http://www.ecma-international.org/ecma-262/#sec-promise-objects)還使用術語 **thenable** 來描述類似於 promise 的對象，並使用 `then` 方法。該術語讓我想起前英格蘭國家隊教練 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我將盡可能不用這個術語。
 
 
 ##  Promise 在 JavaScript 中受支持！

--- a/src/content/zh-tw/fundamentals/primers/promises.md
+++ b/src/content/zh-tw/fundamentals/primers/promises.md
@@ -120,7 +120,7 @@ promise 可以是：
 * **已解決** - 已執行或拒絕
 
 
-[本規範](http://www.ecma-international.org/ecma-262/#sec-promise-objects)還使用術語 **thenable** 來描述類似於 promise 的對象，並使用 `then` 方法。該術語讓我想起前英格蘭國家隊教練 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我將盡可能不用這個術語。
+[本規範](https://www.ecma-international.org/ecma-262/#sec-promise-objects)還使用術語 **thenable** 來描述類似於 promise 的對象，並使用 `then` 方法。該術語讓我想起前英格蘭國家隊教練 [Terry Venables](https://en.wikipedia.org/wiki/Terry_Venables)，因此我將盡可能不用這個術語。
 
 
 ##  Promise 在 JavaScript 中受支持！


### PR DESCRIPTION
In the [promises.md](https://github.com/google/WebFundamentals/blob/master/src/content/en/fundamentals/primers/promises.md) file in the paragraph [Promise terminology](https://github.com/google/WebFundamentals/blob/master/src/content/en/fundamentals/primers/promises.md#promise-terminology--promise-terminology-):

>**The spec** also uses the term thenable to describe an object that is promise-like

**Link broken:**

https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects

**Replaced for:**

http://www.ecma-international.org/ecma-262/#sec-promise-objects

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
