### PR TITLE
Typo: duplicated  word

### DIFF
--- a/src/content/en/updates/2019/03/nic73.md
+++ b/src/content/en/updates/2019/03/nic73.md
@@ -72,7 +72,7 @@ users find and launch them from the same place as other apps, they run in
 their own window, they appear in the task switcher, their icons can show
 notification badging, and so on.
 
-We want to close the [close the capability gap](/web/updates/capabilities)
+We want to [close the capability gap](/web/updates/capabilities)
 between the web and native to provide a solid foundation for modern
 applications delivered on the web. We’re working to add new web platform
 capabilities that give you access to things like the
@@ -192,7 +192,7 @@ there’s plenty more.
 * The `<link>` element now supports `imagesrcset` and `imagesizes` properties
   to correspond to `srcset` and `sizes` attributes of `HTMLImageElement`.
 * Blink's shadow blur radius implementation, now matches Firefox and Safari.
-* Dark mode for Chrome's UI is now supported on Mac, and Windows support is on 
+* Dark mode for Chrome's UI is now supported on Mac, and Windows support is on
   the way. In addition, there's work on a CSS media query:
   [`prefers-color-scheme`](https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme),
   that can be used to detect if the user has requested the system use a light


### PR DESCRIPTION
What's changed, or what was fixed?
- a certain typo fix like duplicated word and remove trailing whitespace

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
