### PR TITLE
fix #6959

### DIFF
--- a/gulp-tasks/tests/projectYaml.js
+++ b/gulp-tasks/tests/projectYaml.js
@@ -77,6 +77,16 @@ const SCHEMA_PROJECT = {
       },
       additionalProperties: false,
     },
+    feedback: {
+      type: 'object',
+      properties: {
+        product_id: {
+          type: 'number',
+          required: true,
+        },
+      },
+      additionalProperties: false,
+    },
   },
   additionalProperties: false,
 };

--- a/src/content/en/_project.yaml
+++ b/src/content/en/_project.yaml
@@ -6,6 +6,8 @@ is_family_root: true
 color: google-blue
 content_license: cc3-apache2
 footer_path: /web/_footer.yaml
+feedback:
+  product_id: 5101932
 icon:
   path: /web/images/web-fundamentals-icon192x192.png
 google_analytics_ids:


### PR DESCRIPTION
What's changed, or what was fixed?

- enables the freeform feedback widget

FYI this PR is theoretically supposed to enable a "Send Feedback" button on the top-right of every docs page. During staging it didn't look like that feature was working. I think there may be some more configuration needed in `_book.yaml`. But I don't care much about that at the moment. What I do care about is that this PR lays the foundation for us to open the freeform feedback widget when users respond to the "was this page helpful?" widget. I will update the "was this page helpful?" code in a subsequent PR.

**Fixes:** #6959

**Target Live Date:** 2019-01-01

- [ ] This has been reviewed and approved by @petele
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
