### PR TITLE
added link to asyncCSS (advanced CSS loader)

### DIFF
--- a/src/content/en/tools/lighthouse/audits/unused-css.md
+++ b/src/content/en/tools/lighthouse/audits/unused-css.md
@@ -129,6 +129,7 @@ You are welcome to [add your own tool to this list][doc]{:.external}.
 Caution: None of these tools have been vetted. Make sure to do your own due diligence.
 
 * [loadCSS](https://github.com/filamentgroup/loadCSS){: .external }
+* [asyncCSS](https://github.com/style-tools/async-css/wiki/Defer-Unused-CSS-for-Google-Lighthouse-Optimization){: .external }
 
 ## More information {: #more-info }
 


### PR DESCRIPTION
What's changed, or what was fixed?
added a link upon the request in the article.

Link: https://github.com/style-tools/async-css/wiki/Defer-Unused-CSS-for-Google-Lighthouse-Optimization

AsyncCSS provides unique solutions to resolve the Google Lighthouse penalty while also truly achieving the best stylesheet performance for any website (no concessions for a good score).

More info: https://docs.style.tools/async-css