### PR TITLE
Add python 3 webserver example to workspaces setup example

### DIFF
--- a/src/content/en/tools/chrome-devtools/workspaces/index.md
+++ b/src/content/en/tools/chrome-devtools/workspaces/index.md
@@ -119,7 +119,8 @@ Complete this tutorial to get hands-on experience with Workspaces.
 
     <pre class="prettyprint">
     <code class="devsite-terminal">cd ~/Desktop/app</code>
-    <code class="devsite-terminal">python -m SimpleHTTPServer</code>
+    <code class="devsite-terminal">python -m SimpleHTTPServer</code> # Python 2
+    <code class="devsite-terminal">python -m http.server</code> # Python 3
     </pre>
 
 1. Open a tab in Google Chrome and go to locally-hosted version of the site. You should be


### PR DESCRIPTION
What's changed, or what was fixed?
- Add python 3 webserver example to https://developers.google.com/web/tools/chrome-devtools/workspaces

**Fixes:** N/A

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
