### PR TITLE
PiP shipped in Chrome OS 72

### DIFF
--- a/src/content/en/updates/2018/10/watch-video-using-picture-in-picture.md
+++ b/src/content/en/updates/2018/10/watch-video-using-picture-in-picture.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Control Picture-in-Picture for video elements on your website.
 
-{# wf_updated_on: 2018-12-05 #}
+{# wf_updated_on: 2019-02-12 #}
 {# wf_published_on: 2018-10-19 #}
 {# wf_tags: news,media #}
 {# wf_featured_image: /web/updates/images/2018/10/watch-video-using-picture-in-picture/hero.png #}
@@ -273,7 +273,7 @@ API are currently implemented in Chrome and other browsers.
 
 Here's what you can expect to see in the near future:
 
-- Picture-in-Picture will be supported in Chrome OS and Android O.
+- Picture-in-Picture will be supported in Android O.
 - Web developers will be able to [add custom Picture-in-Picture controls].
 
 ## Resources {: #resources }


### PR DESCRIPTION
The API has shipped in Chrome 70 on Mac, Linux, and Windows and Chrome 72 on Chrome OS. This simply updates article that links to https://github.com/WICG/picture-in-picture/blob/master/implementation-status.md