### PR TITLE
Parallelize update-resources.sh

### DIFF
--- a/tools/update-resources.sh
+++ b/tools/update-resources.sh
@@ -3,7 +3,7 @@
 getResource() {
   local TEMP_FILE="$(mktemp)"
   echo "$1"
-  if curl --compressed --fail --progress-bar "$1" > "$TEMP_FILE"; then
+  if curl --compressed --fail "$1" > "$TEMP_FILE"; then
     mv "$TEMP_FILE" "$2"
   else
     echo Unable to update "$1"
@@ -22,4 +22,5 @@ getResource https://developers.google.com/_static/js/script_foot_closure.js gae/
 getResource https://developers.google.com/_static/js/script_foot.js gae/scripts/script_foot.js &
 getResource https://developers.google.com/_static/js/prettify-bundle.js gae/scripts/prettify-bundle.js &
 
+# TODO: return an error code if one of the curls fails
 wait

--- a/tools/update-resources.sh
+++ b/tools/update-resources.sh
@@ -3,7 +3,7 @@
 getResource() {
   local TEMP_FILE="$(mktemp)"
   echo "$1"
-  if curl --compressed --fail "$1" > "$TEMP_FILE"; then
+  if curl --compressed --fail --silent "$1" > "$TEMP_FILE"; then
     mv "$TEMP_FILE" "$2"
   else
     echo Unable to update "$1"

--- a/tools/update-resources.sh
+++ b/tools/update-resources.sh
@@ -4,20 +4,22 @@ getResource() {
   local TEMP_FILE="$(mktemp)"
   echo "$1"
   if curl --compressed --fail --progress-bar "$1" > "$TEMP_FILE"; then
-      mv "$TEMP_FILE" "$2"
+    mv "$TEMP_FILE" "$2"
   else
-      echo Unable to update "$1"
-      rm "$TEMP_FILE"
+    echo Unable to update "$1"
+    rm "$TEMP_FILE"
   fi
 }
 
 echo "Getting lastest CSS and Script resources..."
 
-getResource https://developers.google.com/_static/css/devsite-google-blue.css gae/styles/devsite-google-blue.css
-getResource https://developers.google.com/_static/css/devsite-orange.css gae/styles/devsite-orange.css
+getResource https://developers.google.com/_static/css/devsite-google-blue.css gae/styles/devsite-google-blue.css &
+getResource https://developers.google.com/_static/css/devsite-orange.css gae/styles/devsite-orange.css &
 
-getResource https://developers.google.com/_static/js/framebox.js gae/scripts/framebox.js
-getResource https://developers.google.com/_static/js/jquery-bundle.js gae/scripts/jquery-bundle.js
-getResource https://developers.google.com/_static/js/script_foot_closure.js gae/scripts/script_foot_closure.js
-getResource https://developers.google.com/_static/js/script_foot.js gae/scripts/script_foot.js
-getResource https://developers.google.com/_static/js/prettify-bundle.js gae/scripts/prettify-bundle.js
+getResource https://developers.google.com/_static/js/framebox.js gae/scripts/framebox.js &
+getResource https://developers.google.com/_static/js/jquery-bundle.js gae/scripts/jquery-bundle.js &
+getResource https://developers.google.com/_static/js/script_foot_closure.js gae/scripts/script_foot_closure.js &
+getResource https://developers.google.com/_static/js/script_foot.js gae/scripts/script_foot.js &
+getResource https://developers.google.com/_static/js/prettify-bundle.js gae/scripts/prettify-bundle.js &
+
+wait


### PR DESCRIPTION
What's changed, or what was fixed?
- update-resources.sh now runs all fetches in parallel

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
