### PR TITLE
July 2011 link updates

### DIFF
--- a/src/content/en/updates/2011/07/Announcing-New-Game-the-conference-for-HTML5-game-developers.md
+++ b/src/content/en/updates/2011/07/Announcing-New-Game-the-conference-for-HTML5-game-developers.md
@@ -1,16 +1,17 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-07-15 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-07-15 #}
 {# wf_tags: news,games #}
+{# wf_blink_components: N/A #}
 
 # Announcing New Game, the conference for HTML5 game developers {: .page-title }
 
 {% include "web/_shared/contributors/sethladd.html" %}
 
 
-Please join us at [New Game](http://newgameconf.com), to be held November 1-2, 2011 in San Francisco, CA.  New Game is the first HTML5 game conference for North America.
+Please join us at New Game, to be held November 1-2, 2011 in San Francisco, CA.  New Game is the first HTML5 game conference for North America.
 
 Our theme is "HTML5 games are here today" and the conference will feature speakers building and releasing production HTML5 games for desktop, laptop, and mobile.
 

--- a/src/content/en/updates/2011/07/Don-t-Miss-a-Frame-Using-the-Page-Visibility-API-HTML5-Video.md
+++ b/src/content/en/updates/2011/07/Don-t-Miss-a-Frame-Using-the-Page-Visibility-API-HTML5-Video.md
@@ -1,20 +1,21 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-07-15 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-07-15 #}
 {# wf_tags: news,pagevisibility #}
+{# wf_blink_components: N/A #}
 
 # Don't Miss a Frame: Using the Page Visibility API + HTML5 Video {: .page-title }
 
 {% include "web/_shared/contributors/ericbidelman.html" %}
 
 
-The [Page Visibility API](http://updates.html5rocks.com/2011/06/Page-Visibility-API-Have-I-got-your-attention) can be used to check if the current tab is visible or not. [Sam Dutton](http://twitter.com/@sw12) has thrown together a nice demo highlighting one great use case for the API: pausing a playing HTML5 video if the user switches tabs.
+The [Page Visibility API](/web/updates/2011/06/Page-Visibility-API-Have-I-got-your-attention) can be used to check if the current tab is visible or not. [Sam Dutton](https://twitter.com/sw12) has thrown together a nice demo highlighting one great use case for the API: pausing a playing HTML5 video if the user switches tabs.
 
-[Demo](http://www.samdutton.com/pageVisibility/){: .external }
+[Demo](https://samdutton.wordpress.com/2011/07/15/the-page-visibility-api/){: .external }
 
-The demo requires Chrome 13 or higher but could be adapted to work with the upcoming IE10, which will include [support](https://msdn.microsoft.com/en-us/ie/hh272906) for the Page Visibility API.
+The demo requires Chrome 13 or higher but could be adapted to work with the upcoming IE10, which will include [support](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/hh673553%28v%3dvs.85%29) for the Page Visibility API.
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/07/HTML5-Libraries-polyfills-Mid-July.md
+++ b/src/content/en/updates/2011/07/HTML5-Libraries-polyfills-Mid-July.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-07-25 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-07-25 #}
 {# wf_tags: news #}
+{# wf_blink_components: N/A #}
 
 # HTML5 Libraries/polyfills - Mid July {: .page-title }
 
@@ -12,9 +13,9 @@ book_path: /web/updates/_book.yaml
 
 More awesome libraries popping up all over the place:
 
-- [SmokeJS](http://ssssnakes.com/smoke/){: .external } - A framework-agnostic styled alert system for javascript.
+- [SmokeJS](https://ssssnakes.com/smoke/){: .external } - A framework-agnostic styled alert system for JavaScript.
 - [Buzz](http://buzz.jaysalvat.com) - Buzz is a small but powerful JavaScript library that allows you to easily take advantage of the new HTML5 audio element. It degrades gracefully on non-modern browsers.
-- [FileSaver.js](https://github.com/eligrey/FileSaver.js/blob/master/FileSaver.js) - polyfill for the FileSaver's `window.saveAs()` API. Save blobs/files, client-side.
+- [FileSaver.js](https://github.com/eligrey/FileSaver.js) - polyfill for the FileSaver's `window.saveAs()` API. Save blobs/files, client-side.
 - [BlobBuilder.js](https://github.com/eligrey/BlobBuilder.js) - BlobBuilder API polyfill.
 - [canvas-toBlob.js](https://github.com/eligrey/canvas-toBlob.js) - Polyfill for HTML5 canvas's `toBlob()` method, which is not implemented by any browsers.
 

--- a/src/content/en/updates/2011/07/Multiplayer-Audio-Fun.md
+++ b/src/content/en/updates/2011/07/Multiplayer-Audio-Fun.md
@@ -1,16 +1,17 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-07-14 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-07-14 #}
 {# wf_tags: news,webaudio,websockets,connectivity #}
+{# wf_blink_components: N/A #}
 
 # Multiplayer Audio Fun {: .page-title }
 
 {% include "web/_shared/contributors/paulkinlan.html" %}
 
 
-Using the Web Audio API, WebSockets and a very nice designed UI here comes a <a href="http://labs.dinahmoe.com/plink">demo</a> where you can generante notes on the fly and with other people in real time.
+Using the Web Audio API, WebSockets and a very nice designed UI here comes a <a href="http://labs.dinahmoe.com/plink">demo</a> where you can generate notes on the fly and with other people in real time.
 We will keep posting quick updates with the demos that developers around the world make with HTML5.
 
 

--- a/src/content/en/updates/2011/07/Using-Cross-domain-images-in-WebGL.md
+++ b/src/content/en/updates/2011/07/Using-Cross-domain-images-in-WebGL.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-07-05 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-07-05 #}
 {# wf_tags: news,webgl,cors #}
+{# wf_blink_components: N/A #}
 
 # Using Cross-domain images in WebGL {: .page-title }
 
@@ -12,9 +13,9 @@ book_path: /web/updates/_book.yaml
 
 <p>WebGL specification has an important update on how to request images, cross-domain. The feature has already been implemented in Chrome 13 and is coming soon to Firefox 5.</p>
 
-<p>Just use <em>image.crossOrigin</em> method on the client side and if you can edit the server just <a href="http://enable-cors.org/">add support to it</a>.</p>
+<p>Just use <em>image.crossOrigin</em> method on the client side and if you can edit the server just <a href="https://enable-cors.org/">add support to it</a>.</p>
 
-<p>Read all the details in <a href="http://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html">Using Cross-domain images in WebGL and Chrome 13</a>.</p>
+<p>Read all the details in <a href="https://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html">Using Cross-domain images in WebGL and Chrome 13</a>.</p>
 
 
 {% include "comment-widget.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Updating broken links for the month of June 2011. 
- Adding missing wf_blink_components: tags

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
