### PR TITLE
Remove 'certified' and widen scope

### DIFF
--- a/src/content/en/agencies/_index.yaml
+++ b/src/content/en/agencies/_index.yaml
@@ -13,17 +13,17 @@ landing_page:
       description: >
         Find a qualified web development agency to help you build optimized
         and mobile friendly web apps.<br><br>
-        Has your agency built Progressive Web Apps for your clients ? If yes,
+        Has your agency built Progressive Web Apps for your clients? If yes,
         please use
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSeRV9YHhGeofFw_PxLEVV50A-hxCygutjh7mw9U4ffqjVcxZA/viewform?usp=sf_link">
         this application form</a> to be considered for being listed in this
-        directory.<br><br><p class='disclaimer'><small>Google Developers
-        does not endorse, or offer any warranty, regarding these certified
+        directory.<br><br><p class='disclaimer'><small>Google
+        does not endorse, or offer any warranty, regarding these
         agencies. Each agency is fully responsible for their services, and is
-        not affiliated with Google Developers nor do they offer services on
-        behalf of Google Developers. Customers are fully responsible for their
-        use of services, if any. Google Developers will have no liability for
-        any products or services provided by an agency.
+        not affiliated with Google, nor do they offer services on
+        behalf of Google. Customers are fully responsible for their
+        use of services, if any. Google will have no liability for
+        any products or services provided by any agency.
         </small></p>
 
   # DIRECTORY IFRAME


### PR DESCRIPTION
What's changed, or what was fixed?
- adjust wording on agencies page


**Target Live Date:** 2019-01-31

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
