### PR TITLE
Escape parentheses in Markdown link

### DIFF
--- a/src/content/en/updates/2017/03/performant-expand-and-collapse.md
+++ b/src/content/en/updates/2017/03/performant-expand-and-collapse.md
@@ -217,7 +217,7 @@ something like this to map values from 0 to 1 to an eased equivalent.
     }
 
 You can use [Google search to plot what that looks
-like](https://www.google.com/search?q=1%20-%20((1-x)%5E4)%20from%200%20to%201)
+like](https://www.google.com/search?q=1%20-%20%28%281-x%29%5E4%29%20from%200%20to%201)
 as well. Handy! If you’re in need of other easing equations do check out
 [Tween.js by Soledad Penadés](https://github.com/tweenjs/tween.js/blob/master/src/Tween.js#L421-L737),
 which contains a whole heap of them.


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes link not being displayed properly: 
  ![Screenshot 2019-03-13 at 13 55 55](https://user-images.githubusercontent.com/145676/54280434-c6d90380-4597-11e9-984f-900a9dbbe38a.png)

**Target Live Date:** any

- [ ] This has been reviewed and approved by (NAME)
  @surma @paullewis please take a quick look.
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
