### PR TITLE
Update 203 show listing

### DIFF
--- a/src/content/en/shows/_book.yaml
+++ b/src/content/en/shows/_book.yaml
@@ -24,7 +24,8 @@ upper_tabs:
         - title: A11ycasts with Rob Dodson
           path: https://www.youtube.com/playlist?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g
           status: external
-        - include: /web/shows/http203/_toc.yaml
+        - title: HTTP203
+          path: /web/shows/http203
         - include: /web/shows/supercharged/_toc.yaml
         - title: Developer Diary with Paul Lewis
           path: https://www.youtube.com/playlist?list=PLNYkxOF6rcIBykcJ7bvTpqU7vt-oey72J

--- a/src/content/en/shows/http203/index.md
+++ b/src/content/en/shows/http203/index.md
@@ -1,17 +1,17 @@
 project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
-description: HTTP 203 - Where do we start. In each show Jake and Paul pick a hot topic in the world of web development and discuss the various aspects of it, meanwhile dropping in lifehacks, lessons and some rather honest truths.
+description: HTTP 203 - Where do we start. Jake and Surma talk about web development. Or they are supposed to. No topic seems to be off-topic.
 
-{# wf_updated_on: 2016-08-24 #}
+{# wf_blink_components: N/A #}
+{# wf_updated_on: 2019-01-04 #}
 {# wf_published_on: 2016-08-24 #}
 
 # HTTP 203 {: .page-title }
 
-<img src="../imgs/http203_rect.jpg" class="attempt-right">
+<img src="/web/shows/http203/podcast/images/surma-and-jake-2.jpg" class="attempt-right">
 
-**Where do we start?** In each show Jake and Paul pick a hot topic in the
-world of web development and discuss the various aspects of it, meanwhile
-dropping in lifehacks, lessons and some rather honest truths.
+**Where do we start?** Jake and Surma talk about web development. Or they are
+supposed to. No topic seems to be off-topic.
 
 [YouTube](https://www.youtube.com/playlist?list=PLNYkxOF6rcIAKIQFsNbV0JDws_G_bnNo9)
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Remove the stale listing of episodes in the sidebar
- Update the text and image on the 203 title page 

**Target Live Date:** Whenever

- [ ] This has been reviewed and approved by (@jakearchibald )
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.
