### PR TITLE
Constructable Stylesheets: remove extra newline in code sample

### DIFF
--- a/src/content/en/updates/2019/02/constructable-stylesheets.md
+++ b/src/content/en/updates/2019/02/constructable-stylesheets.md
@@ -108,8 +108,7 @@ sheet.replaceSync('a { color: red; }');
 document.adoptedStyleSheets = [sheet];
 
 // Apply the stylesheet to a Shadow Root:
-const node =
-document.createElement('div');
+const node = document.createElement('div');
 const shadow = node.attachShadow({ mode: 'open' });
 shadow.adoptedStyleSheets = [sheet];
 ```


### PR DESCRIPTION
What's changed, or what was fixed?
- remove extra newline in code sample

<img width="483" alt="screen shot 2019-02-11 at 12 27 34 pm" src="https://user-images.githubusercontent.com/105127/52581334-78014800-2df8-11e9-96b2-6aaa5dea4e63.png">

**Fixes:** #issue

**Target Live Date:** now

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
