### PR TITLE
[devtools] add placeholder for wndt74

### DIFF
--- a/src/content/en/updates/2019/03/devtools.md
+++ b/src/content/en/updates/2019/03/devtools.md
@@ -1,0 +1,51 @@
+project_path: /web/_project.yaml
+book_path: /web/updates/_book.yaml
+description: This is just a temporary placeholder. We'll have the full post up by Monday at latest.
+
+{# wf_updated_on: 2019-03-06 #}
+{# wf_published_on: 2019-03-06 #}
+{# wf_tags: chrome74, devtools, devtools-whatsnew #}
+{# wf_featured_image: /web/updates/images/generic/chrome-devtools.png #}
+{# wf_featured_snippet: Ths is just a temporary placeholder. We'll have the full post up by Monday at latest. #}
+{# wf_blink_components: Platform>DevTools #}
+
+# What's New In DevTools (Chrome 74) {: .page-title }
+
+{% include "web/_shared/contributors/kaycebasques.html" %}
+
+Whoops! Our deadline snuck up on us. We'll have the full post up by Monday at latest.
+
+In the meantime, check out our new [DOM tutorial](/web/tools/chrome-devtools/dom/).
+
+## Feedback {: #feedback }
+
+[ML]: https://groups.google.com/forum/#!forum/google-chrome-developer-tools
+[WF]: https://github.com/google/webfundamentals/issues/new
+[SO]: https://stackoverflow.com/questions/tagged/google-chrome-devtools
+
+{% include "web/_shared/helpful.html" %}
+
+To discuss the new features and changes in this post, or anything else related to DevTools:
+
+* File bug reports at [Chromium Bugs](https://crbug.com){:.external}.
+* Discuss features and changes on the [Mailing List][ML]{:.external}. Please don't use the mailing
+  list for support questions. Use Stack Overflow, instead.
+* Get help on how to use DevTools on [Stack Overflow][SO]{:.external}. Please don't file bugs
+  on Stack Overflow. Use Chromium Bugs, instead.
+* Tweet us at [@ChromeDevTools](https://twitter.com/chromedevtools).
+* File bugs on this doc in the [Web Fundamentals][WF]{:.external} repository.
+
+## Consider Canary {: #canary }
+
+[canary]: https://www.google.com/chrome/browser/canary.html
+
+If you're on Mac or Windows, consider using [Chrome Canary][canary] as your default
+development browser. Canary gives you access to the latest DevTools features.
+
+Note: Canary is released as soon as its built, without testing. This means that Canary
+breaks about once-a-month. It's usually fixed within a day. You can go back to using Chrome
+Stable while Canary is broken.
+
+<<../../_shared/discover.md>>
+
+{% include "web/_shared/rss-widget-updates.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?

- adds a placeholder doc for WNDT74... the full post will be out in a day or 2

**Fixes:** N/A

**Target Live Date:** 2019-03-07

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
