### PR TITLE
Add examples to User Activation v2 article.

### DIFF
--- a/src/content/en/updates/2019/01/user-activation.md
+++ b/src/content/en/updates/2019/01/user-activation.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: In version 72, Chrome ships User Activation v2 which makes user activation availability complete for all activation-gated APIs, resolving many user activation inconsistencies.
 
 {# wf_published_on: 2019-01-14 #}
-{# wf_updated_on: 2019-01-23 #}
+{# wf_updated_on: 2019-02-05 #}
 {# wf_featured_image: /web/updates/images/misc/first-input-delay.png #}
 {# wf_tags: chrome72,user-activation,user-gesture #}
 {# wf_featured_snippet: In version 72, Chrome ships User Activation v2 which makes user activation availability complete for all activation-gated APIs, resolving many user activation inconsistencies. #}

--- a/src/content/en/updates/2019/01/user-activation.md
+++ b/src/content/en/updates/2019/01/user-activation.md
@@ -108,7 +108,7 @@ Without User Activation v2, the second event handler fails in all browsers we
 tested. (Even the first one fails
 [in some cases](https://docs.google.com/document/d/1hYRTEkfWDl-KO4Y6cG469FBC3nyBy9_SYItZ1EEsXUA/edit#bookmark=id.7fb3jwz3is2s).)
 
-### Cross-domain postMessaging()
+### Cross-domain postMessage() calls
 
 Here's an example from
 [our `postMessaging()` demo](https://mustaqahmed.github.io/user-activation-v2/api-consistency/postMessages.html).

--- a/src/content/en/updates/2019/01/user-activation.md
+++ b/src/content/en/updates/2019/01/user-activation.md
@@ -111,7 +111,7 @@ tested. (Even the first one fails
 ### Cross-domain postMessage() calls
 
 Here's an example from
-[our `postMessaging()` demo](https://mustaqahmed.github.io/user-activation-v2/api-consistency/postMessages.html).
+[our `postMessage()` demo](https://mustaqahmed.github.io/user-activation-v2/api-consistency/postMessages.html).
 Suppose a `click` handler in a cross-origin subframe sends two messages directly
 the parent frame.  The parent frame should be able to open a popup upon
 receiving either of these messages (but not both):


### PR DESCRIPTION
What's changed, or what was fixed?
- Examples were added to an existing article on User Activation v2.

**Fixes:** #7112 

**Target Live Date:** 2019-01-23

- [x] This has been reviewed and approved by jmedley@. (The new content was written by mustaq@)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
