### PR TITLE
Wording: `are are` => `are` for workbox NetworkFirst strategy

### DIFF
--- a/src/content/en/tools/workbox/reference-docs/v4.2.0/workbox-strategies_NetworkFirst.mjs.html
+++ b/src/content/en/tools/workbox/reference-docs/v4.2.0/workbox-strategies_NetworkFirst.mjs.html
@@ -47,7 +47,7 @@ import &#x27;./_version.mjs&#x27;;
  *
  * By default, this strategy will cache responses with a 200 status code as
  * well as [opaque responses]{@link /web/tools/workbox/guides/handle-third-party-requests}.
- * Opaque responses are are cross-origin requests where the response doesn&#x27;t
+ * Opaque responses are cross-origin requests where the response doesn&#x27;t
  * support [CORS]{@link https://enable-cors.org/}.
  *
  * If the network request fails, and there is no cache match, this will throw

--- a/src/content/en/tools/workbox/reference-docs/v4.2.0/workbox.strategies.NetworkFirst.html
+++ b/src/content/en/tools/workbox/reference-docs/v4.2.0/workbox.strategies.NetworkFirst.html
@@ -23,7 +23,7 @@
             </div>
             <p>An implementation of a
               <a href="/web/fundamentals/instant-and-offline/offline-cookbook/#network-falling-back-to-cache">network first</a> request strategy.</p>
-            <p>By default, this strategy will cache responses with a 200 status code as well as <a href="/web/tools/workbox/guides/handle-third-party-requests">opaque responses</a>. Opaque responses are are cross-origin requests
+            <p>By default, this strategy will cache responses with a 200 status code as well as <a href="/web/tools/workbox/guides/handle-third-party-requests">opaque responses</a>. Opaque responses are cross-origin requests
               where the response doesn't support <a href="https://enable-cors.org/">CORS</a>.</p>
             <p>If the network request fails, and there is no cache match, this will throw a <code>WorkboxError</code> exception.</p>
           </header>


### PR DESCRIPTION

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
