### PR TITLE
Add Uploadcare to the list of GIFs to video convertors

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/replace-animated-gifs-with-video/index.md
@@ -338,8 +338,8 @@ reduce data usage for _all_ users over relying on animated GIFs.
 
 Additionally, converting all your GIFs to video takes time. Time you might not
 have. In this case, you might consider a cloud-based media hosting service such
-as [Cloudinary](https://cloudinary.com/), which does the work for you. Check out
-[this resource from Cloudinary's
+as [Cloudinary](https://cloudinary.com/) or [Uploadcare](https://uploadcare.com/),
+which does the work for you. Check out [this resource from Cloudinary's
 blog](https://cloudinary.com/blog/reduce_size_of_animated_gifs_automatically_convert_to_webm_and_mp4),
 which explains how their service can transcode GIF to video for you.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Added Uploadcare to the list of GIFs to video convertors

**Fixes:** #7543
**CLA name**: @rsedykh

content-new
section-tools
type-Content

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele (previous reviewer on the same subject was @kaycebasques)