### PR TITLE
update the feedback widget to get more information

### DIFF
--- a/src/content/en/_shared/helpful.html
+++ b/src/content/en/_shared/helpful.html
@@ -1,37 +1,83 @@
-<style>
-  .helpful--container {
-    margin: 1em 0;
-    position: relative;
-  }
-  .helpful--section {
-    position: static;
-  }
-</style>
-<p>Was this page helpful?</p>
-<div class="helpful--container">
-  <section class="expandable helpful--section">
-    <button class="button button-primary expand-control gc-analytics-event"
-            data-category="Helpful" data-value="1"
-            data-label="{% dynamic print request.path %}"
-            style="background-color:#f44336;">
-      Yes
-    </button>
-    <aside class="success">
-      Great! Thank you for the feedback. If you have any ideas on how we can improve, please
-      <a href="https://github.com/google/WebFundamentals/issues/new">open an issue</a>.
-    </aside>
-  </section>
-  <section class="expandable helpful--section">
-    <button class="button button-primary expand-control gc-analytics-event"
-            data-category="Helpful" data-value="0"
-            data-label="{% dynamic print request.path %}"
-            style="position:absolute;top:0;left:78px;background-color:#f44336;">
-      No
-    </button>
-    <aside class="warning">
-      Sorry to hear that. Please <a
-      href="https://github.com/google/WebFundamentals/issues/new">open an
-      issue</a> and tell us how we can improve.
-    </aside>
-  </section>
+{% setvar response %}
+  Thank you for the feedback. If you have specific ideas on how to improve this page, please
+  <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+{% endsetvar %}
+<div class="devsite-tracking-question">
+  <div>Was this page helpful?</div>
+  <div class="gc-analytics-event"
+       data-category="Helpful" data-value="1"
+       data-label="{% dynamic print request.path %}">
+    <div>Yes</div>
+    <div class="devsite-tracking-question">
+      <div>What was the best thing about this page?</div>
+      <div class="gc-analytics-event"
+           data-category="Goals" data-value="1"
+           data-label="{% dynamic print request.path %}">
+        <div>It helped me complete my goal(s)</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Completeness" data-value="1"
+           data-label="{% dynamic print request.path %}">
+        <div>It had the information I needed</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Accuracy" data-value="1"
+           data-label="{% dynamic print request.path %}">
+        <div>It had accurate information</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Writing" data-value="1"
+           data-label="{% dynamic print request.path %}">
+        <div>It was easy to read</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Other" data-value="1"
+           data-label="{% dynamic print request.path %}">
+        <div>Something else</div>
+        <div>{{ response }}</div>
+      </div>
+    </div>
+  </div>
+  <div class="gc-analytics-event"
+       data-category="Helpful" data-value="0"
+       data-label="{% dynamic print request.path %}">
+    <div>No</div>
+    <div class="devsite-tracking-question">
+      <div>What was the worst thing about this page?</div>
+      <div class="gc-analytics-event"
+           data-category="Goals" data-value="0"
+           data-label="{% dynamic print request.path %}">
+        <div>It didn't help me complete my goal(s)</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Completeness" data-value="0"
+           data-label="{% dynamic print request.path %}">
+        <div>It was missing information I needed</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Accuracy" data-value="0"
+           data-label="{% dynamic print request.path %}">
+        <div>It had inaccurate information</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Writing" data-value="0"
+           data-label="{% dynamic print request.path %}">
+        <div>It was hard to read</div>
+        <div>{{ response }}</div>
+      </div>
+      <div class="gc-analytics-event"
+           data-category="Other" data-value="0"
+           data-label="{% dynamic print request.path %}">
+        <div>Something else</div>
+        <div>{{ response }}</div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/content/en/_shared/helpful.html
+++ b/src/content/en/_shared/helpful.html
@@ -1,7 +1,3 @@
-{% setvar response %}
-  Thank you for the feedback. If you have specific ideas on how to improve this page, please
-  <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
-{% endsetvar %}
 <div class="devsite-tracking-question">
   <div>Was this page helpful?</div>
   <div class="gc-analytics-event"
@@ -14,31 +10,46 @@
            data-category="Goals" data-value="1"
            data-label="{% dynamic print request.path %}">
         <div>It helped me complete my goal(s)</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Completeness" data-value="1"
            data-label="{% dynamic print request.path %}">
         <div>It had the information I needed</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Accuracy" data-value="1"
            data-label="{% dynamic print request.path %}">
         <div>It had accurate information</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Writing" data-value="1"
            data-label="{% dynamic print request.path %}">
         <div>It was easy to read</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Other" data-value="1"
            data-label="{% dynamic print request.path %}">
         <div>Something else</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
     </div>
   </div>
@@ -52,31 +63,46 @@
            data-category="Goals" data-value="0"
            data-label="{% dynamic print request.path %}">
         <div>It didn't help me complete my goal(s)</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Completeness" data-value="0"
            data-label="{% dynamic print request.path %}">
         <div>It was missing information I needed</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Accuracy" data-value="0"
            data-label="{% dynamic print request.path %}">
         <div>It had inaccurate information</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Writing" data-value="0"
            data-label="{% dynamic print request.path %}">
         <div>It was hard to read</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
       <div class="gc-analytics-event"
            data-category="Other" data-value="0"
            data-label="{% dynamic print request.path %}">
         <div>Something else</div>
-        <div>{{ response }}</div>
+        <div>
+          Thank you for the feedback. If you have specific ideas on how to improve this page, please
+          <a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
What's changed, or what was fixed?

- uses the "analytics tracking question" widget (ATQW) to fix a bug where it was possible for a user to click both yes and no... with the ATQW once you click "yes" or "no" those 2 options disappear

    <img width="1552" alt="screen shot 2019-02-11 at 5 39 38 pm" src="https://user-images.githubusercontent.com/4713486/52605511-08a14d80-2e24-11e9-9ddd-9f18ebf6ef04.png">

     widget now looks like this:

     <img width="905" alt="screen shot 2019-02-11 at 5 58 39 pm" src="https://user-images.githubusercontent.com/4713486/52606240-bf063200-2e26-11e9-8cf2-d6a96b78eca1.png">

     kinda funky, i know, but this is the only way to get the UI that i need + scalability... so... good enough

- uses the "analytics tracking question" again widget to prompt users for more information... after clicking "yes" a user sees this:

     <img width="846" alt="screen shot 2019-02-11 at 5 43 22 pm" src="https://user-images.githubusercontent.com/4713486/52605654-91b88480-2e24-11e9-89c7-cad136e16f62.png">

     and after clicking "no" a user sees this:

     <img width="832" alt="screen shot 2019-02-11 at 5 42 11 pm" src="https://user-images.githubusercontent.com/4713486/52605603-67ff5d80-2e24-11e9-8e2e-068aad758c88.png">

     clicking any of those 10 options shows this:

     <img width="825" alt="screen shot 2019-02-11 at 5 44 40 pm" src="https://user-images.githubusercontent.com/4713486/52605693-bc0a4200-2e24-11e9-800d-60d12874799e.png">


**Fixes:** N/A

**Target Live Date:** 2019-02-12

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
