### PR TITLE
workbox: use correct filename in register-sw snippet

### DIFF
--- a/src/content/en/tools/workbox/guides/_shared/register-sw.html
+++ b/src/content/en/tools/workbox/guides/_shared/register-sw.html
@@ -6,7 +6,7 @@
 if ('serviceWorker' in navigator) {
   // Use the window load event to keep the page load performant
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+    navigator.serviceWorker.register('/service-worker.js');
   });
 }
 &lt;/script>


### PR DESCRIPTION
What's changed, or what was fixed?
- @marcushellberg reported this: https://twitter.com/marcushellberg/status/1103827852552736768
- i changed the filename (to `service-worker.js`) in the register-sw shared snippet

@philipwalton i have no idea if this is correct so please tell me if this is incorrect.


**Target Live Date:** whenever

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
