### PR TITLE
ignore index.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ scratch/*
 tools/claat
 gcloud-client-secret.json
 package-lock.json
+index.yaml
 
 ## Files that are updated regularly from DevSite
 # These files will be updated by tools/update-resources.sh


### PR DESCRIPTION
@petele I updated App Engine and it appears to be auto-generating a new file called `index.yaml`. Doesn't seem like we need to commit it.

What's changed, or what was fixed?

- add `index.yaml` to `.gitignore`

**Fixes:** N/A

**Target Live Date:** 2019-02-01

- [ ] This has been reviewed and approved by @petele
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
