### PR TITLE
[Typo] Make sure the filename matches

### DIFF
--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -20,11 +20,11 @@ can cache and serve these files using a service worker and Workbox.
 Before we can use Workbox, we need to create a service worker file and
 register it to our website.
 
-Start by creating a file called `sw.js` at the root of your site and add a
+Start by creating a file called `service-worker.js` at the root of your site and add a
 console message to the file (This is so we can see it load).
 
 ```javascript
-console.log('Hello from sw.js');
+console.log('Hello from service-worker.js');
 ```
 
 In your web page register your new service worker file like so:


### PR DESCRIPTION
What's changed, or what was fixed?
- Small typo. 


<img width="883" alt="Screenshot 2019-03-14 at 16 32 01" src="https://user-images.githubusercontent.com/1275206/54369868-f14dbe00-4676-11e9-82ef-3d44b498be93.png">


**Fixes:** n/a
**Target Live Date:** 2019-03-14

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
