### PR TITLE
Add Uploadcare to the list of CDNs

### DIFF
--- a/src/content/en/updates/2018/08/web-performance-made-easy.md
+++ b/src/content/en/updates/2018/08/web-performance-made-easy.md
@@ -381,7 +381,8 @@ libraries like [imagemin](https://github.com/imagemin/imagemin).
 
 This way you make sure that the images added in the future get optimized automatically.
 Some CDNs, for example [Akamai](https://www.akamai.com) or third-party solutions like
-[Cloudinary](https://cloudinary.com/) or [Fastly](https://www.fastly.com/) offer you comprehensive
+[Cloudinary](https://cloudinary.com/), [Fastly](https://www.fastly.com/)
+or [Uploadcare](https://uploadcare.com/) offer you comprehensive
 image optimization solutions. so you can also simply host your images on those services.
 
 If you don't want to do that because of the cost, or latency issues, projects like


### PR DESCRIPTION
What's changed, or what was fixed?
- Added Uploadcare to the list of CDNs

**Fixes:** #7542
**CLA name**: @rsedykh

content-new
section-tools
type-Content

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele (previous reviewer on the same subject was @kaycebasques)