### PR TITLE
Fixes #6582

### DIFF
--- a/src/content/es/fundamentals/primers/service-workers/registration.md
+++ b/src/content/es/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Prácticas recomendadas para saber cuándo registrar un service worker.
 
-{# wf_updated_on: 2016-11-28 #}
+{# wf_updated_on: 2018-12-21 #}
 {# wf_published_on: 2016-11-28 #}
 
 # Registro de los service workers {: .page-title }
@@ -154,8 +154,8 @@ marcar el momento del registro: Ambas capturas de pantalla se toman cuando se vi
 ejemplo](https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo)
 en modo incógnito con limitación de red para simular una conexión lenta.
 
-![Tráfico de red con registro temprano.](../images/early-registration.png
-"Network traffic with early registration.")
+![Tráfico de red con registro temprano.](images/early-registration.png
+"Tráfico de red con registro temprano.")
 
 La imagen anterior muestra el tráfico de red cuando se modificó la muestra
 para realizar el registro del service worker lo antes posible. Puedes ver
@@ -164,8 +164,8 @@ de engranaje](http://stackoverflow.com/questions/33590378/status-code200-ok-from
 que provienen del controlador de `install` del service worker)
 mezcladas con las solicitudes de otros recursos necesarios para mostrar la página.
 
-![Tráfico de red con registro tardío.](../images/late-registration.png
-"Network traffic with late registration.")
+![Tráfico de red con registro tardío.](images/late-registration.png
+"Tráfico de red con registro tardío.")
 
 
 En la captura de pantalla anterior, se demoró el registro del service worker hasta después de cargar

--- a/src/content/id/fundamentals/primers/service-workers/registration.md
+++ b/src/content/id/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Praktik terbaik untuk pengaturan waktu pendaftaran service worker Anda.
 
-{# wf_updated_on: 2016-11-28 #}
+{# wf_updated_on: 2018-12-21 #}
 {# wf_published_on: 2016-11-28 #}
 
 # Pendaftaran Service Worker {: .page-title }
@@ -154,8 +154,8 @@ pengaturan waktu pendaftaran. Kedua tangkapan layar diambil saat mengunjungi seb
 contoh](https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo) dalam mode
 Penyamaran dengan menggunakan throttling jaringan untuk menyimulasikan koneksi yang lambat.
 
-![Lalu lintas jaringan pada pendaftaran dini.](../images/early-registration.png
-"Network traffic with early registration.")
+![Lalu lintas jaringan pada pendaftaran dini.](images/early-registration.png
+"Lalu lintas jaringan pada pendaftaran dini.")
 
 Tangkapan layar di atas mencerminkan lalu lintas jaringan bila contoh dimodifikasi
 untuk melakukan pendaftaran service worker sesegera mungkin. Anda bisa melihat
@@ -164,8 +164,8 @@ roda gigi](http://stackoverflow.com/questions/33590378/status-code200-ok-from-se
 di sebelahnya, berasal dari penangan `install` service worker)
 diselingi dengan permintaan akan sumber daya lain yang dibutuhkan untuk menampilkan laman.
 
-![Lalu lintas jaringan dengan pendaftaran terlambat.](../images/late-registration.png
-"Network traffic with late registration.")
+![Lalu lintas jaringan dengan pendaftaran terlambat.](images/late-registration.png
+"Lalu lintas jaringan dengan pendaftaran terlambat.")
 
 
 Dalam tangkapan layar di atas, pendaftaran service worker ditunda hingga setelah

--- a/src/content/ko/fundamentals/primers/service-workers/registration.md
+++ b/src/content/ko/fundamentals/primers/service-workers/registration.md
@@ -154,7 +154,8 @@ description: 서비스 워커 등록 타이밍 관련 모범 사례
 방문하는 동안 네트워크 제한을 통해
 느린 연결을 시뮬레이션하여 촬영했습니다.
 
-<img alt="일찍 등록한 경우의 네트워크 트래픽" src="images/early-registration.png" data-tooltip-align="b,c" data-tooltip="일찍 등록한 경우의 네트워크 트래픽" aria-label="일찍 등록한 경우의 네트워크 트래픽" data-title="일찍 등록한 경우의 네트워크 트래픽">
+![일찍 등록한 경우의 네트워크 트래픽](images/early-registration.png
+"일찍 등록한 경우의 네트워크 트래픽트래픽")
 
 위의 스크린샷은 서비스 워커 등록을 가급적 빨리 수행하도록
 샘플을 수정한 경우의 네트워크 트래픽을 반영합니다. 페이지를
@@ -163,7 +164,8 @@ description: 서비스 워커 등록 타이밍 관련 모범 사례
 나온, [기어 아이콘](http://stackoverflow.com/questions/33590378/status-code200-ok-from-serviceworker-in-chrome-network-devtools/33655173#33655173)이 옆에 표시된 항목)을
 볼 수 있습니다.
 
-<img alt="늦게 등록한 경우의 네트워크 트래픽" src="images/late-registration.png" data-tooltip-align="b,c" data-tooltip="늦게 등록한 경우의 네트워크 트래픽" aria-label="늦게 등록한 경우의 네트워크 트래픽" data-title="늦게 등록한 경우의 네트워크 트래픽">
+![늦게 등록한 경우의 네트워크 트래픽](images/late-registration.png
+"늦게 등록한 경우의 네트워크 트래픽")
 
 위의 스크린샷에서 서비스 워커 등록은 페이지가 로드된 이후까지
 연기되었습니다. 네트워크에서 모든 자원을 가져올 때까지 사전 캐싱 요청은

--- a/src/content/ko/fundamentals/primers/service-workers/registration.md
+++ b/src/content/ko/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: 서비스 워커 등록 타이밍 관련 모범 사례
 
-{# wf_updated_on: 2016-11-28 #}
+{# wf_updated_on: 2018-12-21 #}
 {# wf_published_on: 2016-11-28 #}
 
 # 서비스 워커 등록 {: .page-title }
@@ -154,8 +154,7 @@ description: 서비스 워커 등록 타이밍 관련 모범 사례
 방문하는 동안 네트워크 제한을 통해
 느린 연결을 시뮬레이션하여 촬영했습니다.
 
-![일찍 등록한 경우의 네트워크 트래픽](../images/early-registration.png
-"Network traffic with early registration.")
+<img alt="일찍 등록한 경우의 네트워크 트래픽" src="images/early-registration.png" data-tooltip-align="b,c" data-tooltip="일찍 등록한 경우의 네트워크 트래픽" aria-label="일찍 등록한 경우의 네트워크 트래픽" data-title="일찍 등록한 경우의 네트워크 트래픽">
 
 위의 스크린샷은 서비스 워커 등록을 가급적 빨리 수행하도록
 샘플을 수정한 경우의 네트워크 트래픽을 반영합니다. 페이지를
@@ -164,9 +163,7 @@ description: 서비스 워커 등록 타이밍 관련 모범 사례
 나온, [기어 아이콘](http://stackoverflow.com/questions/33590378/status-code200-ok-from-serviceworker-in-chrome-network-devtools/33655173#33655173)이 옆에 표시된 항목)을
 볼 수 있습니다.
 
-![늦게 등록한 경우의 네트워크 트래픽](../images/late-registration.png
-"Network traffic with late registration.")
-
+<img alt="늦게 등록한 경우의 네트워크 트래픽" src="images/late-registration.png" data-tooltip-align="b,c" data-tooltip="늦게 등록한 경우의 네트워크 트래픽" aria-label="늦게 등록한 경우의 네트워크 트래픽" data-title="늦게 등록한 경우의 네트워크 트래픽">
 
 위의 스크린샷에서 서비스 워커 등록은 페이지가 로드된 이후까지
 연기되었습니다. 네트워크에서 모든 자원을 가져올 때까지 사전 캐싱 요청은

--- a/src/content/pt-br/fundamentals/primers/service-workers/registration.md
+++ b/src/content/pt-br/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Práticas recomendadas para determinar o momento de registro dos service workers.
 
-{# wf_updated_on: 2016-11-28 #}
+{# wf_updated_on: 2018-12-21 #}
 {# wf_published_on: 2016-11-28 #}
 
 # Registro dos service workers {: .page-title }
@@ -154,8 +154,8 @@ fazer. As duas capturas de tela foram obtidas durante o acesso a um [aplicativo
 de exemplo](https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo)
 no modo de navegação anônima usando limitação de rede para simular uma conexão lenta.
 
-![Tráfego de rede com o registro antes.](../images/early-registration.png
-"Network traffic with early registration.")
+![Tráfego de rede com o registro antes.](images/early-registration.png
+"Tráfego de rede com o registro antes.")
 
 A captura de tela acima reflete o tráfego de rede quando o exemplo foi  modificado
 para realizar o registro do service worker o quanto antes. É possível identificar
@@ -164,8 +164,8 @@ de engrenagem](http://stackoverflow.com/questions/33590378/status-code200-ok-fro
 originadas pelo gerenciador de `install` do service worker)
 intercaladas com solicitações de outros recursos necessários para exibir a página.
 
-![Tráfego de rede com registro depois.](../images/late-registration.png
-"Network traffic with late registration.")
+![Tráfego de rede com registro depois.](images/late-registration.png
+"Tráfego de rede com registro depois.")
 
 
 Na captura de tela acima, o registro do service worker foi adiado até que a

--- a/src/content/zh-cn/fundamentals/primers/service-workers/registration.md
+++ b/src/content/zh-cn/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description:确定服务工作线程注册时间的最佳做法。
 
-{# wf_updated_on:2016-11-28 #}
+{# wf_updated_on:2018-12-21 #}
 {# wf_published_on:2016-11-28 #}
 
 # 服务工作线程注册 {: .page-title }
@@ -110,8 +110,8 @@ description:确定服务工作线程注册时间的最佳做法。
 
 
 
-![尽早注册时的网络流量。](../images/early-registration.png
-"Network traffic with early registration.")
+![尽早注册时的网络流量。](images/early-registration.png
+"尽早注册时的网络流量。")
 
 上面的屏幕截图反映了修改示例以尽快执行服务工作线程注册时的网络流量。
 您可以看到预缓存请求（旁边带有[齿轮图标](http://stackoverflow.com/questions/33590378/status-code200-ok-from-serviceworker-in-chrome-network-devtools/33655173#33655173)的条目，源自服务工作线程的 `install` 处理程序）与针对显示页面所需的其他资源的请求分散排列。
@@ -120,8 +120,8 @@ description:确定服务工作线程注册时间的最佳做法。
 
 
 
-![延迟注册时的网络流量。](../images/late-registration.png
-"Network traffic with late registration.")
+![延迟注册时的网络流量。](images/late-registration.png
+"延迟注册时的网络流量。")
 
 
 在上面的屏幕截图中，延迟服务工作线程注册直到页面已加载。

--- a/src/content/zh-tw/fundamentals/primers/service-workers/registration.md
+++ b/src/content/zh-tw/fundamentals/primers/service-workers/registration.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description:確定服務工作線程註冊時間的最佳做法。
 
-{# wf_updated_on:2016-11-28 #}
+{# wf_updated_on:2018-12-21 #}
 {# wf_published_on:2016-11-28 #}
 
 # 服務工作線程註冊 {: .page-title }
@@ -110,8 +110,8 @@ description:確定服務工作線程註冊時間的最佳做法。
 
 
 
-![儘早註冊時的網絡流量。](../images/early-registration.png
-"Network traffic with early registration.")
+![儘早註冊時的網絡流量。](images/early-registration.png
+"儘早註冊時的網絡流量。")
 
 上面的屏幕截圖反映了修改示例以儘快執行服務工作線程註冊時的網絡流量。
 您可以看到預緩存請求（旁邊帶有[齒輪圖標](http://stackoverflow.com/questions/33590378/status-code200-ok-from-serviceworker-in-chrome-network-devtools/33655173#33655173)的條目，源自服務工作線程的 `install` 處理程序）與針對顯示頁面所需的其他資源的請求分散排列。
@@ -120,8 +120,8 @@ description:確定服務工作線程註冊時間的最佳做法。
 
 
 
-![延遲註冊時的網絡流量。](../images/late-registration.png
-"Network traffic with late registration.")
+![延遲註冊時的網絡流量。](images/late-registration.png
+"延遲註冊時的網絡流量。")
 
 
 在上面的屏幕截圖中，延遲服務工作線程註冊直到頁面已加載。


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes image url (fundamentals/primers/service-workers/registration) for ko, es, id, pt-br, zh-cn, zh-tw

**Fixes:** #6582

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
