### PR TITLE
Eliminate new line from description

### DIFF
--- a/src/content/en/updates/2019/02/priority-hints.md
+++ b/src/content/en/updates/2019/02/priority-hints.md
@@ -1,7 +1,6 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
-description: Priority Hints provide developers a way to indicate a resource's relative importance
-to the browser, allowing more control over the order resources are loaded.
+description: Priority Hints provide developers a way to indicate a resource's relative importance to the browser, allowing more control over the order resources are loaded.
 
 {# wf_updated_on: 2019-02-15 #}
 {# wf_published_on: 2019-02-14 #}


### PR DESCRIPTION
What's changed, or what was fixed?
- In the priority hints article, the description was 2 lines. This fixes that.

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
