### PR TITLE
Update SGX abbrev to SXG.

### DIFF
--- a/src/content/en/updates/2019/03/nic73.md
+++ b/src/content/en/updates/2019/03/nic73.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: What's new in Chrome 73 for developers?
 
 {# wf_published_on: 2019-03-12 #}
-{# wf_updated_on: 2019-03-13 #}
+{# wf_updated_on: 2019-04-15 #}
 {# wf_featured_image: /web/updates/images/generic/new-in-chrome.png #}
 {# wf_tags: chrome73,new-in-chrome,desktop,progressive-web-apps,webpackage,css,regex #}
 {# wf_featured_snippet: Chrome 73 makes creating portable content easier with signed HTTP exchanges. Dynamically changing styles becomes way easier with constructable style sheets. And adds support for Progressive Web Apps on Mac, bringing support for PWAs to all desktop and mobile platforms, making it easy to create installable apps, delivered through the web. Let’s dive in and see what’s new for developers in Chrome 73! #}
@@ -23,7 +23,7 @@ description: What's new in Chrome 73 for developers?
 
 In Chrome 73, we've added support for:
 
-* Creating portable content easier with [signed HTTP exchanges](#sgx).
+* Creating portable content easier with [signed HTTP exchanges](#sxg).
 * Dynamically changing styles becomes way easier with
   [constructable style sheets](#constructable-style-sheets).
 * Support for Progressive Web Apps arrives for on Mac, bringing support for
@@ -95,9 +95,9 @@ Then, iterate from there.
 
 <div class="clearfix"></div>
 
-## Signed HTTP Exchanges {: #sgx }
+## Signed HTTP Exchanges {: #sxg }
 
-Signed HTTP Exchanges (SGX), part of an emerging technology called
+Signed HTTP Exchanges (SXG), part of an emerging technology called
 [Web Packages](https://github.com/WICG/webpackage) is now available in Chrome 73.
 A Signed HTTP Exchange makes it possible to create “portable” content that can
 be delivered by other parties, and this is the key aspect, it retains the


### PR DESCRIPTION
What's changed, or what was fixed?
- SGX should be SXG. SGX is a different security feature from Intel.

**Target Live Date:** YYYY-MM-DD

- [x] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

Marking all of these as checked because the post is already live.

**CC:** @petele
