### PR TITLE
Use srcObject instead of createObjectURL for audio recording example

### DIFF
--- a/src/content/en/fundamentals/media/recording-audio/index.md
+++ b/src/content/en/fundamentals/media/recording-audio/index.md
@@ -44,7 +44,7 @@ the `files` property of the event object.
   recorder.addEventListener('change', function(e) {
     var file = e.target.files[0];
     // Do something with the audio file.
-    player.src =  URL.createObjectURL(file);
+    player.srcObject = file;
   });
 &lt;/script>
 </pre>
@@ -87,7 +87,7 @@ object that is passed to the `getUserMedia()` API
 
   var handleSuccess = function(stream) {
     if (window.URL) {
-      player.src = window.URL.createObjectURL(stream);
+      player.srcObject = stream;
     } else {
       player.src = stream;
     }


### PR DESCRIPTION
Was going through https://developers.google.com/web/fundamentals/media/recording-audio/ and got error 

> (index):9 Uncaught (in promise) TypeError: Failed to execute 'createObjectURL' on 'URL': No function was found that matched the signature provided.

Used suggestion here and works nicely in Chrome stable 72. 

https://stackoverflow.com/a/53821674/292408
https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL

What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
