### PR TITLE
[devtools] link to wndt74 video

### DIFF
--- a/src/content/en/updates/2019/03/devtools.md
+++ b/src/content/en/updates/2019/03/devtools.md
@@ -15,6 +15,14 @@ description: Highlight nodes affected by a CSS property, Lighthouse v4, WebSocke
 
 Welcome back! Here's what's new.
 
+## Video version of this page {: #video }
+
+<div class="video-wrapper-full-width">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="I14fXc7sXdU"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
+
 ## Highlight all nodes affected by CSS property {: #highlight }
 
 Hover over a CSS property that affects a node's box model, such as `padding` or `margin`, to


### PR DESCRIPTION
What's changed, or what was fixed?

- link to the wndt74 video from the wndt74 doc page

**Fixes:** N/A

**Target Live Date:** 2019-04-22

- [x] This has been reviewed and approved by @kaycebasques
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
