### PR TITLE
update-resources.sh uses more idiomatic bash

### DIFF
--- a/tools/update-resources.sh
+++ b/tools/update-resources.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-TEMP_FILE='tempFile.txt'
-
 getResource() {
-  echo $1
-  curl --compressed --fail --progress-bar $1 > $TEMP_FILE
-  if [ $? -eq 0 ]; then
-      mv $TEMP_FILE $2
+  local TEMP_FILE="$(mktemp)"
+  echo "$1"
+  if curl --compressed --fail --progress-bar "$1" > "$TEMP_FILE"; then
+      mv "$TEMP_FILE" "$2"
   else
-      echo Unable to update $1
-      rm $TEMP_FILE
+      echo Unable to update "$1"
+      rm "$TEMP_FILE"
   fi
 }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- update-resources.sh uses more idiomatic bash

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
