### PR TITLE
Fix #7328 (redundant margin)

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/responsive/_code/reading.html
+++ b/src/content/en/fundamentals/design-and-ux/responsive/_code/reading.html
@@ -8,11 +8,6 @@
     <link rel="stylesheet" href="https://code.getmdl.io/1.2.1/material.indigo-pink.min.css">
     <script defer src="https://code.getmdl.io/1.2.1/material.min.js"></script>
     <style>
-      body {
-        margin: 2em;
-      }
-    </style>
-    <style>
       /* // [START mqreading] */
       @media (min-width: 575px) {
         article {


### PR DESCRIPTION
Margin that cause horizontal scroll.

What's changed, or what was fixed?
- Redundant margin

**Fixes:** #7328 

**Target Live Date:** 2019-02-28

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
