### PR TITLE
Fixing houdini demo link from googlechrome to googlechromelabs

### DIFF
--- a/src/content/en/updates/2016/05/houdini.md
+++ b/src/content/en/updates/2016/05/houdini.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Houdini is a collection of APIs that expose the CSS engine’s internals to developers
 
-{# wf_updated_on: 2019-01-16 #}
+{# wf_updated_on: 2019-03-14 #}
 {# wf_published_on: 2016-05-19 #}
 {# wf_blink_components: N/A #}
 {# wf_tags: houdini,css #}
@@ -310,7 +310,7 @@ If you want to get involved, there’s always the [Houdini mailing list].
 [Web Components]: http://webcomponents.org/
 [parallax scrolling]: https://en.wikipedia.org/wiki/Parallax_scrolling
 [CSS Custom Properties]: /web/updates/2016/02/css-variables-why-should-you-care
-[Houdini Demo]: https://googlechrome.github.io/houdini-samples/animation-worklet/twitter-header/
+[Houdini Demo]: https://googlechromelabs.github.io/houdini-samples/animation-worklet/twitter-header/
 [Paint Worklet demo]: http://googlechrome.github.io/houdini-samples/paint-worklet/ripple/
 [Paint Worklet source]: https://github.com/GoogleChrome/houdini-samples/tree/master/paint-worklet/ripple
 


### PR DESCRIPTION
What's changed, or what was fixed?
- From https://googlechrome.github.io/houdini-samples/animation-worklet/twitter-header/ to [Houdini Demo]: https://googlechromelabs.github.io/houdini-samples/animation-worklet/twitter-header/

**Fixes:** #7343

**Target Live Date:** 2018-03-14

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
