### PR TITLE
Adding `webp` to the image file extensions

### DIFF
--- a/src/content/en/tools/workbox/guides/common-recipes.md
+++ b/src/content/en/tools/workbox/guides/common-recipes.md
@@ -60,7 +60,7 @@ You might want to use a cache-first images, by matching against a list of known 
 
 ```javascript
 workbox.routing.registerRoute(
-  /\.(?:png|gif|jpg|jpeg|svg)$/,
+  /\.(?:png|gif|jpg|jpeg|webp|svg)$/,
   new workbox.strategies.CacheFirst({
     cacheName: 'images',
     plugins: [


### PR DESCRIPTION
I've seen developers copy/paste this recipe and wonder why WebP image were not cached. 😅

I think using `destination===image` would be better, but I guess the purpose of this recipe is to show a regex.