### PR TITLE
Fixes link for "Inside look at modern web browser Part 3" 

### DIFF
--- a/src/content/en/updates/2018/09/inside-browser-part3.md
+++ b/src/content/en/updates/2018/09/inside-browser-part3.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Inner workings of a browser rendering engine
 
 {# wf_published_on: 2018-09-20 #}
-{# wf_updated_on: 2018-09-26 #}
+{# wf_updated_on: 2019-01-17 #}
 {# wf_featured_image: /web/updates/images/inside-browser/cover.png #}
 {# wf_featured_snippet: Once the browser receives page data, what happens inside of the renderer process to display a page? #}
 {# wf_blink_components: N/A #}
@@ -117,7 +117,7 @@ this information in the `computed` section of DevTools.
 Even if you do not provide any CSS, each DOM node has a computed style. `<h1>` tag is displayed 
 bigger than `<h2>` tag and margins are defined for each element. This is because the browser has a 
 default style sheet. If you want to know what Chrome's default CSS is like, 
-[you can see the source code here](https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/css/html.css).
+[you can see the source code here](https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/html/resources/html.css).
 
 ## Layout
 


### PR DESCRIPTION
What's changed, or what was fixed?
- URL for "...If you want to know what Chrome's default CSS is like, **you can see the source code here**.": 

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele

Thanks @ozasadnyy (https://twitter.com/ozasadnyy/status/1085788003006504961)