### PR TITLE
June 2011 link updates

### DIFF
--- a/src/content/en/updates/2011/06/Contra-in-HTML5-Web-Audio-API.md
+++ b/src/content/en/updates/2011/06/Contra-in-HTML5-Web-Audio-API.md
@@ -1,18 +1,19 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-06-26 #}
+{# wf_updated_on: 2019-01-08 #}
 {# wf_published_on: 2011-06-26 #}
 {# wf_tags: news,webaudio #}
+{# wf_blink_components: N/A #}
 
 # Contra in HTML5 + Web Audio API {: .page-title }
 
 {% include "web/_shared/contributors/ericbidelman.html" %}
 
 
-Thanks to the power of GWT, HTML5, and the [Web Audio API](https://chromium.googlecode.com/svn/trunk/samples/audio/specification/specification.html) we can build the originator of everyone's favorite cheat code, Contra: [http://nes-sound.brad-rydzewski.appspot.com/](http://nes-sound.brad-rydzewski.appspot.com/)
+Thanks to the power of GWT, HTML5, and the [Web Audio API](https://www.w3.org/2011/audio/drafts/1WD/WebAudio/) we can build the originator of everyone's favorite cheat code, Contra: [https://github.com/bradrydzewski/gwt-nes-port](https://github.com/bradrydzewski/gwt-nes-port)
 
-Check out the open source NES Emulator in HTML5, [gwt-nes-port](https://code.google.com/p/gwt-nes-port/).
+Check out the open source NES Emulator in HTML5, [gwt-nes-port](https://github.com/bradrydzewski/gwt-nes-port).
 
 
 

--- a/src/content/en/updates/2011/06/HTML5-Libraries-Late-June.md
+++ b/src/content/en/updates/2011/06/HTML5-Libraries-Late-June.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-06-28 #}
+{# wf_updated_on: 2019-01-08 #}
 {# wf_published_on: 2011-06-28 #}
 {# wf_tags: news,canvas,css #}
+{# wf_blink_components: N/A #}
 
 # HTML5 Libraries - Late June {: .page-title }
 
@@ -12,9 +13,9 @@ book_path: /web/updates/_book.yaml
 
 Some exciting libraries have cropped up lately:
 
-<a href="http://paperjs.org/">Paper.js</a> - a vector graphics scripting framework that runs on top of &lt;canvas>. It is based on and largely compatible with <a href="http://scriptographer.org" target="_blank">Scriptographer</a>, a scripting environment for Adobe Illustrator. If you've ever wanted an object model to sit above canvas, take a peek.
+<a href="http://paperjs.org/">Paper.js</a> - a vector graphics scripting framework that runs on top of &lt;canvas>. It is based on and largely compatible with <a href="https://scriptographer.org/" target="_blank">Scriptographer</a>, a scripting environment for Adobe Illustrator. If you've ever wanted an object model to sit above canvas, take a peek.
 
-<a href="http://rpgjs.com/">RPG JS</a> - a role playing game framework for 2D games that leverages <a href="http://easeljs.com/">EaselJS</a> for its scene graph. Can use many <a href="http://www.rpgmakerweb.com/product/rpg-maker-xp">RPG Maker XP</a> assets to get a quick head start.
+<a href="https://github.com/RSamaium/RPG-JS">RPG JS</a> - a role playing game framework for 2D games that leverages <a href="https://www.createjs.com/easeljs">EaselJS</a> for its scene graph. Can use many <a href="http://www.rpgmakerweb.com/product/rpg-maker-xp">RPG Maker XP</a> assets to get a quick head start.
 
 <a href="http://www.idangero.us/cs/">Chop Slider</a> - making heavy use of CSS transitions and effects to get impressive transitions between states.
 

--- a/src/content/en/updates/2011/06/Page-Visibility-API-Have-I-got-your-attention.md
+++ b/src/content/en/updates/2011/06/Page-Visibility-API-Have-I-got-your-attention.md
@@ -1,20 +1,21 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-06-27 #}
+{# wf_updated_on: 2019-01-08 #}
 {# wf_published_on: 2011-06-27 #}
 {# wf_tags: news,pagevisibility #}
+{# wf_blink_components: N/A #}
 
 # Page Visibility API: Have I got your attention?  {: .page-title }
 
 {% include "web/_shared/contributors/mikemahemoff.html" %}
 
 
-Multi-tab browsing is now the norm, so you can't assume the user is watching your app just because it's running. Fortunately, the new [Page Visibility API](http://code.google.com/chrome/whitepapers/pagevisibility.html) lets your app discover if it's visible or not. You could use the API to cut down on unnecessary network activity and computation.
+Multi-tab browsing is now the norm, so you can't assume the user is watching your app just because it's running. Fortunately, the new [Page Visibility API](https://www.w3.org/TR/page-visibility/?csw=1) lets your app discover if it's visible or not. You could use the API to cut down on unnecessary network activity and computation.
 
 `document.webkitHidden` is a boolean value indicating if the current page is hidden (you can try it now in the console if you're using a recent build of Chromium). `document.webkitVisibilityState` will return a string indicating the current state, one of `visible`, `hidden`, and `prerendered`. And a new `webkitvisibilitychange` event will fire when any of these changes, e.g. when the user opens you app's tab, or moves away from it.
 
-If you're interested in giving this a whirl, check out <a href="https://github.com/evilmartians/visibility.js">visibility.js</a> which adds a little bit of sugar on the API to make watching these interactions a bit more fun.
+If you're interested in giving this a whirl, check out <a href="https://github.com/ai/visibilityjs">visibility.js</a> which adds a little bit of sugar on the API to make watching these interactions a bit more fun.
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/06/Registering-a-custom-protocol-handler.md
+++ b/src/content/en/updates/2011/06/Registering-a-custom-protocol-handler.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-06-29 #}
+{# wf_updated_on: 2019-01-08 #}
 {# wf_published_on: 2011-06-29 #}
 {# wf_tags: news,registerprotocolhandler #}
+{# wf_blink_components: N/A #}
 
 # Registering a custom protocol handler {: .page-title }
 
@@ -17,19 +18,19 @@ Register a protocol scheme like:
 
     navigator.registerProtocolHandler(
         'web+mystuff', 'http://example.com/rph?q=%s', 'My App');
-    
+
 
 The first parameter is the protocol. The second is the URL pattern of the application that should handle this scheme. The pattern should include a '%s' as a placeholder for data and it must must be on the same origin as the app attempting to register the protocol. Once the user approves access, you can use this link through your app, other sites, etc.:
 
 
     <a href="web+mystuff:some+data">Open in "My App"</a>
-    
+
 
 Clicking that link makes a `GET` request to `http://example.com/rph?q=web%2Bmystuff%3A:some%20data`. Thus, you have to parse `q` parameter and manually strip out data from the protocol.
 
 It's worth noting that Firefox has had `navigator.registerProtocolHandler` implemented since FF3. One difference in Chrome's implementation is around custom protocols. Those need to be prefixed with "web+", as seen in the example above.  The following protocols do not need a "web+" prefix: "mailto", "mms", "nntp", "rtsp", "webcal".
 
-More information on this API can be found on the [MDN article](https://developer.mozilla.org/En/DOM/Window.navigator.registerProtocolHandler).
+More information on this API can be found on the [MDN article](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler).
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/06/Welcome-to-updates-html5rocks-com.md
+++ b/src/content/en/updates/2011/06/Welcome-to-updates-html5rocks-com.md
@@ -1,20 +1,21 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-06-22 #}
+{# wf_updated_on: 2019-01-08 #}
 {# wf_published_on: 2011-06-22 #}
 {# wf_tags: news #}
+{# wf_blink_components: N/A #}
 
 # Welcome to updates.html5rocks.com! {: .page-title }
 
 {% include "web/_shared/contributors/ericbidelman.html" %}
 
 
-The open web platform is changing at an ever increasing rate. Many developers find it hard to keep up with the pace the browsers are implementing new HTML5 features, including ourselves. There are a ton of new APIs, demos, libraries, and announcements, every day. 
+The open web platform is changing at an ever increasing rate. Many developers find it hard to keep up with the pace the browsers are implementing new HTML5 features, including ourselves. There are a ton of new APIs, demos, libraries, and announcements, every day.
 
-In an effort to info developers quicker, we've built this "HTML5 Update Stream" to highlight the cool things worth sharing. At first, the updates will include new tutorials on HTML5Rocks, demos we find, and Chromium updates. Over time, we hope to automagically aggregate more stuff. 
+In an effort to info developers quicker, we've built this "HTML5 Update Stream" to highlight the cool things worth sharing. At first, the updates will include new tutorials on HTML5Rocks, demos we find, and Chromium updates. Over time, we hope to automagically aggregate more stuff.
 
-Posts in the stream will contain more content than a Tweet but less than a blog post. Look out for useful code snippets, screenshots, demo links, and more! 
+Posts in the stream will contain more content than a Tweet but less than a blog post. Look out for useful code snippets, screenshots, demo links, and more!
 
 Cheers,
 

--- a/src/content/en/updates/2011/06/navigator-onLine-in-Chrome-Dev-channel.md
+++ b/src/content/en/updates/2011/06/navigator-onLine-in-Chrome-Dev-channel.md
@@ -1,16 +1,17 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-06-23 #}
+{# wf_updated_on: 2019-01-08 #}
 {# wf_published_on: 2011-06-23 #}
 {# wf_tags: news,offline #}
+{# wf_blink_components: N/A #}
 
 # navigator.onLine in Chrome Dev channel {: .page-title }
 
 {% include "web/_shared/contributors/ericbidelman.html" %}
 
 
-With the [offline APIs](http://www.html5rocks.com/features/offline) in HTML5, there's no excuse not to provide a flawless offline experience for users. One thing that can help this story is the `navigator.onLine` property; a feature that recently landed in Chrome dev channel. This property returns `true` or `false` depending on whether or not the app has network connectivity:
+With the [offline APIs](https://www.html5rocks.com/en/features/offline) in HTML5, there's no excuse not to provide a flawless offline experience for users. One thing that can help this story is the `navigator.onLine` property; a feature that recently landed in Chrome dev channel. This property returns `true` or `false` depending on whether or not the app has network connectivity:
 
 
     if (navigator.onLine) {
@@ -18,7 +19,7 @@ With the [offline APIs](http://www.html5rocks.com/features/offline) in HTML5, th
     } else {
       console.log('Connection flaky');
     }
-    
+
 
 A web app can also listen for `online` and `offline` events to determine when the connection is available again or when an app goes offline:
 
@@ -26,13 +27,13 @@ A web app can also listen for `online` and `offline` events to determine when th
     window.addEventListener('online', function(e) {
       // Re-sync data with server.
     }, false);
-    
+
     window.addEventListener('offline', function(e) {
       // Queue up events for server.
     }, false);
-    
 
-I've posted a working demo at [http://html5-demos.appspot.com/static/navigator.onLine.html](http://html5-demos.appspot.com/static/navigator.onLine.html) and more information on offline events can be found in the [MDN](https://developer.mozilla.org/en/Online_and_offline_events).
+
+I've posted a working demo at [http://html5-demos.appspot.com/static/navigator.onLine.html](http://html5-demos.appspot.com/static/navigator.onLine.html) and more information on offline events can be found in the [MDN](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events).
 
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed links from the month of June 2011.
- Adding missing wf_blink_components: tags

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
