### PR TITLE
docs(workbox): v4x renames addRequest to pushRequest

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-background-sync.md
+++ b/src/content/en/tools/workbox/modules/workbox-background-sync.md
@@ -99,7 +99,7 @@ self.addEventListener('fetch', (event) => {
   // adding to the Queue.
   const promiseChain = fetch(event.request.clone())
   .catch((err) => {
-      return queue.addRequest(event.request);
+      return queue.pushRequest(event.request);
   });
 
   event.waitUntil(promiseChain);

--- a/src/content/en/tools/workbox/modules/workbox-background-sync.md
+++ b/src/content/en/tools/workbox/modules/workbox-background-sync.md
@@ -99,7 +99,7 @@ self.addEventListener('fetch', (event) => {
   // adding to the Queue.
   const promiseChain = fetch(event.request.clone())
   .catch((err) => {
-      return queue.pushRequest(event.request);
+      return queue.pushRequest({request: event.request});
   });
 
   event.waitUntil(promiseChain);


### PR DESCRIPTION
As of workbox v4, `addRequest` no longer exists.
- Renames `addRequest` -> `pushRequest`.

**Target Live Date:** NA

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
