### PR TITLE
[Workbox] Manual updates for v4.2.0

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/groups/common-generate-schema.html
+++ b/src/content/en/tools/workbox/_shared/config/groups/common-generate-schema.html
@@ -23,3 +23,5 @@
 {% include "web/tools/workbox/_shared/config/single/offlineGoogleAnalytics.html" %}
 
 {% include "web/tools/workbox/_shared/config/single/cleanupOutdatedCaches.html" %}
+
+{% include "web/tools/workbox/_shared/config/single/navigationPreload.html" %}

--- a/src/content/en/tools/workbox/_shared/config/single/navigationPreload.html
+++ b/src/content/en/tools/workbox/_shared/config/single/navigationPreload.html
@@ -1,0 +1,29 @@
+<tr id="{{ anchor_prefix }}navigationPreload">
+  <td>
+    <p>navigationPreload</p>
+  </td>
+  <td>
+    <p>
+      <em>Optional <code>Boolean</code>, defaulting to <code>false</code></em>
+    </p>
+    <p>
+      Whether or not to enable
+      <a href="/web/tools/workbox/modules/workbox-navigation-preload">navigation preload</a>
+      in the generated service worker.
+    </p>
+    <p>
+      When set to <code>true</code>, you must also use
+      <a href="#generateSW-runtimeCaching"><code>runtimeCaching</code></a> to
+      set up an appropriate reesponse strategy that will match navigation
+      requests, and make use of the preloaded response.
+    </p>
+    <p>
+      <strong>Example:</strong>
+    </p>
+    <pre class="prettyprint">navigationPreload: true,
+runtimeCaching: [{
+  urlPattern: ({event}) => event.request.mode === 'navigate',
+  handler: 'NetworkOnly',
+}]</pre>
+  </td>
+</tr>

--- a/src/content/en/tools/workbox/guides/using-plugins.md
+++ b/src/content/en/tools/workbox/guides/using-plugins.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to using plugins with Workbox.
 
-{# wf_updated_on: 2019-03-19 #}
+{# wf_updated_on: 2019-04-03 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: n/a #}
 
@@ -72,6 +72,11 @@ following functions:
   entry is updated. Useful if you wish to perform an action after a cache
   update.
 
+* `cacheKeyWillBeUsed`: Called before a request is used as a cache key, for
+  both cache lookups (when `mode` is `'read'`) and cache writes (when `mode`
+  is `'write'`). This can come in handy if you need to override or normalize
+  your URLs prior to using them for cache access.
+
 * `cachedResponseWillBeUsed`: Called prior to a response from the cache being
   used, this callback allows you to examine that response, and potentially
   return `null` or a different response to be used instead.
@@ -104,6 +109,12 @@ const myPlugin = {
     // meaning the body has already been read. If you need access to
     // the body of the fresh response, use a technique like:
     // const freshResponse = await caches.match(request, {cacheName});
+  },
+  cacheKeyWillBeUsed: async function ({request, mode}) {
+  // request is the Request object that would otherwise be used as the cache key.
+  // mode is either 'read' or 'write'.
+  // Return either a string, or a Request whose url property will be used as the cache key.
+  // Returning the original request will make this a no-op.
   },
   cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse, event}) => {
     // Return `cachedResponse`, a different Response object or null


### PR DESCRIPTION
R: @philipwalton 

Adds docs for Workbox's new `navigationPreload` build config parameter, and the `cacheKeyWillBeUsed` lifecycle method.

[WF_IGNORE:TEMPLATE_TAGS,TYPOS]