### PR TITLE
Remove warning about user gesture propagation through Promises

### DIFF
--- a/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
+++ b/src/content/en/updates/2016/03/access-usb-devices-on-the-web.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: The WebUSB API makes USB safer and easier to use by bringing it to the Web.
 
-{# wf_updated_on: 2018-04-16 #}
+{# wf_updated_on: 2019-04-11 #}
 {# wf_published_on: 2016-03-30 #}
 {# wf_tags: news,webusb,iot,arduino,origintrials #}
 {# wf_featured_image: /web/updates/images/2016-03-02-access-usb-devices-on-the-web/web-usb-hero-sm.jpg #}
@@ -92,9 +92,6 @@ the new Certificate Authority [Let's Encrypt](https://letsencrypt.org/){: .exter
 As a security feature, getting access to connected USB devices with
 `navigator.usb.requestDevice` must be called via a user gesture
 like a touch or mouse click.
-
-Caution: User gesture do not propagate through async events like Promises. See
-[crbug.com/404161](http://crbug.com/404161)
 
 ### Feature Policy
 


### PR DESCRIPTION
crbug.com/404161 has been resolved so the following code will now work
as of Chrome 72:

```
let devices = await navigator.usb.getDevices();
// See if |devices| contains the device you are interested in. If not,
let device = await navigator.usb.requestDevice();
```

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
