### PR TITLE
Update commit hash for custom-tabs-client in using-twa article

### DIFF
--- a/src/content/en/updates/2019/02/using-twa.md
+++ b/src/content/en/updates/2019/02/using-twa.md
@@ -168,7 +168,7 @@ dependency to the `dependencies` section:
 
 ```
 dependencies {
-   implementation 'com.github.GoogleChrome.custom-tabs-client:customtabs:3a71a75c9f'
+   implementation 'com.github.GoogleChrome.custom-tabs-client:customtabs:d08e93fce3'
 }
 ```
 


### PR DESCRIPTION
As described in https://bugs.chromium.org/p/chromium/issues/detail?id=928701 using a default browser that does not support TWA causes a confusing exception to be thrown.

I did not report this issue, but I did run into it and Googling the issue didn't produce any great answers.

The (current) latest commit appears to have fixed this issue, at least for me: https://github.com/GoogleChrome/custom-tabs-client/commit/d08e93fce3fb3e1f22214ee2f23fddc4f4e92634

This new commit works regardless of what browser I have set as my default albeit with one inconsistency I logged here: https://bugs.chromium.org/p/chromium/issues/detail?id=942930

What's changed, or what was fixed?
- Commit timestamp in using-twa article updated to latest commit

