### PR TITLE
[Workbox] New third-party plugin section

### DIFF
--- a/src/content/en/tools/workbox/guides/using-plugins.md
+++ b/src/content/en/tools/workbox/guides/using-plugins.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to using plugins with Workbox.
 
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-03-19 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: n/a #}
 
@@ -135,3 +135,22 @@ before referencing it. Also, when invoking the
 [`makeRequest()`](/web/tools/workbox/guides/advanced-recipes#make-requests)
 method of a strategy, the `event` you pass to `makeRequest()` will be the event
 passed to the plugin callbacks.
+
+## Third-party Plugins
+
+We encourage developers to hook into Workbox's lifecycle events in creative
+ways, and publish your custom plugins as a module.
+
+The following third-party plugins are available:
+
+- [`cloudinary-workbox-plugin`](https://www.npmjs.com/package/cloudinary-workbox-plugin),
+which [dynamically rewrites](https://blog.fullstacktraining.com/a-cloudinary-plugin-for-workbox/)
+requests for images hosted on Cloudinary, based on the
+[current connection speed](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API).
+
+You may be able to [find more](https://www.npmjs.com/search?q=keywords:workbox-plugin) by searching
+in npm's repository.
+
+If you've built a Workbox plugin that you'd like to share, add the `'workbox-plugin'`
+[keyword](https://docs.npmjs.com/files/package.json#keywords) when you publish it. And let us know
+via [@WorkboxJS](https://twitter.com/workboxjs)!


### PR DESCRIPTION
R: @philipwalton
CC: @tpiros from Cloudinary as an FYI.

This adds a new "Third-party Plugins" section to the Workbox docs, with some general info about publicizing your plugins, and specific info about the plugin that Cloudinary created.