### PR TITLE
Constructable Stylesheets: fix img alt

### DIFF
--- a/src/content/en/updates/2019/02/constructable-stylesheets.md
+++ b/src/content/en/updates/2019/02/constructable-stylesheets.md
@@ -31,7 +31,7 @@ offering a programmatic way to manipulate stylesheets as well as eliminating the
 problems associated with the old method.
 
 <img src="../../images/2019/02/constructable-stylesheets/overview.png"
-alt="Diagram showing client-side rendering affecting FCP and TTI" width="600"
+alt="Diagram showing preparation and application of CSS" width="600"
 style="max-height:458px;">
 
 Constructable Stylesheets make it possible to define and prepare shared CSS


### PR DESCRIPTION
What's changed, or what was fixed?
- fix copypasta alt tag in Constructable Stylesheets update

**Target Live Date:** whenever

- [x] This has been reviewed and approved by (me)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
