### PR TITLE
rendering-on-the-web: longer description

### DIFF
--- a/src/content/en/updates/2019/02/rendering-on-the-web.md
+++ b/src/content/en/updates/2019/02/rendering-on-the-web.md
@@ -5,7 +5,7 @@ book_path: /web/updates/_book.yaml
 {# wf_published_on: 2019-02-06 #}
 {# wf_tags: fundamentals, performance, app-shell #}
 {# wf_featured_image: /web/updates/images/2019/02/rendering-on-the-web/icon.png #}
-{# wf_featured_snippet: Where should we implement logic and rendering in our applications? #}
+{# wf_featured_snippet: Where should we implement logic and rendering in our applications? Should we use Server Side Rendering? What about Rehydration? Let's find some answers! #}
 {# wf_blink_components: N/A #}
 
 # Rendering on the Web {: .page-title }


### PR DESCRIPTION
What's changed, or what was fixed?
- gave rendering-on-the-web a better description (was too short)

**Target Live Date:** asap

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
