### PR TITLE
Fix a typo in the bug link for Media Keys.

### DIFF
--- a/src/content/en/updates/2019/02/chrome-73-media-updates.md
+++ b/src/content/en/updates/2019/02/chrome-73-media-updates.md
@@ -98,7 +98,7 @@ Check out our existing [developer documentation] and try out the [official Media
 Session samples].
 
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5639924124483584) &#124;
-[Chromium Bug](hhttps://bugs.chromium.org/p/chromium/issues/detail?id=497735)
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=497735)
 
 ## Encrypted Media: HDCP Policy Check {: #hdcp }
 


### PR DESCRIPTION
What's changed, or what was fixed?
Just fixing a bug link typo. s/hhttps/https.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
