### PR TITLE
Add feedback widget

### DIFF
--- a/src/content/en/updates/2016/08/removing-document-write.md
+++ b/src/content/en/updates/2016/08/removing-document-write.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Chrome is blocking some scripts that are added using document.write()
 
-{# wf_updated_on: 2016-12-02 #}
+{# wf_updated_on: 2018-12-14 #}
 {# wf_published_on: 2016-08-29 #}
 {# wf_tags: interventions,chrome55 #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
@@ -195,5 +195,8 @@ To learn more, see these additional resources:
 * [Additional rationale for this effort](https://docs.google.com/document/d/1dMJRQKTw75ZNdknP3pirSBH3koPl_IWHnxlcBuu4t_c/preview)
 * [blink-dev Intent to implement thread](https://groups.google.com/a/chromium.org/d/topic/blink-dev/HGh92uMX_kE/discussion)
 
+## Feedback {: #feedback }
+
+{% include "web/_shared/helpful.html" %}
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- adds the "was this page helpful?" feedback widget to the document.write() intervention doc

**Fixes:** N/A

**Target Live Date:** 2018-12-31

- [x] This has been reviewed and approved by @kaycebasques
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
