### PR TITLE
Lock down our handlebars-helpers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.7",
     "handlebars": "^4.0.5",
-    "handlebars-helpers": "^0.10.0",
+    "handlebars-helpers": "0.8.4",
     "js-yaml": "^3.6.1",
     "jsdoc": "^3.5.5",
     "jsonschema": "^1.2.0",


### PR DESCRIPTION
In version`0.9.0` `handlebar-helpers` [introduced the `year`](https://github.com/helpers/handlebars-helpers/blob/6d875b5/CHANGELOG#L6-L29) helper, which was conflicted with existing usage of a `year` variable in our templates.

While we investigate how to solve this in the future, this PR locks our `handlebars-helpers` version to before the `year` helper was introduced.

**Target Live Date:** YYYY-MM-DD

- [x] This has been reviewed and approved by (@petele )
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
