### PR TITLE
Update how-payment-ecosystem-works.md

### DIFF
--- a/src/content/en/fundamentals/payments/basics/how-payment-ecosystem-works.md
+++ b/src/content/en/fundamentals/payments/basics/how-payment-ecosystem-works.md
@@ -36,7 +36,7 @@ _Web Payments_ comprises multiple web standards.
     payment method. Along with standardized payment method identifiers, it
     allows anyone to define their own payment method with URL-based payment
     method identifiers. Learn more at [Payment method
-    basics](payments/basics/payment-method-basics).
+    basics](/web/fundamentals/payments/basics/payment-method-basics).
 *   **Payment Method Manifest:** The [Payment Method
     Manifest](https://w3c.github.io/payment-method-manifest/) defines the
     machine-readable manifest file, known as a payment method manifest,


### PR DESCRIPTION
Should fix #7470

What's changed, or what was fixed?
- item 1: Url to `Payment method basics opened a broken link`

**Fixes:** #7470 

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
