### PR TITLE
Typo fixes in Lighthouse scoring docs

### DIFF
--- a/src/content/en/tools/lighthouse/scoring.md
+++ b/src/content/en/tools/lighthouse/scoring.md
@@ -67,7 +67,7 @@ a Lighthouse score of 99.
 ### How the Performance score is weighted {: #perf-weighting }
 
 The audits that contribute to the Performance score are not equally weighted. See [Scoring
-Details][details]{:.external} to see how each Performance audit is weighted. The heaver-weighted
+Details][details]{:.external} to see how each Performance audit is weighted. The heavier-weighted
 audits have a larger impact on your overall Performance score. The weightings are based on
 heuristics. The Lighthouse team is working on formalizing this approach through more field data.
 

--- a/src/content/en/tools/lighthouse/v3/scoring.md
+++ b/src/content/en/tools/lighthouse/v3/scoring.md
@@ -63,7 +63,7 @@ a Lighthouse score of 99.
 ### How the Performance score is weighted {: #perf-weighting }
 
 The metrics that contribute to the Performance score are not equally weighted. See [Scoring
-Details][details]{:.external} to see how each Performance audit is weighted. The heaver-weighted
+Details][details]{:.external} to see how each Performance audit is weighted. The heavier-weighted
 audits have a larger impact on your overall Performance score. The weightings are based on
 heuristics. The Lighthouse team is working on formalizing this approach through more field data.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Changed "heaver" to read "heavier"

**Target Live Date:** any

**CC:** @petele
