### PR TITLE
Small fix for the Workbox exclude default value

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/webpack-single/exclude.html
+++ b/src/content/en/tools/workbox/_shared/config/webpack-single/exclude.html
@@ -5,7 +5,7 @@
   <td>
     <p>
       <em>Optional <code>Array</code> of <code>RegExp</code> or <code>String</code>,
-        defaulting to <code>[/\.map$/, /^manifest.*\.js(?:on)?$/]</code></em>
+        defaulting to <code>[/\.map$/, /^manifest.*\.js$/]</code></em>
     </p>
     <p>
       This allows you to specifically omit assets matching any of the provided criteria from being


### PR DESCRIPTION
R: @philipwalton @petele 

Small fix for the default `exclude` value, as reported by the community.

[WF_IGNORE:TEMPLATE_TAGS]