### PR TITLE
Web share target updates for new manifest values

### DIFF
--- a/src/content/en/updates/2018/12/web-share-target.md
+++ b/src/content/en/updates/2018/12/web-share-target.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: The Web Share Target API allows installed web apps to register with the underlying OS as a share target to receive shared content from either the Web Share API or system events, like the OS-level share button.
 
 {# wf_published_on: 2018-12-05 #}
-{# wf_updated_on: 2019-03-07 #}
+{# wf_updated_on: 2019-04-11 #}
 {# wf_featured_image: /web/updates/images/generic/share.png #}
 {# wf_tags: capabilities,sharing,chrome71 #}
 {# wf_featured_snippet: The Web Share Target API allows installed web apps to register with the underlying OS as a share target to receive shared content from either the Web Share API or system events, like the OS-level share button. #}
@@ -96,6 +96,8 @@ In the `manifest.json` file, add the following:
 ```json
 "share_target": {
   "action": "/share-target/",
+  "method": "GET",
+  "enctype": "application/x-www-form-urlencoded",
   "params": {
     "title": "title",
     "text": "text",
@@ -109,6 +111,15 @@ If your application already has a share URL scheme, you can replace the
 URL scheme uses `body` instead of `text`, you could replace the above with
 `"text": "body",`.
 
+The `method` value will default to `"GET"` if not provided. You may need to
+switch it to `"POST"`, depending on what type of HTTP request your `action` URL
+expects to receive. If your web app accepts `POST`s, then the `enctype` value
+will determine what
+[type of encoding](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-enctype)
+is used for the body of the `POST` request. The default `enctype` is
+`"application/x-www-form-urlencoded"`, and the value is ignored if `method` is
+set to `"GET"`.
+
 When another application tries to share, your application will be listed as an
 option in the share intent chooser.
 
@@ -118,20 +129,27 @@ share target landing page.
 
 ### Handle the incoming content
 
-If the user selects your application, the browser opens a new window at the
-`action` URL. It will then generate a query string using the values supplied
-in the manifest. For example if the other app provides `title` and `text`,
-the query string would be `?title=hello&text=world`.
+If the user selects your application, and your `method` is `"GET"` (the
+default), the browser opens a new window at the `action` URL. It will generate a
+query string using the URL encoded values supplied in the manifest. For example
+if the other app provides `title` and `text`, the query string would be
+`?title=hello&text=world`.
 
 
 ```js
 window.addEventListener('DOMContentLoaded', () => {
   const parsedUrl = new URL(window.location);
+  // searchParams.get() will properly handle decoding the values.
   console.log('Title shared: ' + parsedUrl.searchParams.get('title'));
   console.log('Text shared: ' + parsedUrl.searchParams.get('text'));
   console.log('URL shared: ' + parsedUrl.searchParams.get('url'));
 });
 ```
+
+If your `method` is `"POST"`, then the body of the incoming `POST` request will
+contain the same values, encoded using the `enctype` specified. You may choose
+to handle this request server-side, by decoding the request body and using the
+provided data.
 
 How you deal with the incoming shared data is up to you, and dependent on your
 app.


### PR DESCRIPTION
R: @petele @PaulKinlan 

While testing out web share target, I noticed that DevTools will warn you about missing manifest attribute values:

<img width="846" alt="Screen Shot 2019-04-11 at 10 35 40 AM" src="https://user-images.githubusercontent.com/1749548/55976198-a0bb8780-5c59-11e9-92ba-d88f01b9f64f.png">

Those are, I guess, recently added to the spec, but they're not mentioned at all in https://developers.google.com/web/updates/2018/12/web-share-target

This PR adds a description of the `method` and `enctype` manifest attributes, along with some brief description of their default values, and why you might need to customize them.