### PR TITLE
#7035 | escape single quote

### DIFF
--- a/src/content/en/ilt/pwa/introduction-to-push-notifications.md
+++ b/src/content/en/ilt/pwa/introduction-to-push-notifications.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/ilt/pwa/_book.yaml
 
 {# wf_auto_generated #}
-{# wf_updated_on: 2018-07-02 #}
+{# wf_updated_on: 2018-12-28 #}
 {# wf_published_on: 2016-01-01 #}
 
 
@@ -379,7 +379,7 @@ That completes the path from server push to user notification. Let's look at eac
 
 Let's see how the service worker handles push messages. The service worker both receives the push message and creates the notification.
 
-When a  [browser that supports push messages](http://caniuse.com/#search=notification) receives a message, it sends a `push` event to the service worker. We can create a `push` event listener in the service worker to handle the message:
+When a  [browser that supports push messages](https://caniuse.com/#search=notification) receives a message, it sends a `push` event to the service worker. We can create a `push` event listener in the service worker to handle the message:
 
 #### serviceworker.js
 
@@ -580,7 +580,7 @@ self.addEventListener('push', function(e) {
     actions: [
       {action: 'explore', title: 'Explore this new world',
         icon: 'images/checkmark.png'},
-      {action: 'close', title: 'I don't want any of this',
+      {action: 'close', title: 'I don\'t want any of this',
         icon: 'images/xmark.png'},
     ]
   };


### PR DESCRIPTION
What's changed, or what was fixed?
- escaping `'`
- making caniuse https

**Fixes:** #7035

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
