### PR TITLE
Remove iframe'd Lighthouse runner app

### DIFF
--- a/src/content/en/tools/lighthouse/run.md
+++ b/src/content/en/tools/lighthouse/run.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Run Lighthouse against any site.
 
-{# wf_updated_on: 2017-06-08 #}
+{# wf_updated_on: 2019-03-01 #}
 {# wf_published_on: 2017-06-08 #}
 
 # Try Lighthouse {: .page-title }

--- a/src/content/en/tools/lighthouse/run.md
+++ b/src/content/en/tools/lighthouse/run.md
@@ -16,15 +16,6 @@ description: Run Lighthouse against any site.
   margin-left: 0 !important;
   width: 100% !important;
 }
-.lighthouse-frame {
-  height: 475px;
-  width: 100%;
-}
 </style>
 
-Take [Lighthouse](/web/tools/lighthouse/) for a spin. Enter the URL of any site
-to get started.
-
-<iframe src="https://lighthouse-ci.appspot.com/try"
-        scrolling="no" class="lighthouse-frame"></iframe>
-
+Take [Lighthouse](/web/tools/lighthouse/) for a spin at [https://web.dev/measure](https://web.dev/measure).


### PR DESCRIPTION
What's changed, or what was fixed?
- As web.dev exists now, we don't want to keep supporting users with this app-engine Lighthouse instance. 

**Fixes:** b/126535466

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
