### PR TITLE
Fix typo in contributors

### DIFF
--- a/src/data/_contributors.yaml
+++ b/src/data/_contributors.yaml
@@ -1064,7 +1064,7 @@ plegner:
   role:
     - engineer
   description:
-    en: Software Engineer at Gogole
+    en: Software Engineer at Google
   org:
     name: Google
     unit: Software Engineer


### PR DESCRIPTION
Simple typo fix in `_contributors.yaml`