### PR TITLE
Clarify how FCP is measured.

### DIFF
--- a/src/content/en/tools/lighthouse/audits/first-contentful-paint.md
+++ b/src/content/en/tools/lighthouse/audits/first-contentful-paint.md
@@ -19,9 +19,9 @@ description: Reference documentation for the "First Contentful Paint" Lighthouse
   <p>--- <a class="external" href="https://w3c.github.io/paint-timing/">Paint Timing spec</a></p>
 </blockquote>
 
-First Contentful Paint (FCP) marks the point, immediately after navigation, when the browser renders
-the first bit of content from the DOM. This is an important milestone for users because
-it provides feedback that the page is actually loading.
+First Contentful Paint (FCP) measures the time from navigation to the time when the browser renders the
+first bit of content from the DOM. This is an important milestone for users because it provides 
+feedback that the page is actually loading.
 
 ## Recommendations {: #recommendations }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Clarify in the docs that FCP is measured from the time navigation starts as opposed to being a point in time.

**Fixes:** N/A

**Target Live Date:** 2018-12-18

- [x] This has been reviewed and approved by @kaycebasques 
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
