### PR TITLE
Updates for getInstalledRelatedApps

### DIFF
--- a/src/content/en/updates/2018/12/get-installed-related-apps.md
+++ b/src/content/en/updates/2018/12/get-installed-related-apps.md
@@ -3,9 +3,9 @@ book_path: /web/updates/_book.yaml
 description: The getInstalledRelatedApps API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa..
 
 {# wf_published_on: 2018-12-20 #}
-{# wf_updated_on: 2018-12-19 #}
+{# wf_updated_on: 2019-03-06 #}
 {# wf_featured_image: /web/updates/images/generic/focus.png #}
-{# wf_tags: capabilities,progressive-web-apps,webapp,webapk,native #}
+{# wf_tags: capabilities,progressive-web-apps,webapp,webapk,native,chrome73,origintrials #}
 {# wf_featured_snippet: As the capability gap between web and native gets smaller, it becomes easier to offer the same experience for both web and native users. This may lead to cases where users have both the web and native versions installed on the same device. Apps should be able to detect this situation. The <code>getInstalledRelatedApps</code> API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa.  #}
 {# wf_blink_components: Mobile>WebAPKs #}
 
@@ -15,7 +15,13 @@ description: The getInstalledRelatedApps API is a new web platform API that allo
 
 <div class="clearfix"></div>
 
-{% include "web/updates/_shared/capabilities.html" %}
+<aside class="caution">
+  We’re currently working on this API as part of the new
+  <a href="/web/updates/capabilities">capabilities project</a>. Starting in
+  Chrome 73, it is available as an <a href="#ot"><b>origin trial</b></a> on Android.
+  This post will be updated as the API evolves, and was last updated on
+  March 6th, 2019.
+</aside>
 
 ## What is the `getInstalledRelatedApps` API? {: #what }
 
@@ -38,6 +44,11 @@ device, and vice versa. With the `getInstalledRelatedApps` API, you can
 disable some functionality of one app if it should be provided by the other
 app instead.
 
+If `getInstalledRelatedApps` looks familiar, it is. We originally announced
+this feature in April 2017, when it first went to an origin trial. After that
+origin trial ended, we took stock of the feedback and spent some time iterating
+on this design.
+
 [Read explainer][explainer]{: .button .button-primary }
 
 <div class="clearfix"></div>
@@ -57,7 +68,6 @@ Installable web apps can help prevent confusion between the web and native
 versions by checking to see if the native version is already installed and
 either not prompting to install the PWA, or providing different prompts.
 
-
 ## Current status {: #status }
 
 | Step                                         | Status                       |
@@ -65,26 +75,43 @@ either not prompting to install the PWA, or providing different prompts.
 | 1. Create explainer                          | [Complete][explainer]        |
 | **2. Create initial draft of specification** | [**In Progress**][spec]      |
 | **3. Gather feedback & iterate on design**   | [**In Progress**](#feedback) |
-| 4. Origin trial                              | Not started                  |
+| **4. Origin trial**                          | [**In Progress**](#ot)       |
 | 5. Launch                                    | Not started                  |
 
-If `getInstalledRelatedApps` looks familiar, it is. We originally announced
-this feature in April 2017, when it first went to an origin trial. After that
-origin trial ended, we took stock of the feedback and spent some time iterating
-on the design. We hope to launch a new origin trial in the first half of 2019.
+### See it in action
 
+1. Using Chrome 73 or later on Android, open the [`getInstalledRelatedApps` demo][demo].
+   Note, this site uses an origin trial token to enable the API.
+2. Install the demo app from the Play store and refresh the [demo][demo] page.
+   You should now see the app listed.
 
 ## How to use the `getInstalledRelatedApps` API {: #use }
 
-Dogfood: We are still iterating on the design of the `getInstalledRelatedApps`
-API. It’s only available behind a flag (`#enable-experimental-web-platform-features`).
-While in development, bugs are expected, or it may fail to work completely.
-The code below is based on the current design, and will likely change between
-now and the time it’s standardized.
+Starting in Chrome 73, the `getInstalledRelatedApps` API is available as an
+origin trial for Android. [Origin trials][ot-what-is] allow you to try out
+new features and give feedback on usability, practicality, and effectiveness
+to us, and the web standards community. For more information, see the
+[Origin Trials Guide for Web Developers][ot-dev-guide].
 
 Check out the [`getInstalledRelatedApps` API Demo][demo] and
 [`getInstalledRelatedApps` API Demo source][demo-source]
 
+### Register for the origin trial {: #ot }
+
+1. [Request a token][ot-request] for your origin.
+2. Add the token to your pages, there are two ways to provide this token on
+   any pages in your origin:
+     * Add an `origin-trial` `<meta>` tag to the head of any page. For example,
+       this may look something like:
+       `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
+     * If you can configure your server, you can also provide the token on pages
+       using an `Origin-Trial` HTTP header. The resulting response header should
+       look something like: `Origin-Trial: TOKEN_GOES_HERE`
+
+### Alternatives to the origin trial
+
+If you want to experiment with the API locally, without an origin trial,
+enable the `#enable-experimental-web-platform-features` flag in `chrome://flags`.
 
 ### Establish a relationship between your apps {: #relationship }
 
@@ -94,7 +121,6 @@ other apps from using the API to detect if your app is installed, and prevents
 sites from collecting information about the apps you have installed on your
 device.
 
-
 #### Define the relationship to your native app {: #relationship-web }
 
 In your [web app manifest](/web/fundamentals/web-app-manifest), add a
@@ -102,7 +128,6 @@ In your [web app manifest](/web/fundamentals/web-app-manifest), add a
 to detect. The `related_applications` property is an array of objects that
 contain the platform on which the app is hosted and the unique identifier for
 your app on that platform.
-
 
 ```json
 {
@@ -116,10 +141,8 @@ your app on that platform.
 }
 ```
 
-
 The `url` property is optional, and the API works fine without it. On Android,
 the `platform` must be `play`. On other devices, `platform` will be different.
-
 
 #### Define the relationship to your web app {: #relationship-native }
 
@@ -131,8 +154,7 @@ platforms, the way you define the relationship will differ slightly.
 In `AndroidManifest.xml`, add an asset statement that links back to your web
 app:
 
-
-```
+```xml
 <manifest>
   <application>
    ...
@@ -142,12 +164,10 @@ app:
 </manifest>
 ```
 
-
 Then, in `strings.xml`, add the following asset statement, updating `site` with
 your domain. Be sure to include the escaping characters.
 
-
-```
+```xml
 <string name="asset_statements">
   [{
     \"relation\": [\"delegate_permission/common.handle_all_urls\"],
@@ -159,9 +179,7 @@ your domain. Be sure to include the escaping characters.
 </string>
 ```
 
-
 ### Test for the presence of your native app {: #test-native }
-
 
 Once you’ve updated your native app and added the appropriate fields to the
 web app manifest, you can add the code to check for the presence of your native
@@ -169,8 +187,7 @@ app to you web app. Calling `navigator.getInstalledRelatedApps()` returns a
 `Promise` that resolves with an array of your apps that are installed on the
 users device.
 
-
-```
+```js
 navigator.getInstalledRelatedApps().then((relatedApps) => {
   relatedApps.forEach((app) => {
     console.log(app.id, app.platform, app.url);
@@ -178,10 +195,8 @@ navigator.getInstalledRelatedApps().then((relatedApps) => {
 });
 ```
 
-
 Note: Like most other powerful web APIs, the `getInstalledRelatedApps` API is
 only available when served over **HTTPS**.
-
 
 ## Feedback {: #feedback }
 
@@ -195,7 +210,6 @@ way that meets your needs and that we’re not missing any key scenarios.
   WICG/get-installed-related-apps repo</a> and provide as much detail as you can.
 </aside>
 
-
 We’re also interested to hear how you plan to use the
 `getInstalledRelatedApps` API:
 
@@ -205,7 +219,6 @@ We’re also interested to hear how you plan to use the
 
 Share your thoughts on the
 [`getInstalledRelatedApps` API WICG Discourse][wicg-discourse] discussion.
-
 
 {% include "web/_shared/helpful.html" %}
 
@@ -228,4 +241,7 @@ Share your thoughts on the
 [cr-status]: https://www.chromestatus.com/features/5695378309513216
 [explainer]: https://github.com/WICG/get-installed-related-apps/blob/master/EXPLAINER.md
 [wicg-discourse]: https://discourse.wicg.io/t/proposal-get-installed-related-apps-api/1602
-
+[ot-what-is]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/README.md
+[ot-dev-guide]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
+[ot-use]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#how-do-i-enable-an-experimental-feature-on-my-origin
+[ot-request]: https://developers.chrome.com/origintrials/

--- a/src/content/en/updates/2018/12/get-installed-related-apps.md
+++ b/src/content/en/updates/2018/12/get-installed-related-apps.md
@@ -244,4 +244,4 @@ Share your thoughts on the
 [ot-what-is]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/README.md
 [ot-dev-guide]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
 [ot-use]: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md#how-do-i-enable-an-experimental-feature-on-my-origin
-[ot-request]: https://developers.chrome.com/origintrials/
+[ot-request]: https://developers.chrome.com/origintrials/#/view_trial/855683929200394241

--- a/src/content/en/updates/2018/12/get-installed-related-apps.md
+++ b/src/content/en/updates/2018/12/get-installed-related-apps.md
@@ -3,11 +3,13 @@ book_path: /web/updates/_book.yaml
 description: The getInstalledRelatedApps API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa..
 
 {# wf_published_on: 2018-12-20 #}
-{# wf_updated_on: 2019-03-06 #}
+{# wf_updated_on: 2019-03-07 #}
 {# wf_featured_image: /web/updates/images/generic/focus.png #}
 {# wf_tags: capabilities,progressive-web-apps,webapp,webapk,native,chrome73,origintrials #}
 {# wf_featured_snippet: As the capability gap between web and native gets smaller, it becomes easier to offer the same experience for both web and native users. This may lead to cases where users have both the web and native versions installed on the same device. Apps should be able to detect this situation. The <code>getInstalledRelatedApps</code> API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa.  #}
 {# wf_blink_components: Mobile>WebAPKs #}
+
+{# When updating this post, don't forget to update /updates/capabilities.md #}
 
 # Check If Your Native App Is Installed With getInstalledRelatedApps {: .page-title }
 
@@ -19,8 +21,8 @@ description: The getInstalledRelatedApps API is a new web platform API that allo
   We’re currently working on this API as part of the new
   <a href="/web/updates/capabilities">capabilities project</a>. Starting in
   Chrome 73, it is available as an <a href="#ot"><b>origin trial</b></a> on Android.
-  This post will be updated as the API evolves, and was last updated on
-  March 6th, 2019.
+  This post will be updated as the API evolves.<br>
+  <b>Last Updated:</b> March 12th, 2019
 </aside>
 
 ## What is the `getInstalledRelatedApps` API? {: #what }

--- a/src/content/en/updates/capabilities.md
+++ b/src/content/en/updates/capabilities.md
@@ -1,7 +1,7 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2019-03-06 #}
+{# wf_updated_on: 2019-03-07 #}
 {# wf_published_on: 2018-11-12 #}
 {# wf_tags: capabilities #}
 {# wf_featured_image: /web/updates/images/generic/thumbs-up.png #}
@@ -64,7 +64,8 @@ browser vendors as we iterate on the design, to ensure an interoperable design.
         that allows your web app to check to see if your native app is
         installed on the users device, and vice versa.
         <br><br>
-        <b>Current Status:</b> Available as an origin trial.
+        <b>Current Status:</b> Available as an origin trial.<br>
+        <b>Last Updated:</b> March 12th, 2019
       </td>
     </tr>
     <tr>

--- a/src/content/en/updates/capabilities.md
+++ b/src/content/en/updates/capabilities.md
@@ -1,7 +1,7 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2019-01-28 #}
+{# wf_updated_on: 2019-03-06 #}
 {# wf_published_on: 2018-11-12 #}
 {# wf_tags: capabilities #}
 {# wf_featured_image: /web/updates/images/generic/thumbs-up.png #}
@@ -64,7 +64,7 @@ browser vendors as we iterate on the design, to ensure an interoperable design.
         that allows your web app to check to see if your native app is
         installed on the users device, and vice versa.
         <br><br>
-        <b>Current Status:</b> Gathering feedback &amp; iterating on design.
+        <b>Current Status:</b> Available as an origin trial.
       </td>
     </tr>
     <tr>
@@ -218,5 +218,3 @@ it’s time to ship it.
 <div class="clearfix"></div>
 
 {% include "web/_shared/helpful.html" %}
-
-


### PR DESCRIPTION
What's changed, or what was fixed?
- Added info about OT in 73

**Target Live Date:** 2019-03-12

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

