### PR TITLE
[devtools] update appcache warning

### DIFF
--- a/src/content/en/tools/chrome-devtools/storage/applicationcache.md
+++ b/src/content/en/tools/chrome-devtools/storage/applicationcache.md
@@ -11,8 +11,10 @@ description: How to view Application Cache data from the Sources panel of Chrome
 {% include "web/_shared/contributors/kaycebasques.html" %}
 
 <aside class="warning">
-  The Application Cache API is <a href="https://html.spec.whatwg.org/multipage/offline.html#offline">deprecated</a>.
-  DevTools features related to the Application Cache are not being maintained. This guide also is not being maintained.
+  The Application Cache API is 
+  <a href="https://html.spec.whatwg.org/multipage/offline.html#offline">
+    being removed from the web platform
+  </a>.
 </aside>
 
 [MDN]: https://developer.mozilla.org/en-US/docs/Web/API/Window/applicationCache


### PR DESCRIPTION
What's changed, or what was fixed?

- make warning more precise

**Fixes:** N/A

**Target Live Date:** 2019-03-26

- [x] This has been reviewed and approved by @kaycebasques 
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
