### PR TITLE
Removes Google+ links from WebFu

### DIFF
--- a/src/content/en/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/en/fundamentals/discovery/social-discovery/index.md
@@ -97,14 +97,6 @@ in [this page](https://schema.org/docs/full.html).
 metadata to social sites, typical `itemprop` values are `name`, `description`,
 and `image`.
 
-### Learn more
-These microdata provide semantic information to crawlers, typically for
-[Google+](https://plus.google.com/){: .external } and Google Search. To learn more about
-snippets and rendering on Google+, read the following documents:
-
-* [Article Rendering - Google+ Platform](/+/web/snippet/article-rendering)
-* [Snippet - Google+ Platform](/+/web/snippet/)
-
 ### Validate rich snippets
 In order to validate rich snippets on Google+, you can use tools such as:
 
@@ -161,8 +153,7 @@ Properties and contents may take the following values:
 </table>
 
 These meta tags provide semantic information to crawlers from social sites,
-typically from [Google+](https://plus.google.com/){: .external } and
-[Facebook](https://www.facebook.com/){: .external }.
+like [Facebook](https://www.facebook.com/){: .external }.
 
 ### Learn more
 To learn more about things you can attach to the post on Facebook, visit the

--- a/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -364,12 +364,6 @@ Most web servers offer a simple redirect feature. Use `301 (Moved Permanently)`
 to indicate to search engines and browsers that the HTTPS version is canonical,
 and redirect your users to the HTTPS version of your site from HTTP.
 
-## Migration concerns
-
-Many developers have legitimate concerns about migrating from HTTP to HTTPS.
-The Google Webmasters Team has some [excellent
-guidance](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J) available.
-
 ### Search ranking
 
 Google uses [HTTPS as a positive search quality

--- a/src/content/en/shows/polycasts/season-2/AskPolymer_PC27.md
+++ b/src/content/en/shows/polycasts/season-2/AskPolymer_PC27.md
@@ -33,6 +33,4 @@ We’re trying something new here on Polycasts. If you have questions for the te
 <https://youtu.be/mw0ozps3jLM?t=19m46s>
 
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/LLLNvf) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/AskPolymer_PC29.md
+++ b/src/content/en/shows/polycasts/season-2/AskPolymer_PC29.md
@@ -43,5 +43,4 @@ It might seem crazy, but using an element for AJAX is actually pretty great! In 
 <https://customelements.io/bendavis78/paper-time-picker/>
 
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/LLLNvf) to the Google Developers Channel

--- a/src/content/en/shows/polycasts/season-2/Behaviors.md
+++ b/src/content/en/shows/polycasts/season-2/Behaviors.md
@@ -42,6 +42,4 @@ Behaviors unlock amazing potential by letting you mix functionality into your el
 <https://www.youtube.com/watch?v=xz-yixRxZN8&list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN&index=3>
 
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/Data_Binding_101.md
+++ b/src/content/en/shows/polycasts/season-2/Data_Binding_101.md
@@ -27,5 +27,4 @@ Curious to know how Polymer’s data binding system works under the hood? Today 
 <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set>
 
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/LLLNvf) to the Google Developers Channel

--- a/src/content/en/shows/polycasts/season-2/Iron-Iconsets.md
+++ b/src/content/en/shows/polycasts/season-2/Iron-Iconsets.md
@@ -37,6 +37,4 @@ https://www.youtube.com/watch?v=YrlmieL3Z0k&index=1&list=PLOU2XLYxmsII5c3Mgw6fNY
 
 ###More information
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/WebAnimations.md
+++ b/src/content/en/shows/polycasts/season-2/WebAnimations.md
@@ -42,6 +42,4 @@ In this episode I’ll teach you how to use the neon-animation behaviors from th
 
 ###More information
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/binding-to-objects.md
+++ b/src/content/en/shows/polycasts/season-2/binding-to-objects.md
@@ -27,5 +27,4 @@ Binding to objects and subproperties has always confused me. Until now! Today on
 <https://www.polymer-project.org/1.0/docs/devguide/data-binding.html#set-path>
 
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/LLLNvf) to the Google Developers Channel

--- a/src/content/en/shows/polycasts/season-2/create-reusable-elements.md
+++ b/src/content/en/shows/polycasts/season-2/create-reusable-elements.md
@@ -29,6 +29,4 @@ Creating reusable components doesn't have to be so tricky! Use the polyserve too
 - [Moar routing with... more-routing](https://www.youtube.com/watch?v=-67kb7poIT8&list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN&index=4&feature=iv&src_vid=p7Q1mQtFGM8&annotation_id=annotation_1833456187)
 - [Scrolling at 60 frames with core-list](https://www.youtube.com/watch?v=2UKPRbrw3Kk&list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN&index=3&feature=iv&src_vid=p7Q1mQtFGM8&annotation_id=annotation_2675568095)
 
-Join the Polymer G+ community at [https://plus.google.com/communities/115626364525706131031](https://plus.google.com/communities/115626364525706131031)
-
 Subscribe to the Google Developers channel at [https://goo.gl/mQyv5L](//goo.gl/mQyv5L)

--- a/src/content/en/shows/polycasts/season-2/give-your-element-an-API.md
+++ b/src/content/en/shows/polycasts/season-2/give-your-element-an-API.md
@@ -45,7 +45,4 @@ Polymer 0.8: First Look -- Polycasts #13
 
 Polymer Slack: [http://bit.ly/polymerslack](http://bit.ly/polymerslack)
 
-Polymer G+ community: [https://plus.google.com/communities/115626364525706131031](https://plus.google.com/communities/115626364525706131031)
-
 [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/go-offline.md
+++ b/src/content/en/shows/polycasts/season-2/go-offline.md
@@ -44,6 +44,4 @@ description: Take your Polymer app offline, without writing a single line of Jav
 
 Polymer Slack: [http://bit.ly/polymerslack](http://bit.ly/polymerslack)
 
-Polymer G+ community: [https://plus.google.com/communities/115626364525706131031](https://plus.google.com/communities/115626364525706131031)
-
 [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel

--- a/src/content/en/shows/polycasts/season-2/iron-ajax.md
+++ b/src/content/en/shows/polycasts/season-2/iron-ajax.md
@@ -42,7 +42,4 @@ It might seem crazy, but using an element for AJAX is actually pretty great! In 
 <https://www.polymer-project.org/summit>
 
 - [Polymer Slack](http://bit.ly/polymerslack)
-- [Polymer G+ community](https://plus.google.com/communities/115626364525706131031)
 - [Subscribe to the Chrome Developers channel](//goo.gl/LLLNvf)
-
-

--- a/src/content/en/shows/polycasts/season-2/neon-animated-pages.md
+++ b/src/content/en/shows/polycasts/season-2/neon-animated-pages.md
@@ -41,6 +41,4 @@ Now that you understand behaviors, neon-animations, and how the iron-pages eleme
 <https://www.youtube.com/watch?v=YrlmieL3Z0k&list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN&index=4>
 
 - Polymer Slack: <http://bit.ly/polymerslack>
-- Polymer G+ community: <https://plus.google.com/communities/115626364525706131031>
 - [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/polymer-starter-kit.md
+++ b/src/content/en/shows/polycasts/season-2/polymer-starter-kit.md
@@ -38,7 +38,4 @@ description: Polymer Starter Kit is full of amazing tricks! Let’s do a quick i
 
 Polymer Slack: [http://bit.ly/polymerslack](http://bit.ly/polymerslack)
 
-Polymer G+ community: [https://plus.google.com/communities/115626364525706131031](https://plus.google.com/communities/115626364525706131031)
-
 [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/polycasts/season-2/theming-elements.md
+++ b/src/content/en/shows/polycasts/season-2/theming-elements.md
@@ -27,7 +27,5 @@ CSS Custom properties are incredibly powerful. Check out how you can use them to
 - [Extending native elements -- Polycasts #15](https://www.youtube.com/watch?v=OV8BvxpNQOs&list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN)
 - [Create reusable elements with ease -- Polycasts #14](https://www.youtube.com/watch?v=p7Q1mQtFGM8&list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN&index=2)
 - [Polymer Slack](http://bit.ly/polymerslack)
-- [Polymer G+ community](https://plus.google.com/communities/115626364525706131031)
 
 [Subscribe](https://goo.gl/mQyv5L) to the Google Developers Channel
-

--- a/src/content/en/shows/ttt/series-2/windows-commandline.md
+++ b/src/content/en/shows/ttt/series-2/windows-commandline.md
@@ -17,7 +17,7 @@ description: Windows Tooling: If you develop for the web on Windows, this is the
 </div>
 
 
-As devs who spend the majority of our time coding on OSX and Linux, we were [curious](https://plus.google.com/+AddyOsmani/posts/91JeoX83S69) what a modern command-line setup might look like on Windows.
+As devs who spend the majority of our time coding on OSX and Linux, we were curious what a modern command-line setup might look like on Windows.
 
 A StackOverflow [developer survey](https://insights.stackoverflow.com/survey/2015) reminded us that there are more devs using Windows than any other OS so we were curious if the tooling there was on par with what we were used to in *nix land.
 

--- a/src/content/en/updates/2011/10/Spooktacular-HTML5-Pumpkin.md
+++ b/src/content/en/updates/2011/10/Spooktacular-HTML5-Pumpkin.md
@@ -14,11 +14,5 @@ book_path: /web/updates/_book.yaml
 <p>A fun Halloween treat.</p>
 
 <p>
-Thanks to <a href="https://plus.google.com/107226275692313566931/">Rachel Blum</a> for the picture, and <a href="https://plus.google.com/116115719351294422282/">Dan Beam</a> and <a href="https://plus.google.com/117548600251804149016/">James Hawkins</a> for the carving.
+Thanks to Rachel Blum for the picture, Dan Beam, and James Hawkins for the carving.
 </p>
-
-<p>
-Use the <a href="https://plus.google.com/+ChrisWilson/posts/inPnnYp8JoN">HTML5 pumpkin carving template</a> yourself.
-</p>
-
-

--- a/src/content/en/updates/2012/04/WebRTC-Protothon.md
+++ b/src/content/en/updates/2012/04/WebRTC-Protothon.md
@@ -13,8 +13,4 @@ book_path: /web/updates/_book.yaml
 
 On March 24th, Google hosted the world's first WebRTC developer event, the WebRTC [Protothon](http://protothon.com). The hackathon brought together developers and designers from around the world, with browser engineers at hand to give assistance when needed.
 
-For more details, check out the WebRTC [Google+ post](https://plus.google.com/+WebRTCorg/posts/iVsQt4XQcV6) about the event.
-
 Note: the videos and demos have been removed. [The archived page is available](http://protothon.markupartist.com/events/webrtc/).
-
-

--- a/src/content/en/updates/2012/08/Quick-FAQs-on-input-type-date-in-Google-Chrome.md
+++ b/src/content/en/updates/2012/08/Quick-FAQs-on-input-type-date-in-Google-Chrome.md
@@ -11,9 +11,9 @@ book_path: /web/updates/_book.yaml
 {% include "web/_shared/contributors/agektmr.html" %}
 
 
-* This article is written by a Chrome software engineer [Kent Tamura](https://plus.google.com/104770450049736549185/about).
+* This article is written by a Chrome software engineer Kent Tamura.
 
-As you might have already noticed, [Google Chrome supports a datepicker since Chrome 20](https://plus.google.com/107085977904914121234/posts/R5LyvTSa21k). Just by setting the `type` attribute of the `input` element to `date`, the user can click the arrow button and Chrome will pop up a nice calendar widget.
+As you might have already noticed, Google Chrome supports a datepicker since Chrome 20. Just by setting the `type` attribute of the `input` element to `date`, the user can click the arrow button and Chrome will pop up a nice calendar widget.
 
 As we have received a lot of feedback from developers, we'd like to clarify a few things about how to get the best out of using the date picker in this article.
 
@@ -57,6 +57,3 @@ If you'd like to apply jQuery Datepicker only on platforms without `input[type=d
 
     if (!isDateInputSupported())  // or.. !Modernizr.inputtypes.date
       $('input[type="date"]').datepicker();
-
-
-

--- a/src/content/en/updates/2013/11/The-Yeoman-Monthly-Digest-1.md
+++ b/src/content/en/updates/2013/11/The-Yeoman-Monthly-Digest-1.md
@@ -55,6 +55,4 @@ Allo’ Allo’. Welcome to the first issue of the [Yeoman](http://yeoman.io) mo
 * [AngularJS generator v0.5.0/v0.5.1 out](https://github.com/yeoman/generator-angular/blob/master/CHANGELOG.md with bugfixes, better livereloading, automatically wire up selected Angular modules) <span class="external-domain">[github.com/yeoman]</span>
 * [Another Yeoman generator for Backbone and RequireJS](https://github.com/reintroducing/generator-bbr) <span class="external-domain">[github.com/reintroducing]</span>
 
-If there are Yeoman resources you would like to suggest for the next issue, please feel free to suggest them to [@yeoman](http://twitter.com/yeoman) on Twitter or [+Yeoman](https://plus.google.com/101063139999404044459) on Plus and we’ll be sure to check em’ out.
-
-
+If there are Yeoman resources you would like to suggest for the next issue, please feel free to suggest them to [@yeoman](http://twitter.com/yeoman) on Twitter or we’ll be sure to check em’ out.

--- a/src/content/en/updates/2013/12/The-Yeoman-Monthly-Digest-2.md
+++ b/src/content/en/updates/2013/12/The-Yeoman-Monthly-Digest-2.md
@@ -127,7 +127,7 @@ Other official generators including [jQuery](https://github.com/yeoman/generator
 
 ## yo newyear
 
-That's a wrap! If there are Yeoman resources you would like to suggest for the next issue, please feel free to suggest them to [@yeoman](http://twitter.com/yeoman) on Twitter or [+Yeoman](https://plus.google.com/101063139999404044459) on Plus and we’ll be sure to check em’ out. Happy Holidays and have a fantastic new year!
+That's a wrap! If there are Yeoman resources you would like to suggest for the next issue, please feel free to suggest them to [@yeoman](http://twitter.com/yeoman) on Twitter and we’ll be sure to check em’ out. Happy Holidays and have a fantastic new year!
 
 *With special thanks to Stephen Sawchuk, Sindre Sorhus and Pascal Hartig for their review of this issue*
 

--- a/src/content/en/updates/2014/02/The-Yeoman-Monthly-Digest-3.md
+++ b/src/content/en/updates/2014/02/The-Yeoman-Monthly-Digest-3.md
@@ -122,7 +122,7 @@ Finally, updates have also been made to our official [Ember.js](https://github.c
 
 ## Until next time
 
-If you’ve written an article, given a talk or created a generator you think would be useful to others, please feel free to share it with us on [Twitter](https://twitter.com/yeoman) or [Google+](https://plus.google.com/101063139999404044459/posts). We’re always interested in seeing how our tools are used.
+If you’ve written an article, given a talk or created a generator you think would be useful to others, please feel free to share it with us on [Twitter](https://twitter.com/yeoman). We’re always interested in seeing how our tools are used.
 
 Until the next time we run `yo digest`, happy scaffolding and don't be afraid - Yeoman is here to help, not replace you :D
 

--- a/src/content/en/updates/2015/01/What-the-Viewport.md
+++ b/src/content/en/updates/2015/01/What-the-Viewport.md
@@ -22,7 +22,7 @@ approximately 980px of screen real estate and render at this size. With a viewpo
 tag, developers could define the width, most common of which is "device-width", which sets the screen size to that of the device. You can [learn more on Web
 Fundamentals](/web/fundamentals/design-and-ux/responsive/#set-the-viewport).
 
-The way [Rick Byers](https://plus.google.com/+RickByers/about) describes the virtual viewport is
+The way Rick Byers describes the virtual viewport is
 as follows: the idea of the virtual viewport is to split the notion of "the
 viewport" into two, "the layout viewport" (where fixed position items are attached)
 and "the visual viewport" (What the users actually see).
@@ -30,10 +30,10 @@ and "the visual viewport" (What the users actually see).
 ## **Super Simple Example**
 
 The website videojs.com is a good example because it's appbar is fixed to the
-top and has links on both the left and right side of the appbar.  
+top and has links on both the left and right side of the appbar.
 
 The image below shows what you would see if you zoomed in on a site and tried
-panning left and right.  
+panning left and right.
 
 The top devices are Chrome M39, which doesn't have a virtual viewport
 and the bottom 3 are from Chrome M40, which has a virtual viewport.
@@ -48,7 +48,7 @@ and the bottom 3 are from Chrome M40, which has a virtual viewport.
 
 In Chrome M39, you will see the appbar after you zoom in,
 but scrolling to the right doesn't allow you to view the links on the right side
-of the bar, you'll only ever see the logo.  
+of the bar, you'll only ever see the logo.
 
 Compare this to Chrome M40 (which has a "virtual viewport") and you'll see that
 the "visual viewport" scrolls everything inside the "layout viewport", allowing
@@ -63,14 +63,10 @@ The only major developer facing change that comes with this is that in M39, you 
 
 ### **More Solid Info**
 
-You want to learn more huh?  
+You want to learn more huh?
 
-Well then, you can view the slide deck below OR check out [Rick's Google+
-Post](https://plus.google.com/+RickByers/posts/bpxrWN4G3X5), which you really
-should do since he's much better at this stuff than me ;)  
+Well then, you can view the slide deck below.
 
 <p style="text-align: center;">
   <iframe src="https://docs.google.com/presentation/embed?id=1nJvJqL2dw5STi5FFpR6tP371vSpDWWs5Beksbfitpzc&amp;start=false&amp;loop=false&amp;" frameborder="0" style="max-width: 600px; width: 100%; height: 400px;"></iframe>
 </p>
-
-

--- a/src/content/en/updates/2015/03/creating-semantic-sites-with-web-components-and-jsonld.md
+++ b/src/content/en/updates/2015/03/creating-semantic-sites-with-web-components-and-jsonld.md
@@ -64,7 +64,7 @@ As a first step, we embed the data in the page using a JSON-LD script:
     <script type="application/ld+json">
     {...}
     </script>
-    
+
 
 This way we ensure that the data is easily accessible to other consumers supporting schema.org standard and the JSON-LD format, e.g. search engines.
 
@@ -78,14 +78,14 @@ In order to do so, we import them to our page using [HTML imports](https://www.p
 
     <link rel="import" href="bower_components/google-map-jsonld/google-map-jsonld.html">
     <link rel="import" href="bower_components/address-dropdown-jsonld/address-dropdown-jsonld.html">
-    
+
 
 Once they are imported, we can use them on our page:
 
 
     <address-dropdown-jsonld jsonld=""></address-dropdown-jsonld>
     <google-map-jsonld jsonld=""></google-map-jsonld>
-    
+
 
 Finally, we hook the JSON-LD data and the elements together. We do so in a [polymer-ready callback](https://www.polymer-project.org/docs/polymer/polymer.html#polymer-ready) (it is an event that triggers when the components are ready to use). Because the elements can be configured via attributes, it is enough to assign our JSON-LD data to the appropriate attribute of the component:
 
@@ -97,7 +97,7 @@ Finally, we hook the JSON-LD data and the elements together. We do so in a [poly
         document.querySelector('google-map-jsonld').jsonld = jsonld['@graph'];
         document.querySelector('address-dropdown-jsonld').jsonld = jsonld['@graph'];
       });
-    
+
 
 ## JSON-LD, the powerful brother of JSON
 
@@ -114,6 +114,4 @@ To sum up, JSON-LD and schema.org combined with the web components technology en
 You can try out [the examples on Github](https://github.com/PolymerLabs/structured-data-web-components) or read the Polymer’s guide on [creating reusable components](https://www.polymer-project.org/docs/start/reusableelements.html) to start writing your own.
 Check the [Structured Data documentation](/structured-data/) on developers.google.com to get inspired about various entities you can mark up with JSON-LD.
 
-Consider submitting your shiny new elements to [customelements.io](http://customelements.io/){: .external } for others to enjoy and give us a shout at [@polymer](https://twitter.com/intent/follow?screen_name=polymer) or [+Polymer community](https://plus.google.com/communities/115626364525706131031) to show off the awesomeness!
-
-
+Consider submitting your shiny new elements to [customelements.io](http://customelements.io/){: .external } for others to enjoy and give us a shout at [@polymer](https://twitter.com/intent/follow?screen_name=polymer) to show off the awesomeness!

--- a/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
+++ b/src/content/en/updates/2015/07/interact-with-ble-devices-on-the-web.md
@@ -41,7 +41,7 @@ finalized yet, the Chrome Team is actively looking for enthusiastic developers
 [feedback on the implementation](https://bugs.chromium.org/p/chromium/issues/entry?components=Blink%3EBluetooth).
 
 A subset of the Web Bluetooth API is available in Chrome OS,
-Chrome for Android M, Mac (Chrome 56) and Windows 10 (Chrome 70). 
+Chrome for Android M, Mac (Chrome 56) and Windows 10 (Chrome 70).
 This means you should be able to
 [request](#request_bluetooth_devices) and [connect to](#connect_to_a_bluetooth_device)
 nearby Bluetooth devices,
@@ -506,7 +506,6 @@ Though it's still incomplete, here's a sneak peek of what to expect in the near 
 ## Resources
 
 - Stack Overflow: [https://stackoverflow.com/questions/tagged/web-bluetooth](https://stackoverflow.com/questions/tagged/web-bluetooth)
-- Web Bluetooth Community: [https://plus.google.com/communities/108953318610326025178](https://plus.google.com/communities/108953318610326025178)
 - Chrome Feature Status: [https://www.chromestatus.com/feature/5264933985976320](https://www.chromestatus.com/feature/5264933985976320)
 - Implementation Bugs: [https://crbug.com/?q=component:Blink>Bluetooth](https://crbug.com/?q=component:Blink>Bluetooth)
 - Web Bluetooth Spec: [https://webbluetoothcg.github.io/web-bluetooth](https://webbluetoothcg.github.io/web-bluetooth)
@@ -518,5 +517,3 @@ Though it's still incomplete, here's a sneak peek of what to expect in the near 
           data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
   </iframe>
 </div>
-
-

--- a/src/content/en/updates/2017/01/nic56.md
+++ b/src/content/en/updates/2017/01/nic56.md
@@ -26,7 +26,7 @@ description: What's new in Chrome 56 for developers? Web Bluetooth API, CSS Posi
   elements that scroll normally until sticking to the top of the viewport.
 * And [HTML5 by Default](#html5-by-default) is enabled for all users.
 
-I’m Pete LePage, let’s dive in and see what’s new for developers in Chrome 56. 
+I’m Pete LePage, let’s dive in and see what’s new for developers in Chrome 56.
 
 <div class="clearfix"></div>
 
@@ -52,19 +52,18 @@ nearby devices even easier.
 Francois has a great
 [article on Updates](/web/updates/2015/07/interact-with-ble-devices-on-the-web),
 be sure to check out some of neat [demos](https://github.com/WebBluetoothCG/demos)
-to go along with it. And be sure to check out the
-[Web Bluetooth Community](https://plus.google.com/communities/108953318610326025178).
+to go along with it.
 
 ## CSS `position: sticky;` {: #position-sticky }
 
 Previously, building content headers that scrolled normally until sticking
 to the top of the viewport required listening to scroll events and
-switching an element’s position from relative to fixed at a specified threshold. 
+switching an element’s position from relative to fixed at a specified threshold.
 It was difficult to synchronize, and often results in small visual jumps.
 
 Chrome now supports CSS
 [`position: sticky;`](//developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning),
-a new way to position elements. 
+a new way to position elements.
 
 An element that is position sticky, starts relative; but becomes fixed,
 after the element reaches a certain scroll position.
@@ -88,7 +87,7 @@ Last August, we announced that we’d be
 to offer a safer, more power-efficient experience. This change disables Adobe
 Flash Player unless there’s a user indication that they want Flash content on
 specific sites, and eventually all websites will require the user’s permission
-to run Flash. 
+to run Flash.
 
 In Chrome 56,
 [HTML5 By Default has been enabled for all users](//blog.chromium.org/2016/12/roll-out-plan-for-html5-by-default.html ),
@@ -108,7 +107,7 @@ And of course, there’s plenty more.
 
 
 If you want to stay up to date with Chrome and know what’s coming, be sure to
-[subscribe](https://goo.gl/6FP1a5), follow 
+[subscribe](https://goo.gl/6FP1a5), follow
 [@ChromiumDev](//twitter.com/chromiumdev) on Twitter and be sure to check
 out the [videos from the Chrome Dev Summit](https://www.youtube.com/playlist?list=PLNYkxOF6rcIBTs2KPy1E6tIYaWoFcG3uj)
 for a deeper dive into some of the awesome things the Chrome team is working on.
@@ -116,7 +115,7 @@ for a deeper dive into some of the awesome things the Chrome team is working on.
 I’m Pete LePage, and as soon as Chrome 57 is released, I’ll be right here to tell you -- what’s new in Chrome!
 
 ## Subscribe to Chrome Developers on YouTube {: .hide-from-toc }
-Subscribe to our [YouTube channel](https://goo.gl/6FP1a5) or our 
+Subscribe to our [YouTube channel](https://goo.gl/6FP1a5) or our
 [RSS feed](/web/shows/rss.xml)
 
 <link rel="alternate" type="application/rss+xml" title="Web Shows from Google Developers (RSS)" href="/web/shows/rss.xml">
@@ -141,4 +140,3 @@ Subscribe to our [YouTube channel](https://goo.gl/6FP1a5) or our
 
 Oh, and a big thanks to Andrew for lending me his shirt! I had a bit of a
 wardrobe malfunction.
-

--- a/src/content/es/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/es/fundamentals/discovery/social-discovery/index.md
@@ -24,7 +24,7 @@ Puedes influenciar el modo en que aparece tu sitio cuando se comparte por redes 
 debes agregar algunas líneas de código a cada página. Lo anterior puede ayudar a incrementar la interacción de los usuarios gracias al
 suministro de vistas previas con más información de lo que estaría disponible de otra forma.
 Sin estas vistas previas, los sitios sociales solo brindarán información básica, sin imágenes o
-información útil de otro tipo. 
+información útil de otro tipo.
 
 ¿Sobre cuál crees que es más probable que se haga clic? Las personas se sienten más atraídas por las imágenes
 y están más seguras de que les gustará lo que encontrarán cuando tienen una vista previa
@@ -96,18 +96,10 @@ en [esta página](https://schema.org/docs/full.html).
 metadatos a sitios sociales, los valores `itemprop` típicos son `name`, `description`,
  y por último `image`.
 
-### Obtén más información
-Estos microdatos proveen información semántica a los rastreadores, generalmente para
-[Google+](https://plus.google.com/){: .external } y Búsqueda de Google. Para obtener más información sobre
-fragmentos y representación en Google+, lee los siguientes documentos:
-
-* [Representación de artículos - Plataforma Google+](/+/web/snippet/article-rendering)
-* [Fragmento - Plataforma Google+](/+/web/snippet/)
-
 ### Valida fragmentos enriquecidos
 Para validar fragmentos enriquecidos en Google+, puedes usar las siguientes herramientas:
 
-* [Herramienta de prueba de datos estructurados](https://www.google.com/webmasters/tools/richsnippets) - Herramientas para webmasters de Google  
+* [Herramienta de prueba de datos estructurados](https://www.google.com/webmasters/tools/richsnippets) - Herramientas para webmasters de Google
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
@@ -160,8 +152,7 @@ Las propiedades y los contenidos pueden tomar los siguientes valores:
 </table>
 
 Estas metaetiquetas proporcionan información semántica a los rastreadores desde los sitios sociales,
-generalmente desde [Google+](https://plus.google.com/){: .external } y
-[Facebook](https://www.facebook.com/){: .external }.
+generalmente desde [Facebook](https://www.facebook.com/){: .external }.
 
 ### Obtén más información
 Para obtener más información sobre los elementos que puedes adjuntar a la publicación de Facebook, visita el sitio oficial de
@@ -186,7 +177,7 @@ Para que una Twitter Card funcione, [tu dominio debe ser
 aprobado](https://cards-dev.twitter.com/validator) y debe
 contener una metaetiqueta que contiene `twitter:card` como el atributo `name` en lugar del atributo
 `property`.
-  
+
 Aquí puedes ver un ejemplo rápido:
 
 <pre class="prettyprint">
@@ -223,7 +214,7 @@ Nota que los microdatos y el OGP comparten cierto marcado:
 * `title` y `description` se comparten entre microdatos y OGP
 * `itemprop="image"` está utilizando la etiqueta `link` con el atributo `href` en lugar de
 reutilizar la etiqueta `meta` con `property="og:image"`
-  
+
 Por último, asegúrate de validar que tu página web aparezca como lo esperas en cada
 sitio social antes de publicarla.
 

--- a/src/content/es/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/es/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -299,11 +299,6 @@ que se ejecutan. [Esta página de ONWASP explica cómo configurar el marcador Se
 La mayoría de los servidores web ofrecen una función simple de redireccionamiento. Usa `301 (Moved Permanently)` para
 indicar a los motores de búsqueda y a los navegadores que la versión de HTTPS es canónica y para redireccionar a tus usuarios de la versión HTTP a la versión HTTPS de tu sitio.
 
-## Inquietudes sobre la migración
-
-Muchos programadores tienen dudas válidas sobre la migración de HTTP a HTTPS.
-El equipo de Google Webmasters tiene algunas [pautas excelentes](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J) disponibles.
-
 ### Ranking de búsqueda
 
 Google usa [HTTPS como indicador de buena calidad de búsqueda](https://googlewebmastercentral.blogspot.com/2014/08/https-as-ranking-signal.html).

--- a/src/content/id/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/id/fundamentals/discovery/social-discovery/index.md
@@ -24,7 +24,7 @@ Anda bisa memengaruhi cara penampilan situs saat dibagikan lewat media sosial de
 menambahkan beberapa baris kode ke setiap laman. Ini bisa membantu meningkatkan interaksi dengan menyediakan
 pratinjau dengan informasi yang lebih lengkap daripada yang disediakan situs lain.
 Tanpa ini, situs sosial hanya akan menyediakan informasi dasar, tanpa gambar atau
-informasi berguna lainnya. 
+informasi berguna lainnya.
 
 Manakah yang menurut Anda lebih cenderung diklik? Orang-orang tertarik pada gambar
 dan merasa lebih yakin mereka akan suka apa mereka temukan bila mereka memiliki
@@ -96,18 +96,10 @@ di [laman ini](https://schema.org/docs/full.html).
 metadata ke situs sosial, nilai-nilai `itemprop` yang umum adalah `name`, `description`,
 dan `image`.
 
-### Ketahui selengkapnya
-Mikrodata ini menyediakan informasi semantik kepada perayap, biasanya untuk
-[Google+](https://plus.google.com/){: .external } dan Google Penelusuran. Untuk mengetahui selengkapnya tentang
-cuplikan kode dan rendering di Google+, bacalah dokumen berikut:
-
-* [Rendering Artikel - Platform Google+](/+/web/snippet/article-rendering)
-* [Cuplikan - Platform Google+](/+/web/snippet/)
-
 ### Validasikan cuplikan yang lengkap
 Untuk memvalidasi cuplikan yang lengkap di Google+, Anda bisa menggunakan alat seperti:
 
-* [Alat (Bantu) Pengujian Data Terstruktur](https://www.google.com/webmasters/tools/richsnippets) - Alat Webmaster  
+* [Alat (Bantu) Pengujian Data Terstruktur](https://www.google.com/webmasters/tools/richsnippets) - Alat Webmaster
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
@@ -160,8 +152,7 @@ Properti dan materi dapat mengambil nilai-nilai berikut:
 </table>
 
 Tag meta ini menyediakan informasi semantik kepada perayap dari situs sosial,
-biasanya dari [Google+](https://plus.google.com/){: .external } dan
-[Facebook](https://www.facebook.com/){: .external }.
+biasanya dari [Facebook](https://www.facebook.com/){: .external }.
 
 ### Ketahui selengkapnya
 Untuk mengetahui selengkapnya tentang apa saja yang bisa Anda lampirkan ke entri blog di Facebook, kunjungi
@@ -186,7 +177,7 @@ Agar Twitter Card bisa berfungsi, [domain Anda harus
 telah disetujui](https://cards-dev.twitter.com/validator) dan harus
 berisi tag meta yang memiliki `twitter:card` sebagai atribut `name`, sebagai ganti atribut
 `property`.
-  
+
 Inilah contoh ringkasnya:
 
 <pre class="prettyprint">
@@ -223,7 +214,7 @@ Perhatikan, mikrodata dan OGP berbagi beberapa markup:
 * `title` dan `description` digunakan bersama mikrodata dan OGP
 * `itemprop="image"` menggunakan tag `link` dengan atribut `href` sebagai ganti
 menggunakan ulang tag `meta` dengan `property="og:image"`
-  
+
 Terakhir, pastikan memvalidasi bahwa laman web Anda tampil sesuai harapan pada setiap
 situs sosial sebelum mempublikasikannya.
 

--- a/src/content/id/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/id/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -299,11 +299,6 @@ yang disetelnya. [Laman OWASP ini menjelaskan cara menyetel flag Secure](https:/
 Sebagian besar server web menawarkan fitur pengalihan sederhana. Gunakan `301 (Moved Permanently)` untuk
 menunjukkan ke mesin telusur dan browser bahwa versi HTTPS bersifat kanonis dan mengalihkan pengguna Anda ke versi HTTPS situs Anda dari HTTP.
 
-## Persoalan dalam migrasi
-
-Banyak developer memiliki persoalan yang sudah sewajarnya tentang migrasi dari HTTP ke HTTPS.
-Google Webmaster Team memberikan beberapa [panduan bagus](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J).
-
 ### Peringkat penelusuran
 
 Google menggunakan [HTTPS sebagai indikator kualitas penelusuran positif](https://googlewebmastercentral.blogspot.com/2014/08/https-as-ranking-signal.html).

--- a/src/content/ja/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/ja/fundamentals/discovery/social-discovery/index.md
@@ -24,7 +24,7 @@ description: サイトの各ページにコードを数行追加すると、ソ�
 リッチな情報を追加でプレビュー表示すると、エンゲージメントを高めることができます。この対応を行わないと、ソーシャル サイトの基本情報しか表示されず、画像やその他の有用な情報が提供されません。
 
 
- 
+
 
 ユーザーは以下のどちらのページをクリックする可能性が高いと思いますか。ユーザーは画像に引かれるため、先にプレビューが目に入ると、そのサイトにさらに興味を持つようになります。
 
@@ -89,20 +89,10 @@ description: サイトの各ページにコードを数行追加すると、ソ�
 ###  `itemprop` を追加して schema.org ボキャブラリで各アイテムを記述する
 `itemprop` は、スコープ内の `itemtype` のプロパティを定義します。メタデータをソーシャル サイトに提供する場合、一般的に使用する `itemprop` の値は `name`、`description`、および `image` です。
 
-
-
-###  詳細
-このような microdata によって、主に [Google+](https://plus.google.com/){: .external } や Google 検索用の意味情報がクローラに提供されます。
-Google+ のスニペットやレンダリングの詳細については、次のドキュメントをご覧ください。
-
-
-* [Article Rendering - Google+ Platform](/+/web/snippet/article-rendering)
-* [Snippet - Google+ Platform](/+/web/snippet/)
-
 ###  リッチ スニペットを検証する
 Google+ のリッチ スニペットを検証する場合、次のようなツールを使用できます。
 
-* [構造化データ テストツール](https://www.google.com/webmasters/tools/richsnippets) - ウェブマスター ツール  
+* [構造化データ テストツール](https://www.google.com/webmasters/tools/richsnippets) - ウェブマスター ツール
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
@@ -154,9 +144,6 @@ Google+ のリッチ スニペットを検証する場合、次のようなツ�
   </tbody>
 </table>
 
-これらのメタタグによって、主に [Google+](https://plus.google.com/){: .external } や [Facebook](https://www.facebook.com/){: .external } などのソーシャル サイトのクローラに意味情報が提供されます。
-
-
 
 ###  詳細
 Facebook の投稿に表示できる画像やデータの詳細については、Open Graph Protocol の公式サイトをご覧ください。
@@ -179,7 +166,7 @@ Twitter カードを適切に表示するには、[ドメインが承認され�
 
 
 
-  
+
 
 
 <pre class="prettyprint">
@@ -217,7 +204,7 @@ microdata と OGP が同じマークアップを共有していることに注�
 * `itemprop="image"` は、`property="og:image"` を指定した `meta` タグを再利用する代わりに、`href` 属性を指定した `link` タグを使用しています。
 
 最後に、ウェブページを公開する前に、各ソーシャル サイトにウェブページが想定どおりに表示されることを確認してください。
-  
+
 
 
 

--- a/src/content/ja/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/ja/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -294,12 +294,6 @@ jquery.com など、ほとんどの会社はこのサービスを提供してい
 
 ほとんどのウェブサーバーは、単純なリダイレクト機能を提供しています。`301 (Moved Permanently)` を使用して、HTTPS バージョンが標準であり、ユーザーを HTTP からサイトの HTTPS バージョンにリダイレクトすることを、検索エンジンやブラウザに示します。
 
-
-##  移行に関する懸念事項
-
-多くのデベロッパーが HTTP から HTTPS への移行に懸念を抱くのはもっともです。そこで、Google Webmasters チームは[すばらしいガイダンス](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J)を用意しています。
-
-
 ###  検索ランキング
 
 [Google では、HTTPS を優れた検索品質のインジケーターとして使用しています](https://googlewebmastercentral.blogspot.com/2014/08/https-as-ranking-signal.html)。また、Google は、検索ランクを維持したまま[サイトを転送、移動、または移行する方法](https://support.google.com/webmasters/topic/6029673)に関するガイドも発行しています。

--- a/src/content/ko/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/ko/fundamentals/discovery/social-discovery/index.md
@@ -24,7 +24,7 @@ description: 각 페이지에 코드를 몇 줄 추가하여 소셜 미디어를
 사이트 모습에 변화를 줄 수 있습니다. 그러면 이런 방법을 사용할 수 없을 때에 비해
 미리보기에 더욱 풍성한 정보를 포함시킬 수 있으므로 사용자 참여도를 높이는 효과를 거둘 수 있습니다.
 이런 방법을 사용할 수 없다면
-소셜 사이트에서 이미지나 다른 유용한 정보가 없는 기본적인 정보만 제공할 것입니다. 
+소셜 사이트에서 이미지나 다른 유용한 정보가 없는 기본적인 정보만 제공할 것입니다.
 
 둘 중 어떤 소셜 사이트를 클릭할 가능성이 더 높을까요? 사람들은 무미건조한 텍스트보다는
 이미지에 끌리게 마련이고, 미리보기가 제공되어 찾으려 했던 정보와 연관된 이미지가 보이면
@@ -96,18 +96,10 @@ description: 각 페이지에 코드를 몇 줄 추가하여 소셜 미디어를
 메타데이터를 제공할 경우 일반적인 `itemprop` 값은 `name`, `description`
 및 `image`입니다.
 
-### 자세히 알아보기
-이런 마이크로데이터는 보통
-[Google+](https://plus.google.com/){: .external }와 Google 검색을 위해 크롤러에 의미론적 정보를 제공합니다. Google+에서의 스니펫과
-렌더링에 대한 자세한 내용은 다음 문서를 참조하세요.
-
-* [문서 렌더링 - Google+ 플랫폼](/+/web/snippet/article-rendering)
-* [스니펫 - Google+ 플랫폼](/+/web/snippet/)
-
 ### 리치 스니펫 유효성 검사
 Google+에서는 다음과 같은 도구를 사용하여 리치 스니펫의 유효성을 검사할 수 있습니다.
 
-* [구조적 데이터 테스트 도구](https://www.google.com/webmasters/tools/richsnippets) - 웹마스터 도구  
+* [구조적 데이터 테스트 도구](https://www.google.com/webmasters/tools/richsnippets) - 웹마스터 도구
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
@@ -160,8 +152,7 @@ Google+에서는 다음과 같은 도구를 사용하여 리치 스니펫의 유
 </table>
 
 이런 메타 태그는
-전형적으로 [Google+](https://plus.google.com/){: .external } 및
-[Facebook](https://www.facebook.com/){: .external } 같은 소셜 사이트에서 크롤러에게 의미론적 정보를 제공합니다.
+전형적으로 [Facebook](https://www.facebook.com/){: .external } 같은 소셜 사이트에서 크롤러에게 의미론적 정보를 제공합니다.
 
 ### 자세히 알아보기
 Facebook의 게시물에 첨부할 수 있는 항목에 대한 자세한 내용은
@@ -175,7 +166,7 @@ Open Graph Protocol 공식 사이트에서 확인할 수 있습니다.
 * [디버거](https://developers.facebook.com/tools/debug/){: .external }
 
 ## Twitter Card를 사용하여 Twitter에서 리치 스니펫 제공
-[Twitter Card](https://dev.twitter.com/docs/cards)는 
+[Twitter Card](https://dev.twitter.com/docs/cards)는
 [Twitter에 사용할 수 있는 Open Graph Protocol](https://twitter.com/){: .external }에 대한 확장 프로그램입니다. Twitter Card를
 사용하면 자신의 웹페이지로 연결되는 링크를 포함한 트윗에 이미지와 동영상 같은 미디어 첨부파일을 추가할 수
 있습니다. 알맞은 메타데이터를 추가하면 페이지로 연결되는 링크를 포함한 트윗에 자신이 추가한
@@ -186,7 +177,7 @@ Twitter Card가 작동하도록 하려면 [도메인 승인을 받아야
 하고](https://cards-dev.twitter.com/validator)
 `twitter:card`가 `property` 속성 대신 `name` 속성으로 있는 메타 태그가 도메인에 포함되어 있어야
 합니다.
-  
+
 간단한 예를 들면 다음과 같습니다.
 
 <pre class="prettyprint">
@@ -223,7 +214,7 @@ Twitter Card에 대해 자세히 알아보려면 아래 사이트를 방문해 �
 * `title`과 `description`은 마이크로데이터와 OGP 사이에 공유됨
 * `itemprop="image"`는 `property="og:image"`로 `meta` 태그를 재사용하는 대신
 `href` 속성이 있는 `link` 태그를 사용함
-  
+
 마지막으로, 웹페이지가 각각의 소셜 사이트에서 생각했던 대로 나타나는지 확인한 후에
 게시해야 합니다.
 

--- a/src/content/ko/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/ko/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -299,11 +299,6 @@ HTTPS가 사이트에 액세스할 수 있는 가장 좋은 방법임을 검색 
 대부분의 웹 서버는 단순한 리디렉션 기능을 제공합니다. `301 (Moved Permanently)`를 사용하여
 검색 엔진 및 브라우저에 HTTPS 버전이 기본임을 알리고 사용자를 사이트의 HTTP 버전에서 HTTPS 버전으로 리디렉션하세요.
 
-## 마이그레이션 우려 사항
-
-대부분의 개발자는 HTTP에서 HTTPS로 마이그레이션에 대해 우려합니다.
-Google 웹마스터 팀에서 [우수한 안내 서비스](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J)를 제공합니다.
-
 ### 검색 순위
 
 Google은 [HTTPS를 긍정적인 검색 품질 지표로 사용합니다](https://googlewebmastercentral.blogspot.com/2014/08/https-as-ranking-signal.html).

--- a/src/content/nl/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/nl/fundamentals/discovery/social-discovery/index.md
@@ -61,20 +61,14 @@ De type van een item kan worden gespecificeerd met het `itemtype` attribuut same
 ### Voeg `itemprop` toe om ieder item te beschrijven volgens het schema.org vocabulaire
 `itemprop`s defineren eigenschappen voor `itemtype`s in de scope. Voor sociale media metadata is voornamelijk de `itemprop` waardes van `name`, `description` and `image` het meest relevant.
 
-### Leer meer
-Deze microdata levert semantische data aan crawlers, voornamelijk [Google+](https://plus.google.com/){: .external } en Google Search. Om meer te leren over snippets en rendering op Google+ lees de volgende documenten:
-
-* [Article Rendering - Google+ Platform](/+/web/snippet/article-rendering)
-* [Snippet - Google+ Platform](/+/web/snippet/)
-
 ### Valideer rich snippets
 Om rich snippets te valideren op Google+ kan je deze tools gebruiken:
 
-* [Structured Data Testing Tool](http://www.google.com/webmasters/tools/richsnippets){: .external } - Webmaster Tools  
+* [Structured Data Testing Tool](http://www.google.com/webmasters/tools/richsnippets){: .external } - Webmaster Tools
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
-* [Semantic inspector](https://chrome.google.com/webstore/detail/semantic-inspector/jobakbebljifplmcapcooffdbdmfdbjh/reviews){: .external } - Chrome Extension  
+* [Semantic inspector](https://chrome.google.com/webstore/detail/semantic-inspector/jobakbebljifplmcapcooffdbdmfdbjh/reviews){: .external } - Chrome Extension
 
 <img src="imgs/semantic-inspector.png" srcset="imgs/semantic-inspector.png 1x, imgs/semantic-inspector-2x.png 2x" />
 
@@ -121,7 +115,7 @@ Een `meta` tag bevat een `property` attribuut en een `content` attribuut.
   </tbody>
 </table>
 
-Deze meta tags bevatten semantische informatie voor sociale media crawlers, voornamelijk van Google+](https://plus.google.com/){: .external } en [Facebook](https://www.facebook.com/).
+Deze meta tags bevatten semantische informatie voor sociale media crawlers, voornamelijk van [Facebook](https://www.facebook.com/).
 
 ### Leer meer
 Om meer te leren over wat je kan toevoegen aan een Facebook post, bezoek de officieele Open Graph Protocol site:

--- a/src/content/pt-br/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/pt-br/fundamentals/discovery/social-discovery/index.md
@@ -24,7 +24,7 @@ Você pode influenciar a forma com que o site é exibido quando compartilhado
 em redes sociais adicionando algumas linhas de código a cada página. Ajuda a gerar mais envolvimento
 quando se oferece prévias com informações mais valiosas do que as normalmente oferecidas.
 Sem isso, as redes sociais forneceriam apenas informações básicas, sem imagens ou
-outras informações úteis. 
+outras informações úteis.
 
 Qual dos dois você acha que tem mais chances de receber um clique? As pessoas são atraídas por imagens
 e sentem-se mais confiantes de que vão gostar do conteúdo quando veem uma
@@ -96,18 +96,12 @@ de conteúdo da sua página da web. Veja um exemplo relevante
 metadados em sites sociais, os valores comuns para `itemprop` são `name`, `description`
 e `image`.
 
-### Saiba mais
-Esses microdados fornecem informações semânticas aos rastreadores, normalmente do
-[Google+](https://plus.google.com/){: .external } e da Pesquisa do Google. Para saber mais
-sobre fragmentos e renderização no Google+, leia os documentos abaixo:
 
-* [Renderização de artigo - Plataforma Google+](/+/web/snippet/article-rendering)
-* [Fragmento - Plataforma Google+](/+/web/snippet/)
 
 ### Valide fragmentos ricos
 Para validar fragmentos ricos no Google+, você pode usar ferramentas como:
 
-* [Ferramenta de teste de dados estruturados](https://www.google.com/webmasters/tools/richsnippets) - Webmaster Tools  
+* [Ferramenta de teste de dados estruturados](https://www.google.com/webmasters/tools/richsnippets) - Webmaster Tools
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
@@ -160,8 +154,7 @@ As propriedades e os conteúdos podem ter os seguintes valores:
 </table>
 
 Essas tags "meta" fornecem informações semânticas aos rastreadores dos sites sociais,
-normalmente do [Google+](https://plus.google.com/){: .external } e
-do [Facebook](https://www.facebook.com/){: .external }.
+normalmente do [Facebook](https://www.facebook.com/){: .external }.
 
 ### Saiba mais
 Para saber mais sobre que coisas você pode anexar a uma postagem do Facebook, acesse o site oficial
@@ -186,7 +179,7 @@ Para fazer um cartão do Twitter funcionar, [o seu domínio deve
 ser aprovado](https://cards-dev.twitter.com/validator) e
 conter uma tag "meta" que tenha `twitter:card` como o atributo `name` em vez de o atributo
 `property`.
-  
+
 Veja um exemplo rápido:
 
 <pre class="prettyprint">
@@ -223,7 +216,7 @@ Observe que os microdados e o OGP compartilham parte da marcação:
 * `title` e `description` são compartilhadas entre microdados e OGP
 * `itemprop="image"` está usando a tag `link` com o atributo `href` em vez de
 reutilizar a tag `meta` com `property="og:image"`
-  
+
 Para fechar, não deixe de confirmar que sua página web é exibida como o esperado em cada
 rede social antes de publicar.
 

--- a/src/content/pt-br/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/pt-br/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -299,11 +299,6 @@ que ele define. [Essa página da OWASP explica como aplicar o sinalizador Secure
 A maioria dos servidores da Web oferece um recurso simples de redirecionamento. Use `301 (Moved Permanently)` para
 indicar aos mecanismos de pesquisa e navegadores que a versão HTTPS é canônica, e redirecione os usuários da versão HTTP para a versão HTTPS do site.
 
-## Questões da migração
-
-Muitos desenvolvedores têm preocupações válidas sobre a migração de HTTP para HTTPS.
-A equipe de webmasters do Google tem [orientações excelentes](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J) disponíveis.
-
 ### Classificação das pesquisas
 
 O Google usa [HTTPS como um indicador de qualidade positivo para a pesquisa](https://googlewebmastercentral.blogspot.com/2014/08/https-as-ranking-signal.html) e,

--- a/src/content/zh-cn/fundamentals/discovery/social-discovery/index.md
+++ b/src/content/zh-cn/fundamentals/discovery/social-discovery/index.md
@@ -24,7 +24,7 @@ description:您只需为每个页面添加几行代码，就可以影响通过�
 这可能有助于提高吸引力，因为提供的预览所包含的信息要比以其他方式提供的信息更加丰富。如果没有它，社交网站只能提供不含图片或其他有帮助信息的基本信息。
 
 
- 
+
 
 您认为下面哪一个被点击的可能性更大？用户容易被图片吸引，如果能提前预览，就会更坚信他们会喜欢自己找到的内容。
 
@@ -90,19 +90,10 @@ description:您只需为每个页面添加几行代码，就可以影响通过�
 `itemprop` 定义作用域中 `itemtype` 的属性。对于向社交网站提供元数据，典型的 `itemprop` 值为 `name`、`description` 和 `image`。
 
 
-
-### 了解详情
-这些 microdata 向抓取工具（通常是 [Google+](https://plus.google.com/){: .external } 和 Google 搜索）提供语义信息。
-如需了解有关 Google+ 上摘要和渲染的更多信息，请阅读下列文档：
-
-
-* [文章渲染 - Google+ 平台](/+/web/snippet/article-rendering)
-* [摘要 - Google+ 平台](/+/web/snippet/)
-
 ### 验证丰富摘要
 要验证 Google+ 上的丰富摘要，您可以使用下面这样的工具：
 
-* [结构化数据测试工具](https://www.google.com/webmasters/tools/richsnippets) - 网站站长工具  
+* [结构化数据测试工具](https://www.google.com/webmasters/tools/richsnippets) - 网站站长工具
 
 <img src="imgs/webmaster-tools.png" srcset="imgs/webmaster-tools.png 1x, imgs/webmaster-tools-2x.png 2x" />
 
@@ -154,7 +145,7 @@ description:您只需为每个页面添加几行代码，就可以影响通过�
   </tbody>
 </table>
 
-这些元标记向社交网站（通常是 [Google+](https://plus.google.com/){: .external } 和 [Facebook](https://www.facebook.com/){: .external }）的抓取工具提供语义信息。
+这些元标记向社交网站（通常是 [Facebook](https://www.facebook.com/){: .external }）的抓取工具提供语义信息。
 
 
 
@@ -182,7 +173,7 @@ description:您只需为每个页面添加几行代码，就可以影响通过�
 
 
 
-  
+
 
 
 <pre class="prettyprint">
@@ -219,7 +210,7 @@ description:您只需为每个页面添加几行代码，就可以影响通过�
 * `title` 和 `description` 在 microdata 与 OGP 之间共享
 * `itemprop="image"` 使用带 `href` 属性的 `link` 标记，而不是重复使用带 `property="og:image"` 的 `meta` 标记
 最后，务必验证网页在各社交网站上的呈现方式合乎预期，然后再进行发布。
-  
+
 
 
 

--- a/src/content/zh-cn/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/zh-cn/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -298,11 +298,6 @@ Note: `max-age` 的计算单位为秒。您可以从较小的值开始，并随�
 大多数网络服务器都提供一种简单的重定向功能。使用 `301 (Moved Permanently)` 来告诉搜索引擎和浏览器，此 HTTPS 版本是规范的，并将用户从 HTTP 重定向到网站的 HTTPS 版本。
 
 
-## 迁移问题
-
-对于从 HTTP 迁移到 HTTPS，许多开发者有着合情合理的顾虑。Google 网站站长团队提供了一些[非常好的指导](https://plus.google.com/+GoogleWebmasters/posts/eYmUYvNNT5J)。
-
-
 ### 搜索排名
 
 Google 使用 [HTTPS 用作肯定性的搜索质量指标](https://googlewebmastercentral.blogspot.com/2014/08/https-as-ranking-signal.html)。Google 还发布一个指南，说明在维护其搜索排名时[如何传输、移动或迁移您的网站](https://support.google.com/webmasters/topic/6029673)。

--- a/src/data/_contributors.yaml
+++ b/src/data/_contributors.yaml
@@ -1820,7 +1820,6 @@ johyphenel:
   country: USA
   role:
     - author
-  homepage: 'https://plus.google.com/+Jo-elvanBergen'
   twitter: johyphenel
   email: jo-el@google.com
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Removes remaining g+ links from the webfu repo

[WF_IGNORE:BLINK,LAST_UPDATED,TYPOS,MAX_LEN,HELPFUL_WIDGET,FEED_WIDGET,SCRIPT]