### PR TITLE
Deprecations and Removals for Chrome 74

### DIFF
--- a/src/content/en/updates/2018/12/chrome-72-deps-rems.md
+++ b/src/content/en/updates/2018/12/chrome-72-deps-rems.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 72 to help you plan.
 
-{# wf_updated_on: 2019-03-21 #}
+{# wf_updated_on: 2019-03-22 #}
 {# wf_published_on: 2018-12-18 #}
 {# wf_tags: deprecations,removals,chrome72 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}

--- a/src/content/en/updates/2018/12/chrome-72-deps-rems.md
+++ b/src/content/en/updates/2018/12/chrome-72-deps-rems.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 72 to help you plan.
 
-{# wf_updated_on: 2019-03-07 #}
+{# wf_updated_on: 2019-03-21 #}
 {# wf_published_on: 2018-12-18 #}
 {# wf_tags: deprecations,removals,chrome72 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}

--- a/src/content/en/updates/2018/12/chrome-72-deps-rems.md
+++ b/src/content/en/updates/2018/12/chrome-72-deps-rems.md
@@ -19,8 +19,8 @@ description: A round up of the deprecations and removals in Chrome 72 to help yo
 
 ### Don't allow popups during page unload
 
-Note: This feature was not removed in Chrome 72 as planned. Removal is expected
-in Chrome 74.
+Note: This feature was actually removed in Chrome 74. We apologize for the
+mistake.
 
 Pages may no longer use `window.open()` to open a new page during unload. The
 Chrome popup blocker already prohibited this, but now it is prohibited whether

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -48,7 +48,12 @@ Removal is expected in Chrome 74.
 
 ### Remove PaymentAddress's languageCode property
 
-The `PaymentAddress.languageCode` property has been removed from the Payment Request API. This property is the browser's best guess for the language of the text in the shipping, billing, delivery, or pickup address in Payment Request API. The languageCode property is marked at risk in the specification and has already been removed from Firefox and Safari. Usage in Chrome is small enough for safe removal.
+The `PaymentAddress.languageCode` property has been removed from the Payment
+Request API. This property is the browser's best guess for the language of the
+text in the shipping, billing, delivery, or pickup address in the Payment
+Request API. The languageCode property is marked at risk in the specification
+and has already been removed from Firefox and Safari. Usage in Chrome is small
+enough for safe removal.
 
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-reviews/aBGjyKqok50/discussion) &#124;
 [Chrome Platform Status](https://www.chromestatus.com/feature/4992562146312192) &#124;

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 74 to help you plan.
 
-{# wf_updated_on: 2019-03-18 #}
+{# wf_updated_on: 2019-03-21 #}
 {# wf_published_on: 2019-03-21 #}
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 74 to help you plan.
 
-{# wf_updated_on: 2019-03-15 #}
+{# wf_updated_on: 2019-03-18 #}
 {# wf_published_on: 2019-03-21 #}
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
@@ -14,6 +14,33 @@ description: A round up of the deprecations and removals in Chrome 74 to help yo
 # Deprecations and removals in Chrome 74 {: .page-title }
 
 {% include "web/_shared/contributors/josephmedley.html" %}
+
+## Remove Custom Elements v0
+
+Custom Elements are a Web Components technology that lets you create new HTML
+tags, beef up existing tags, or extend components authored by other developers.
+Custom Elements v1 have been [implemented in
+Chrome](https://www.chromestatus.com/feature/4696261944934400) since version
+54, which shipped in October 2016. Custom Elements v0 was an experimental
+version not implemented in other browsers. As such it is now deprecated with
+removal expected in Chrome 73, around April 2019.
+
+[Intent to Deprecate](https://groups.google.com/a/chromium.org/d/topic/blink-dev/h-JwMiPUnuU/discussion) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/4642138092470272) &#124;
+[Chromium Bug](https://crbug.com/180965)
+
+### Remove PaymentAddress's languageCode property
+
+The `PaymentAddress.languageCode` property has been removed from the Payment
+Request API. This property is the browser's best guess for the language of the
+text in the shipping, billing, delivery, or pickup address in the Payment
+Request API. The languageCode property is marked at risk in the specification
+and has already been removed from Firefox and Safari. Usage in Chrome is small
+enough for safe removal.
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-reviews/aBGjyKqok50/discussion) &#124;
+[Chrome Platform Status](https://www.chromestatus.com/feature/4992562146312192) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=877521)
 
 ## Don't allow popups during page unload
 
@@ -45,19 +72,6 @@ Removal is expected in Chrome 74.
 [Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/JdAQ6HNoZvk/discussion) &#124;
 [Chrome Platform Status](https://www.chromestatus.com/feature/5706745674465280) &#124;
 [Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=539938)
-
-### Remove PaymentAddress's languageCode property
-
-The `PaymentAddress.languageCode` property has been removed from the Payment
-Request API. This property is the browser's best guess for the language of the
-text in the shipping, billing, delivery, or pickup address in the Payment
-Request API. The languageCode property is marked at risk in the specification
-and has already been removed from Firefox and Safari. Usage in Chrome is small
-enough for safe removal.
-
-[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-reviews/aBGjyKqok50/discussion) &#124;
-[Chrome Platform Status](https://www.chromestatus.com/feature/4992562146312192) &#124;
-[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=877521)
 
 {% include "web/updates/_shared/deprecations-policy.html" %}
 

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 74 to help you plan.
 
 {# wf_updated_on: 2019-03-07 #}
-{# wf_published_on: 2018-12-18 #}
+{# wf_published_on: 2019-03-21 #}
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -1,0 +1,38 @@
+project_path: /web/_project.yaml
+book_path: /web/updates/_book.yaml
+description: A round up of the deprecations and removals in Chrome 74 to help you plan.
+
+{# wf_updated_on: 2019-03-07 #}
+{# wf_published_on: 2018-12-18 #}
+{# wf_tags: deprecations,removals,chrome74 #}
+{# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
+{# wf_featured_image: /web/updates/images/generic/warning.png #}
+{# wf_featured_snippet: A round up of the deprecations and removals in Chrome 74 to help you plan.#}
+
+{% include "web/updates/_shared/see-all-dep-rem.html" %}
+
+# Deprecations and removals in Chrome 74 {: .page-title }
+
+{% include "web/_shared/contributors/josephmedley.html" %}
+
+## Removals
+
+### Don't allow popups during page unload
+
+Pages may no longer use `window.open()` to open a new page during unload. The
+Chrome popup blocker already prohibited this, but now it is prohibited whether
+or not the popup blocker is enabled.
+
+[Intent to Remove](https://crbug.com/844455) &#124;
+[Chromestatus Tracker](https://www.chromestatus.com/feature/5989473649164288) &#124;
+[Chromium Bug](https://groups.google.com/a/chromium.org/d/topic/blink-dev/MkA0A1YKSw4/discussion)
+
+
+
+{% include "web/updates/_shared/deprecations-policy.html" %}
+
+## Feedback {: #feedback .hide-from-toc }
+
+{% include "web/_shared/helpful.html" %}
+
+{% include "web/_shared/rss-widget-updates.html" %}

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -7,7 +7,7 @@ description: A round up of the deprecations and removals in Chrome 74 to help yo
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
-{# wf_featured_snippet: A round up of the deprecations and removals in Chrome 74 to help you plan.#}
+{# wf_featured_snippet: A round up of the deprecations and removals in Chrome 74 to help you plan. #}
 
 {% include "web/updates/_shared/see-all-dep-rem.html" %}
 
@@ -15,12 +15,12 @@ description: A round up of the deprecations and removals in Chrome 74 to help yo
 
 {% include "web/_shared/contributors/josephmedley.html" %}
 
-### Remove PaymentAddress's languageCode property
+### Remove PaymentAddress's `languageCode` property
 
 The `PaymentAddress.languageCode` property has been removed from the Payment
 Request API. This property is the browser's best guess for the language of the
 text in the shipping, billing, delivery, or pickup address in the Payment
-Request API. The languageCode property is marked at risk in the specification
+Request API. The `languageCode` property is marked at risk in the specification
 and has already been removed from Firefox and Safari. Usage in Chrome is small
 enough for safe removal.
 
@@ -40,14 +40,14 @@ or not the popup blocker is enabled.
 
 ## Deprecate drive-by downloads in sandboxed iframes
 
-Chrome will soon prevent downloads in sandboxed iframes that lack a user
-gesture, though this restriction could be lifted via an `allow-downloads
-without-user-activation` keyword in the sandbox attribute list. This allows
-content providers to restrict malicious or abusive downloads.
+Chrome will soon prevent downloads in sandboxed `iframes` that lack a user
+gesture, though this restriction could be lifted via an 
+`allow-downloads-without-user-activation` keyword in the sandbox attribute list. 
+This allows content providers to restrict malicious or abusive downloads.
 
 Downloads can bring security vulnerabilities to a system. Even though
 additional security checks are done in Chrome and the operating system, we feel
-blocking downloads in sandboxed iframes also fits the general thought behind
+blocking downloads in sandboxed `iframes` also fits the general thought behind
 the sandbox. Apart from security concerns, it would be a more pleasant user
 experience for a click to trigger a download on the same page, compared with
 downloads starting automatically when a user lands on a new page, or started

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -15,20 +15,6 @@ description: A round up of the deprecations and removals in Chrome 74 to help yo
 
 {% include "web/_shared/contributors/josephmedley.html" %}
 
-## Remove Custom Elements v0
-
-Custom Elements are a Web Components technology that lets you create new HTML
-tags, beef up existing tags, or extend components authored by other developers.
-Custom Elements v1 have been [implemented in
-Chrome](https://www.chromestatus.com/feature/4696261944934400) since version
-54, which shipped in October 2016. Custom Elements v0 was an experimental
-version not implemented in other browsers. As such it is now deprecated with
-removal expected in Chrome 73, around April 2019.
-
-[Intent to Deprecate](https://groups.google.com/a/chromium.org/d/topic/blink-dev/h-JwMiPUnuU/discussion) &#124;
-[Chromestatus Tracker](https://www.chromestatus.com/feature/4642138092470272) &#124;
-[Chromium Bug](https://crbug.com/180965)
-
 ### Remove PaymentAddress's languageCode property
 
 The `PaymentAddress.languageCode` property has been removed from the Payment

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 74 to help you plan.
 
-{# wf_updated_on: 2019-03-14 #}
+{# wf_updated_on: 2019-03-15 #}
 {# wf_published_on: 2019-03-21 #}
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
@@ -24,6 +24,27 @@ or not the popup blocker is enabled.
 [Intent to Remove](https://crbug.com/844455) &#124;
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5989473649164288) &#124;
 [Chromium Bug](https://groups.google.com/a/chromium.org/d/topic/blink-dev/MkA0A1YKSw4/discussion)
+
+## Deprecate drive-by downloads in sandboxed iframes
+
+Chrome will soon prevent downloads in sandboxed iframes that lack a user
+gesture, though this restriction could be lifted via an `allow-downloads
+without-user-activation` keyword in the sandbox attribute list. This allows
+content providers to restrict malicious or abusive downloads.
+
+Downloads can bring security vulnerabilities to a system. Even though
+additional security checks are done in Chrome and the operating system, we feel
+blocking downloads in sandboxed iframes also fits the general thought behind
+the sandbox. Apart from security concerns, it would be a more pleasant user
+experience for a click to trigger a download on the same page, compared with
+downloads starting automatically when a user lands on a new page, or started
+non-spontaneously after the click.
+
+Removal is expected in Chrome 74.
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-dev/JdAQ6HNoZvk/discussion) &#124;
+[Chrome Platform Status](https://www.chromestatus.com/feature/5706745674465280) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=539938)
 
 ### Remove PaymentAddress's languageCode property
 

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 74 to help you plan.
 
-{# wf_updated_on: 2019-03-07 #}
+{# wf_updated_on: 2019-03-14 #}
 {# wf_published_on: 2019-03-21 #}
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
@@ -15,9 +15,7 @@ description: A round up of the deprecations and removals in Chrome 74 to help yo
 
 {% include "web/_shared/contributors/josephmedley.html" %}
 
-## Removals
-
-### Don't allow popups during page unload
+## Don't allow popups during page unload
 
 Pages may no longer use `window.open()` to open a new page during unload. The
 Chrome popup blocker already prohibited this, but now it is prohibited whether
@@ -27,7 +25,13 @@ or not the popup blocker is enabled.
 [Chromestatus Tracker](https://www.chromestatus.com/feature/5989473649164288) &#124;
 [Chromium Bug](https://groups.google.com/a/chromium.org/d/topic/blink-dev/MkA0A1YKSw4/discussion)
 
+### Remove PaymentAddress's languageCode property
 
+The `PaymentAddress.languageCode` property has been removed from the Payment Request API. This property is the browser's best guess for the language of the text in the shipping, billing, delivery, or pickup address in Payment Request API. The languageCode property is marked at risk in the specification and has already been removed from Firefox and Safari. Usage in Chrome is small enough for safe removal.
+
+[Intent to Remove](https://groups.google.com/a/chromium.org/d/topic/blink-reviews/aBGjyKqok50/discussion) &#124;
+[Chrome Platform Status](https://www.chromestatus.com/feature/4992562146312192) &#124;
+[Chromium Bug](https://bugs.chromium.org/p/chromium/issues/detail?id=877521)
 
 {% include "web/updates/_shared/deprecations-policy.html" %}
 

--- a/src/content/en/updates/2019/03/chrome-74-deps-rems.md
+++ b/src/content/en/updates/2019/03/chrome-74-deps-rems.md
@@ -2,8 +2,8 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the deprecations and removals in Chrome 74 to help you plan.
 
-{# wf_updated_on: 2019-03-21 #}
-{# wf_published_on: 2019-03-21 #}
+{# wf_updated_on: 2019-03-22 #}
+{# wf_published_on: 2019-03-22 #}
 {# wf_tags: deprecations,removals,chrome74 #}
 {# wf_blink_components: Blink,Security,Internals>Network>FTP,Internals>Network>SSL,Blink>Payments #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}


### PR DESCRIPTION
**Target Live Date:** 2019-03-21

- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
