### PR TITLE
Expand image optimization CDNs list with Uploadcare.com

### DIFF
--- a/src/content/en/tools/lighthouse/audits/optimize-images.md
+++ b/src/content/en/tools/lighthouse/audits/optimize-images.md
@@ -85,6 +85,7 @@ Image optimization CDNs:
 * [imgix](https://www.imgix.com/){: .external target="_blank" rel="noopener" }
 * [Image Engine](https://imageengine.io/){: .external target="_blank" rel="noopener" }
 * [Cloudinary](https://cloudinary.com/){: .external target="_blank" rel="noopener" }
+* [Uploadcare](https://uploadcare.com/){: .external target="_blank" rel="noopener" }
 
 Image optimization APIs:
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Added [Uploadcare](https://uploadcare.com) to the list of image optimization CDNs.

**Fixes:**  #7532
**CLA name**: @rsedykh

content-updated
section-tools
type-Content

**Target Live Date:** YYYY-MM-DD

- [x] This has been reviewed and approved by @kaycebasques
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele