### PR TITLE
Update reportingobserver.md

### DIFF
--- a/src/content/en/updates/2018/07/reportingobserver.md
+++ b/src/content/en/updates/2018/07/reportingobserver.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: ReportingObserver gives developers insight into what their code is doing in the wild. ReportingObserver surfaces information on issues like deprecations and interventions, messages that were previously only available in the DevTools console.
 
-{# wf_updated_on: 2018-10-23 #}
+{# wf_updated_on: 2019-04-16 #}
 {# wf_published_on: 2018-07-26 #}
 {# wf_tags: chrome69,reporting-observer,analytics,interventions,deprecations #}
 {# wf_featured_image: /web/updates/images/generic/send.png #}

--- a/src/content/en/updates/2018/07/reportingobserver.md
+++ b/src/content/en/updates/2018/07/reportingobserver.md
@@ -105,9 +105,9 @@ list of issues that the page caused:
 ```js
 const observer = new ReportingObserver((reports, observer) => {
   for (const report of reports) {
-    // → report.id === 'XMLHttpRequestSynchronousInNonWorkerOutsideBeforeUnload'
     // → report.type === 'deprecation'
     // → report.url === 'https://reporting-observer-api-demo.glitch.me'
+    // → report.body.id === 'XMLHttpRequestSynchronousInNonWorkerOutsideBeforeUnload'
     // → report.body.message === 'Synchronous XMLHttpRequest is deprecated...'
     // → report.body.lineNumber === 11
     // → report.body.columnNumber === 22


### PR DESCRIPTION
Noticed in testing this API last night that report.id was located in report.body.id.  MDN also lists this as not being included in the report object : https://developer.mozilla.org/en-US/docs/Web/API/Report#Properties

What's changed, or what was fixed?
- Updated location of the report id since it lies within the body object of the report.

**Fixes:** No issue associated.

**Target Live Date:** 2019-05-01 / Not sure if this is needed.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
