### PR TITLE
Add "cast" tag to cast related articles

### DIFF
--- a/src/content/en/updates/2015/11/presentation-api.md
+++ b/src/content/en/updates/2015/11/presentation-api.md
@@ -2,9 +2,10 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Chrome on Android now allows mobile sites to present to Google Cast devices using the Presentation API and the Cast Web SDK.
 
-{# wf_updated_on: 2015-12-17 #}
+{# wf_updated_on: 2019-04-25 #}
 {# wf_published_on: 2015-12-17 #}
-{# wf_tags: news,audio,video,media,secondscreen #}
+{# wf_tags: news,audio,video,media,secondscreen,cast #}
+{# wf_blink_components: Blink>PresentationAPI #}
 {# wf_featured_image: /web/updates/images/2015/11/presentation-api/featured.jpg #}
 
 # Google Cast for Chrome on Android {: .page-title }

--- a/src/content/en/updates/2018/04/present-web-pages-to-secondary-attached-displays.md
+++ b/src/content/en/updates/2018/04/present-web-pages-to-secondary-attached-displays.md
@@ -2,9 +2,9 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Chrome 66 allows web pages to use a secondary attached display through the Presentation API and to control its contents through the Presentation Receiver API.
 
-{# wf_updated_on: 2018-05-18 #}
+{# wf_updated_on: 2019-04-25 #}
 {# wf_published_on: 2018-04-05 #}
-{# wf_tags: news,media,presentation #}
+{# wf_tags: news,media,presentation,cast #}
 {# wf_featured_image: /web/updates/images/2018/04/present-web-pages-to-secondary-attached-displays/hero.jpg #}
 {# wf_featured_snippet: Chrome 66 allows web pages to use a secondary attached display through the Presentation API and to control its contents through the Presentation Receiver API. #}
 {# wf_blink_components: Blink>PresentationAPI #}

--- a/src/data/commonTags.json
+++ b/src/data/commonTags.json
@@ -32,6 +32,7 @@
   "canvas",
   "capabilities",
   "casestudy",
+  "cast",
   "chai",
   "chrome-ux-report",
   "chrome49",


### PR DESCRIPTION
This simply adds missing `cast` tag to cast related articles.