### PR TITLE
Don't change wf_updated_on if its in the future

### DIFF
--- a/gulp-tasks/wfUpdatedOn.js
+++ b/gulp-tasks/wfUpdatedOn.js
@@ -68,13 +68,15 @@ gulp.task('update-updated_on', async () => {
 
     const originalUpdatedOn = matched[0];
     const originalTimestamp = matched[1];
-    const newTimeStamp = moment().format(`YYYY-MM-DD`);
-    if (originalTimestamp === newTimeStamp) {
+    const momentNow = moment();
+
+    if (momentNow.isSameOrBefore(originalTimestamp)) {
+      // Updated date is today or in the future.
       continue;
     }
 
     const newUpdatedOn = originalUpdatedOn
-      .replace(originalTimestamp, newTimeStamp);
+      .replace(originalTimestamp, momentNow.format(`YYYY-MM-DD`));
     const newContents = fileContents.replace(originalUpdatedOn, newUpdatedOn);
     await fse.writeFile(changedFile, newContents);
     // Add the file to the current commit.


### PR DESCRIPTION
What's changed, or what was fixed?
- Modify gulp task to prevent it from updating `wf_last_updated` fields if they're in the future.

