### PR TITLE
August 2011 link updates

### DIFF
--- a/src/content/en/updates/2011/08/Debugging-the-Filesystem-API.md
+++ b/src/content/en/updates/2011/08/Debugging-the-Filesystem-API.md
@@ -1,24 +1,25 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-08-17 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-08-17 #}
 {# wf_tags: news,storage,filesystem #}
+{# wf_blink_components: N/A #}
 
 # Debugging the Filesystem API {: .page-title }
 
 {% include "web/_shared/contributors/ericbidelman.html" %}
 
 
-The [HTML5 Filesystem](http://www.html5rocks.com/tutorials/file/filesystem/){: .external } is a powerful API. With power, comes complexity. With complexity, comes more debugging frustrations. It's an unfortunate fact that the Chrome [DevTools](/web/tools/chrome-devtools) currently do not have support for the Filesystem API. It makes debugging it more difficult than it should be. By difficult, I mean being required to write code to list/remove files in the filesystem.
+The [HTML5 Filesystem](https://www.html5rocks.com/en/tutorials/file/filesystem/){: .external } is a powerful API. With power, comes complexity. With complexity, comes more debugging frustrations. It's an unfortunate fact that the Chrome [DevTools](/web/tools/chrome-devtools) currently do not have support for the Filesystem API. It makes debugging it more difficult than it should be. By difficult, I mean being required to write code to list/remove files in the filesystem.
 
-During my [endeavors](http://oreilly.com/catalog/0636920021360) with the Filesystem API, I picked up a couple of tips along the way that I thought I'd pass along. Each tip has its own set of limitations, but using a combination of these will get you 90% of the way. Here are the top 5:
+During my [endeavors](http://shop.oreilly.com/product/0636920021360.do) with the Filesystem API, I picked up a couple of tips along the way that I thought I'd pass along. Each tip has its own set of limitations, but using a combination of these will get you 90% of the way. Here are the top 5:
 
-1. <b>Make sure you aren't running from `file://`</b>. This is a sneaky one that a lot of people get bit by. Chrome imposes major [security restrictions](http://blog.chromium.org/2008/12/security-in-depth-local-web-pages.html) on `file://`. Many of the advanced file APIs (`BlobBuilder`, `FileReader`, Filesystem API,...) throw errors or fail silently if you run the app locally from `file://`. If you don't have a web server handy, Chrome can be started with the `--allow-file-access-from-files` flag to bypass this security restriction. Only use this flag for testing purposes.
+1. <b>Make sure you aren't running from `file://`</b>. This is a sneaky one that a lot of people get bit by. Chrome imposes major [security restrictions](https://blog.chromium.org/2008/12/security-in-depth-local-web-pages.html) on `file://`. Many of the advanced file APIs (`BlobBuilder`, `FileReader`, Filesystem API,...) throw errors or fail silently if you run the app locally from `file://`. If you don't have a web server handy, Chrome can be started with the `--allow-file-access-from-files` flag to bypass this security restriction. Only use this flag for testing purposes.
 
-2. <b>The dreaded `SECURITY_ERR` or `QUOTA_EXCEEDED_ERR`</b>. This usually happens when attempting to write data but you're under the influence of #1. If that's not the case,  than it's likely that you don't have quota. There are two types of quota that the filesystem can be opened with, `TEMPORARY` or `PERSISTENT`. If you're using the latter, the user needs to explicitly grant persistent storage to your app. See [this post](https://groups.google.com/a/chromium.org/group/chromium-html5/browse_thread/thread/9be7a2dc04d9af67/5261d24266ba4366?#5261d24266ba4366) on how to do that.
+2. <b>The dreaded `SECURITY_ERR` or `QUOTA_EXCEEDED_ERR`</b>. This usually happens when attempting to write data but you're under the influence of #1. If that's not the case,  than it's likely that you don't have quota. There are two types of quota that the filesystem can be opened with, `TEMPORARY` or `PERSISTENT`. If you're using the latter, the user needs to explicitly grant persistent storage to your app. See [this post](https://groups.google.com/a/chromium.org/forum/#!topic/chromium-html5/m-ei3ATZr2c) on how to do that.
 
-3. <b>`filesystem:` URL FTW</b>. It's handy to open the `filesystem:` URL for the root `DirectoryEntry` of your app's origin. What does that mean? For example, if your app lives on `www.example.com`, open `filesystem:http://www.example.com/temporary/` in a new tab. Chrome will show a read-only list of the files/folders stored your app origin. For more info on `filesystem:` URLs, see [http://www.html5rocks.com/en/tutorials/file/filesystem/#toc-filesystemurls](http://www.html5rocks.com/en/tutorials/file/filesystem/#toc-filesystemurls).
+3. <b>`filesystem:` URL FTW</b>. It's handy to open the `filesystem:` URL for the root `DirectoryEntry` of your app's origin. What does that mean? For example, if your app lives on `www.example.com`, open `filesystem:http://www.example.com/temporary/` in a new tab. Chrome will show a read-only list of the files/folders stored your app origin. For more info on `filesystem:` URLs, see [https://www.html5rocks.com/en/tutorials/file/filesystem/#toc-filesystemurls](https://www.html5rocks.com/en/tutorials/file/filesystem/#toc-filesystemurls).
 
 4. <b>`chrome://settings/cookies` is your friend</b>. This page allows you to nuke the data stored for an origin. That includes database storage, AppCache, cookies, localStorage, and stuff in the FileSystem API. Be forewarned though, it's an all or nothing thing. You can't remove just one file or pieces of data.
 

--- a/src/content/en/updates/2011/08/Downloading-resources-in-HTML5-a-download.md
+++ b/src/content/en/updates/2011/08/Downloading-resources-in-HTML5-a-download.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-08-01 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-08-01 #}
 {# wf_tags: news #}
+{# wf_blink_components: N/A #}
 
 # Downloading resources in HTML5: a[download] {: .page-title }
 
@@ -12,7 +13,7 @@ book_path: /web/updates/_book.yaml
 
 Chrome now supports the HTML spec's new `download` attribute to `a` elements. When used, this attribute signifies that the resource it points to should be downloaded by the browser rather than navigating to it.
 
-From [Downloading Resources](http://developers.whatwg.org/links.html#downloading-resources):
+From [Downloading Resources](https://html.spec.whatwg.org/dev/links.html#downloading-resources):
 
 >The `download` attribute, if present, indicates that the author intends the hyperlink to be used for downloading a resource. The attribute may have a value; the value, if any, specifies the default filename that the author recommends for use in labeling the resource in a local file system. There are no restrictions on allowed values, but authors are cautioned that most file systems have limitations with regard to what punctuation is supported in file names, and user agents are likely to adjust file names accordingly.
 
@@ -22,7 +23,7 @@ For example, clicking the following link downloads the .png as "MyGoogleLogo.png
 
 
     <a href="http://www.google.com/.../logo2w.png" download="MyGoogleLogo">download me</a>
-    
+
 
 The real benefit of `a[download]` will be when working with [blob: URLs](//www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-bloburis) and [filesystem: URLs](http://html5-demos.appspot.com/static/filesystem/generatingResourceURIs.html) URLs.
 It'll give users a way to download content created/modified within your app.

--- a/src/content/en/updates/2011/08/Saving-generated-files-on-the-client-side.md
+++ b/src/content/en/updates/2011/08/Saving-generated-files-on-the-client-side.md
@@ -1,57 +1,58 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-08-07 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-08-07 #}
 {# wf_tags: news,filesystem #}
+{# wf_blink_components: N/A #}
 
 # Saving generated files on the client-side {: .page-title }
 
 {% include "web/_shared/contributors/eligrey.html" %}
 
 
-<p>Have you ever wanted to add a <q>Save as&hellip;</q> button to a web app? Whether you're making an advanced <a href="https://developer.mozilla.org/en/WebGL">WebGL</a>-powered <abbr title="computer-aided design">CAD</abbr> web app and want to save 3D object files or you just want to save plain text files in a simple Markdown text editor, saving files in the browser has always been a tricky business. Usually when you want to save a file generated with JavaScript, you have to send the data to your server and then return the data right back with a <code>Content-disposition: attachment</code> header. This is less than ideal for web apps that need to work offline. The W3C File API includes a <a href="http://www.w3.org/TR/file-writer-api/#the-filesaver-interface"><code>FileSaver</code> interface</a>, which makes saving generated data as easy as <code>saveAs(data, filename)</code>, though unfortunately it will eventually be removed from the spec. I have written a JavaScript library called <a href="https://github.com/eligrey/FileSaver.js">FileSaver.js</a>, which implements <code>FileSaver</code> in all modern browsers. Now that it's possible to generate any type of file you want right in the browser, document editors can have an instant save button that doesn't rely on an online connection. When paired with the standard HTML5 <a href="http://www.w3.org/TR/html5/the-canvas-element.html"><code>canvas.toBlob()</code></a> method, FileSaver.js lets you save canvases instantly and give them filenames, which is very useful for HTML5 image editing webapps. For browsers that don't yet support <code>canvas.toBlob()</code>, <a href="https://github.com/eboyjr">Devin Samarin</a> and I wrote <a href="https://github.com/eligrey/canvas-toBlob.js">canvas-toBlob.js</a>. Saving a canvas is as simple as running the following code:</p>
+<p>Have you ever wanted to add a <q>Save as&hellip;</q> button to a web app? Whether you're making an advanced <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API">WebGL</a>-powered <abbr title="computer-aided design">CAD</abbr> web app and want to save 3D object files or you just want to save plain text files in a simple Markdown text editor, saving files in the browser has always been a tricky business. Usually when you want to save a file generated with JavaScript, you have to send the data to your server and then return the data right back with a <code>Content-disposition: attachment</code> header. This is less than ideal for web apps that need to work offline. The W3C File API includes a <a href="https://www.w3.org/TR/file-writer-api/#the-filesaver-interface"><code>FileSaver</code> interface</a>, which makes saving generated data as easy as <code>saveAs(data, filename)</code>, though unfortunately it will eventually be removed from the spec. I have written a JavaScript library called <a href="https://github.com/eligrey/FileSaver.js">FileSaver.js</a>, which implements <code>FileSaver</code> in all modern browsers. Now that it's possible to generate any type of file you want right in the browser, document editors can have an instant save button that doesn't rely on an online connection. When paired with the standard HTML5 <a href="https://dev.w3.org/html5/pf-summary/the-canvas-element.html"><code>canvas.toBlob()</code></a> method, FileSaver.js lets you save canvases instantly and give them filenames, which is very useful for HTML5 image editing webapps. For browsers that don't yet support <code>canvas.toBlob()</code>, Devin Samarin and I wrote <a href="https://github.com/eligrey/canvas-toBlob.js">canvas-toBlob.js</a>. Saving a canvas is as simple as running the following code:</p>
 
 
     canvas.toBlob(function(blob) {
       saveAs(blob, filename);
     });
-    
 
-<p>I have created a <a href="http://oftn.org/projects/FileSaver.js/demo/">demo</a> of FileSaver.js in action that demonstrates saving a canvas doodle, plain text, and rich text. Please note that saving with custom filenames is only supported in browsers that either natively support <code>FileSaver</code> or browsers like <a href="http://www.chromium.org/getting-involved/dev-channel">Google Chrome 14 dev</a> and <a href="http://tools.google.com/dlpage/chromesxs">Google Chrome Canary</a>, that support <a href="http://developers.whatwg.org/links.html#downloading-resources">&lt;a&gt;.download</a> or web filesystems via <a href="http://www.w3.org/TR/file-system-api/#using-localfilesystem"><code>LocalFileSystem</code></a>.</p>
 
-<figure><a href="http://eligrey.com/demos/FileSaver.js/"><img style="border:1px solid #ccc;max-width: 100%;" src="/web/updates/images/2011/08/saving-generated-files/filesaverss.png">
+<p>I have created a <a href="http://oftn.org/projects/FileSaver.js/demo/">demo</a> of FileSaver.js in action that demonstrates saving a canvas doodle, plain text, and rich text. Please note that saving with custom filenames is only supported in browsers that either natively support <code>FileSaver</code> or browsers like <a href="http://www.chromium.org/getting-involved/dev-channel">Google Chrome 14 dev</a> and <a href="https://www.google.com/intl/en/chrome/canary/">Google Chrome Canary</a>, that support <a href="https://html.spec.whatwg.org/dev/links.html#downloading-resources">&lt;a&gt;.download</a> or web filesystems via <a href="https://www.w3.org/TR/file-system-api/#using-localfilesystem"><code>LocalFileSystem</code></a>.</p>
+
+<figure><a href="https://eligrey.com/demos/FileSaver.js/"><img style="border:1px solid #ccc;max-width: 100%;" src="/web/updates/images/2011/08/saving-generated-files/filesaverss.png">
 <figcaption>View FileSaver.js demo</figcaption></a></figure>
 
 ## How to construct files for saving
 
-<p>First off, you want to instantiate a <a href="https://developer.mozilla.org/en/DOM/BlobBuilder"><code>BlobBuilder</code></a>. The <code>BlobBuilder</code> API isn't supported in all current browsers, so I made <a href="https://github.com/eligrey/BlobBuilder.js">BlobBuilder.js</a> which implements it. The following example illustrates how to save an XHTML document with <code>saveAs()</code>.</p>
+<p>First off, you want to instantiate a <a href="https://developer.mozilla.org/en-US/docs/Web/API/BlobBuilder"><code>BlobBuilder</code></a>. The <code>BlobBuilder</code> API isn't supported in all current browsers, so I made <a href="https://github.com/eligrey/BlobBuilder.js">BlobBuilder.js</a> which implements it. The following example illustrates how to save an XHTML document with <code>saveAs()</code>.</p>
 
 
     var bb = new BlobBuilder();
     bb.append((new XMLSerializer).serializeToString(document));
     var blob = bb.getBlob("application/xhtml+xml;charset=" + document.characterSet);
     saveAs(blob, "document.xhtml");
-    
 
-<p>Not saving textual data? You can append binary <code>Blob</code>s and <a href="https://developer.mozilla.org/en/JavaScript_typed_arrays"><code>ArrayBuffer</code>s</a> to a <code>BlobBuilder</code> too! The following is an example of setting generating some binary data and saving it.</p>
+
+<p>Not saving textual data? You can append binary <code>Blob</code>s and <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays"><code>ArrayBuffer</code>s</a> to a <code>BlobBuilder</code> too! The following is an example of setting generating some binary data and saving it.</p>
 
 
     var bb = new BlobBuilder();
     var buffer = new ArrayBuffer(8); // allocates 8 bytes
     var data = new DataView(buffer);
-    
+
     // You can write (u)int8/16/32s and float32/64s to dataviews
     data.setUint8 (0, 0x01);
     data.setUint16(1, 0x2345);
     data.setUint32(3, 0x6789ABCD);
     data.setUint8 (7, 0xEF);
-    
+
     bb.append(buffer);
     var blob = bb.getBlob("example/binary");
     saveAs(blob, "data.dat");
     // The contents of data.dat are &lt;01 23 45 67 89 AB CD EF&gt;
-    
+
 
 <p>If you're generating large files, you can implement an abort button that aborts the <code>FileSaver</code>.</p>
 
@@ -60,7 +61,7 @@ book_path: /web/updates/_book.yaml
     abort_button.addEventListener("click", function() {
       filesaver.abort();
     }, false);
-    
+
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/08/Seek-into-local-files-with-the-File-System-API.md
+++ b/src/content/en/updates/2011/08/Seek-into-local-files-with-the-File-System-API.md
@@ -1,35 +1,36 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-08-04 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-08-04 #}
 {# wf_tags: news,offline,filesystem #}
+{# wf_blink_components: N/A #}
 
 # Seek into local files with the File System API {: .page-title }
 
 {% include "web/_shared/contributors/sethladd.html" %}
 
 
-If you have a `File` object (say, one stored using the [FileSystem API](http://www.html5rocks.com/en/tutorials/file/filesystem/){: .external }), it's possible to seek into it and read chunks without reading the entire file into memory:
+If you have a `File` object (say, one stored using the [FileSystem API](https://www.html5rocks.com/en/tutorials/file/filesystem/){: .external }), it's possible to seek into it and read chunks without reading the entire file into memory:
 
 
     var url = "filesystem:http://example.com/temporary/myfile.zip";
-    
+
     window.webkitResolveLocalFileSystemURL(url, function(fileEntry) {
       fileEntry.file(function(file) {
         var reader = new FileReader();
-    
+
         reader.onload = function(e) {
           var ab = e.target.result; // arrayBuffer containing bytes 0-10 of file.
           var uInt8Arr = new Uint8Array(ab);
           ...
         };
-    
+
         var blob = file.webkitSlice(0, 10, "application/zip");  // mimetype is optional
         reader.readAsArrayBuffer(blob);
       }, errorHandler);
     }, errorHandler);
-    
+
 
 
 {% include "comment-widget.html" %}

--- a/src/content/en/updates/2011/08/What-s-different-in-the-new-WebSocket-protocol.md
+++ b/src/content/en/updates/2011/08/What-s-different-in-the-new-WebSocket-protocol.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-08-30 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-08-30 #}
 {# wf_tags: news,websockets,connectivity #}
+{# wf_blink_components: N/A #}
 
 # What's different in the new WebSocket protocol {: .page-title }
 

--- a/src/content/en/updates/2011/08/insertAdjacentHTML-Everywhere.md
+++ b/src/content/en/updates/2011/08/insertAdjacentHTML-Everywhere.md
@@ -1,9 +1,10 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2011-08-27 #}
+{# wf_updated_on: 2019-01-09 #}
 {# wf_published_on: 2011-08-27 #}
 {# wf_tags: news,dom #}
+{# wf_blink_components: N/A #}
 
 # insertAdjacentHTML Everywhere {: .page-title }
 
@@ -13,28 +14,28 @@ book_path: /web/updates/_book.yaml
 <p>If we want to insert content in a HTML document we have three ways to do it:</p>
 <ul>
 <li>Using DOM methods like <code>createNode</code> and <code>appendChild</code></li>
-<li>Using <a href="http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-B63ED1A3">Document Fragments</a></li>
+<li>Using <a href="https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-B63ED1A3">Document Fragments</a></li>
 <li>Using <code>innerHTML</code></li>
 </ul>
 <p>One can arguably say we also have <code>document.write</code> for few use cases.</p>
 <p>
-<code>innerHTML</code> has been standarized in HTML5 and with it a brother method <code><a href="http://dev.w3.org/html5/spec/Overview.html#insertadjacenthtml">insertAdjacentHTML</a></code> which works as <code>innerHTML</code> but allows us to define more specifically where we want to insert the HTML content: beforeBegin, afterBegin, beforeEnd and afterEnd.
+<code>innerHTML</code> has been standarized in HTML5 and with it a brother method <code><a href="http://w3c.github.io/html/#insertadjacenthtml">insertAdjacentHTML</a></code> which works as <code>innerHTML</code> but allows us to define more specifically where we want to insert the HTML content: beforeBegin, afterBegin, beforeEnd and afterEnd.
 </p>
 
 
     var ul = document.getElementById("list");
     ul.insertAdjacentHTML("beforeEnd", "&lt;li>A new li on the list.&lt;/li>");
-    
+
 
 <p>
-Back in 2008 John Resig wrote <a href="http://ejohn.org/blog/dom-insertadjacenthtml/">an article about insertAdjacentHTML</a> with this conclusion:
+Back in 2008 John Resig wrote <a href="https://johnresig.com/blog/dom-insertadjacenthtml/">an article about insertAdjacentHTML</a> with this conclusion:
 </p>
 <p>
 <blockquote>
 Having browsers implement this method will dramatically reduce the amount of code needed to write a respectable JavaScript library. I'm looking forward to the day in which this method is more-widely available (along with querySelectorAll) so that we can really buckle down and do some serious code simplification.
 </blockquote>
 <p>
-Until now, the main issue with insertAdjacentHTML has been its lack of browser support. With Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=613662#c13">implementing insertAdjacentHTML</a> as of version 8, it will available in all major browsers including mobile browsers. If you want to use it now and make sure it works in Firefox versions earlier than 8 you can use this <a href="https://github.com/ernestd/insertAdjacentHTML-polyfill/blob/master/insertAdjacentHTML.js">polyfill</a>.
+Until now, the main issue with insertAdjacentHTML has been its lack of browser support. With Firefox <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=613662#c13">implementing insertAdjacentHTML</a> as of version 8, it will available in all major browsers including mobile browsers. If you want to use it now and make sure it works in Firefox versions earlier than 8 you can use this <a href="https://gist.github.com/eligrey/1276030">polyfill</a>.
 </p>
 
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed links from the month of August 2011.
- Adding missing wf_blink_components: tags

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
