### PR TITLE
Fix app-shell appspot 404s

### DIFF
--- a/src/content/en/fundamentals/architecture/app-shell.md
+++ b/src/content/en/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/fundamentals/_project.yaml 
+project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: Application shell architecture keeps your UI local and loads content dynamically without sacrificing the linkability and discoverability of the web. 
+description: Application shell architecture keeps your UI local and loads content dynamically without sacrificing the linkability and discoverability of the web.
 
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 {# wf_blink_components: N/A #}
 
@@ -162,11 +162,11 @@ index file. Let's look at what it contains.
       <header class="header">
         <h1 class="header__title">App Shell</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -197,8 +197,7 @@ index file. Let's look at what it contains.
 <div class="clearfix"></div>
 
 
-Note: See [https://app-shell.appspot.com/](https://app-shell.appspot.com/) for a
-real-life look at a very simple PWA using an application shell and server-side
+Note: See [Your First Progressive Web App](/web/fundamentals/codelabs/your-first-pwapp/) for more on using an application shell and server-side
 rendering for content. An app shell can be implemented using any library or
 framework as covered in our <a
 href="https://www.youtube.com/watch?v=srdKq0DckXQ">Progressive Web Apps across
@@ -207,7 +206,7 @@ href="https://shop.polymer-project.org">Shop</a>) and React (<a
 href="https://github.com/insin/react-hn">ReactHN</a>,
 <a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>).
- 
+
 
 ### Caching the application shell {: #app-shell-caching }
 

--- a/src/content/en/ilt/pwa/introduction-to-progressive-web-app-architectures.md
+++ b/src/content/en/ilt/pwa/introduction-to-progressive-web-app-architectures.md
@@ -449,7 +449,7 @@ When should you use the app shell architecture?  It makes the most sense for app
 
 ### App Shell Features
 
-PWAs use a service worker to cache the app shell and data content so that it always loads fast regardless of the network conditions, even when fully offline, retrieving from cache when appropriate and making live calls when appropriate. For instance, a service worker can redirect HTTP/HTTPS requests to a cache and serve dynamic data from a local database. But, unlike  [the older AppCache standard](http://www.w3schools.com/html/html5_app_cache.asp) with its fixed rules, all of these decisions happen in the code that you write. Developers get to decide how network requests from apps are handled.
+PWAs use a service worker to cache the app shell and data content so that it always loads fast regardless of the network conditions, even when fully offline, retrieving from cache when appropriate and making live calls when appropriate. For instance, a service worker can redirect HTTP/HTTPS requests to a cache and serve dynamic data from a local database. But, unlike  [the older AppCache standard](https://www.w3schools.com/html/html5_webstorage.asp) with its fixed rules, all of these decisions happen in the code that you write. Developers get to decide how network requests from apps are handled.
 
 ### Benefits
 
@@ -471,7 +471,7 @@ The benefits of an app shell architecture with a service worker include:
 
 For a simple example of a web app manifest file, see the Use a Web App Manifest File section.
 
-You can see actual offline application shells demonstrated in Jake Archibald's demo of an  [offline Wikipedia app](https://wiki-offline.jakearchibald.com/wiki/Rick_and_Morty),  [Flipkart Lite](http://tech-blog.flipkart.net/2015/11/progressive-web-app/) (an e-commerce company), and  [Voice Memos](https://github.com/googlechrome/voice-memos) (a sample web app that records voice memos). For a very basic app shell plus service worker example with minimal options about frameworks or libraries, see  [app-shell.appspot.com](http://app-shell.appspot.com).
+You can see actual offline application shells demonstrated in Jake Archibald's demo of an  [offline Wikipedia app](https://wiki-offline.jakearchibald.com/wiki/Rick_and_Morty),  [Flipkart Lite](/web/showcase/2016/flipkart) (an e-commerce company), and  [Voice Memos](https://github.com/googlechrome/voice-memos) (a sample web app that records voice memos). For more on the app shell plus a service worker example with minimal options about frameworks or libraries, see [Your First Progressive Web App](/web/fundamentals/codelabs/your-first-pwapp/).
 
 Other great examples include  [AliExpress](/web/showcase/2016/aliexpress), one of the world's largest e-commerce sites,  [BaBe](/web/showcase/2016/babe), an Indonesian news aggregator service,  [United eXtra](/web/showcase/2016/extra), a leading retailer in Saudi Arabia, and  [The Washington Post](https://www.washingtonpost.com/pr/wp/2016/05/19/the-washington-post-introduces-new-progressive-web-app-experience/), America's most widely circulated newspaper.
 
@@ -480,14 +480,11 @@ Other great examples include  [AliExpress](/web/showcase/2016/aliexpress), one o
 
 ## How to Create an App Shell
 
-
-
-
 So, your next step could be to add a service worker to your existing web app. Using a service worker is one of the things that turns a single-page app into an app shell. (See the  [App Shell Features](#features) section earlier in this document for a description of the service worker.)
 
 However, there are many situations that can affect your strategy for structuring your PWA and its app shell. It is important to understand the network traffic so you know what to actually precache and what to request as far as dynamic content. These decisions cannot be arbitrary.
 
-You can use  [Chrome Developer Tools](https://developer.chrome.com/devtools/docs/remote-debugging) to help analyze network traffic patterns. It is also important to ask yourself: "What are people trying to achieve when they visit my site?"
+You can use  [Chrome Developer Tools](/web/tools/chrome-devtools/remote-debugging/) to help analyze network traffic patterns. It is also important to ask yourself: "What are people trying to achieve when they visit my site?"
 
 ### Exercise
 
@@ -892,7 +889,7 @@ It is a simple JSON file that provides developers with:
 * A centralized place to put metadata about a web site, such as fields for the application name, display mode information such as background color and font size, links to icons, and so on.
 * A way to declare a default orientation for their web application,and provide the ability to set the display mode for the application (e.g., in full screen).
 
-The following manifest file is for the simple app shell at  [appspot.com](https://app-shell.appspot.com/).
+The following manifest file is for a simple app shell.
 
 ```
 {

--- a/src/content/es/fundamentals/architecture/app-shell.md
+++ b/src/content/es/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: La arquitectura de shell de la app mantiene tu IU local y carga contenido dinámicamente sin sacrificar las vínculos y la visibilidad de la Web. 
+description: La arquitectura de shell de la app mantiene tu IU local y carga contenido dinámicamente sin sacrificar las vínculos y la visibilidad de la Web.
 
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 # El modelo de "shell de app" {: .page-title }
@@ -162,11 +162,11 @@ archivo index completo. Observemos lo que contiene.
       <header class="header">
         <h1 class="header__title">Shell de app</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -197,7 +197,7 @@ archivo index completo. Observemos lo que contiene.
 <div class="clearfix"></div>
 
 
-Note: Visita [https://app-shell.appspot.com/](https://app-shell.appspot.com/) para ver una PWA
+Note: Visita [The App Shell Model](/web/fundamentals/architecture/app-shell) para ver una PWA
 simple y real que utiliza una shell de app y
 representación de contenido del lado del servidor. Una shell de app se puede implementar por medio de cualquier biblioteca o
 framework mencionado en nuestra charla sobre <a
@@ -207,7 +207,7 @@ href="https://shop.polymer-project.org">Shop</a>) y React (<a
 href="https://github.com/insin/react-hn">ReactHN</a>,
 <a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>).
- 
+
 
 ### Almacenamiento en caché de la shell de app {: #app-shell-caching }
 

--- a/src/content/id/fundamentals/architecture/app-shell.md
+++ b/src/content/id/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: Arsitektur shell aplikasi membuat UI Anda tetap lokal dan memuat konten secara dinamis tanpa mengorbankan kemampuan untuk dapat ditemukan dan ditautkan pada web. 
+description: Arsitektur shell aplikasi membuat UI Anda tetap lokal dan memuat konten secara dinamis tanpa mengorbankan kemampuan untuk dapat ditemukan dan ditautkan pada web.
 
-{# wf_updated_on: 2017-07-12 #}
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 # Model Shell Aplikasi {: .page-title }
@@ -162,11 +162,11 @@ file indeks lengkap. Mari kita lihat apa materinya.
       <header class="header">
         <h1 class="header__title">Shell Aplikasi</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -197,7 +197,7 @@ file indeks lengkap. Mari kita lihat apa materinya.
 <div class="clearfix"></div>
 
 
-Note: Lihat [https://app-shell.appspot.com/](https://app-shell.appspot.com/) untuk
+Note: Lihat [The App Shell Model](/web/fundamentals/architecture/app-shell) untuk
 tampilan sesungguhnya dengan PWA sangat sederhana menggunakan shell aplikasi dan
 rendering sisi-server untuk materi. Shell aplikasi bisa diimplementasikan dengan menggunakan sembarang pustaka atau
 kerangka kerja seperti yang dibahas dalam pembahasan <a
@@ -207,7 +207,7 @@ href="https://shop.polymer-project.org">Shop</a>) dan React (<a
 href="https://github.com/insin/react-hn">ReactHN</a>,
 <a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>).
- 
+
 
 ### Meng-cache shell aplikasi {: #app-shell-caching }
 

--- a/src/content/it/fundamentals/architecture/app-shell.md
+++ b/src/content/it/fundamentals/architecture/app-shell.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: L'architettura della shell dell'applicazione mantiene l'interfaccia utente locale e carica il contenuto in modo dinamico senza sacrificare la capacità di collegamento e l'individuabilità del Web.
 
-{# wf_updated_on: 2018-03-09 #}
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 {# wf_blink_components: N/A #}
 
@@ -177,11 +177,11 @@ offline.
   <header class="header">
     <h1 class="header__title">App Shell</h1>
   </header>
-  
+
   <nav class="nav">
   ...
   </nav>
-  
+
   <main class="main">
   ...
   </main>
@@ -212,8 +212,7 @@ offline.
 
 <div class="clearfix"></div>
 
-Note: vai a vedere [https://app-shell.appspot.com/](https://app-shell.appspot.com/)
-per vedere una PWA reale, molto semplice, che utilizza una shell
+Note: vai a vedere [The App Shell Model](/web/fundamentals/architecture/app-shell) per vedere una PWA reale, molto semplice, che utilizza una shell
 dell'applicazione e il rendering sul lato server per il contenuto. La shell dell'applicazione può
 essere implementata utilizzando qualsiasi libreria o framework come descritto
 nel nostro talk <a

--- a/src/content/ja/fundamentals/architecture/app-shell.md
+++ b/src/content/ja/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: App Shell アーキテクチャでは UI をローカルに保持して、ウェブのリンク可能性と見つけやすさを損なうことなくコンテンツを動的に読み込むことができます。 
+description: App Shell アーキテクチャでは UI をローカルに保持して、ウェブのリンク可能性と見つけやすさを損なうことなくコンテンツを動的に読み込むことができます。
 
-{# wf_updated_on: 2016-09-26 #} 
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 #  App Shell モデル {: .page-title }
@@ -137,11 +137,11 @@ Service Worker を使用することで、すべての UI とインフラスト�
       <header class="header">
         <h1 class="header__title">App Shell</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -172,17 +172,17 @@ Service Worker を使用することで、すべての UI とインフラスト�
 <div class="clearfix"></div>
 
 
-注: コンテンツに App Shell とサーバー側のレンダリングを使用した非常にシンプルな PWA を [https://app-shell.appspot.com/](https://app-shell.appspot.com/) で実際に確認できます。<a
+注: コンテンツに App Shell とサーバー側のレンダリングを使用した非常にシンプルな PWA を [The App Shell Model](/web/fundamentals/architecture/app-shell) で実際に確認できます。<a
 href="https://www.youtube.com/watch?v=srdKq0DckXQ">あらゆるフレームワークをまたがる Progressive Web App</a> の動画で紹介されているとおり、App Shell は、どのライブラリまたはフレームワークを使用しても実装できます。Polymer （<a
 href="https://shop.polymer-project.org">Shop</a>）と React（<a
 href="https://github.com/insin/react-hn">ReactHN</a>、<a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>）を使用したサンプルもご覧いただけます。
 
- 
+
 
 ###  App Shell のキャッシング{: #app-shell-caching }
 
-App Shell は、手動で記述された Service Worker、または 
+App Shell は、手動で記述された Service Worker、または
 [sw-precache](https://github.com/googlechrome/sw-precache) などの静的なアセットのプリキャッシュ ツールを使用して生成された Service Worker を使用してキャッシュすることができます。
 
 

--- a/src/content/ko/fundamentals/architecture/app-shell.md
+++ b/src/content/ko/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: 애플리케이션 셸 아키텍처는 웹의 연결성과 검색 기능을 저해하지 않고 UI를 로컬로 유지하고 콘텐츠를 동적으로 로드합니다. 
+description: 애플리케이션 셸 아키텍처는 웹의 연결성과 검색 기능을 저해하지 않고 UI를 로컬로 유지하고 콘텐츠를 동적으로 로드합니다.
 
-{# wf_updated_on: 2016-09-26 #} 
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 # 앱 셸 모델 {: .page-title }
@@ -162,11 +162,11 @@ API를 통해 콘텐츠를 동적으로 가져오지만 웹의 연결성과 검�
       <header class="header">
         <h1 class="header__title">App Shell</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -197,7 +197,7 @@ API를 통해 콘텐츠를 동적으로 가져오지만 웹의 연결성과 검�
 <div class="clearfix"></div>
 
 
-참고: [https://app-shell.appspot.com/](https://app-shell.appspot.com/)에서
+참고: [The App Shell Model](/web/fundamentals/architecture/app-shell) 에서
 애플리케이션 셸과 서버측 콘텐츠 렌더링을 사용하는 매우 단순한 PWA의 실제 모습을
 살펴보세요. 앱 셸은
 <a
@@ -207,7 +207,7 @@ href="https://shop.polymer-project.org">Shop</a>)와 React(<a
 href="https://github.com/insin/react-hn">ReactHN</a>,
 <a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>)를 사용한 샘플이 있습니다.
- 
+
 
 ### 애플리케이션 셸 캐싱 {: #app-shell-caching }
 
@@ -253,7 +253,7 @@ sw-precache가 생성한 서비스 워커가 빌드 프로세스에서 구성한
 HTML, 자바스크립트 및 CSS 파일에서 리소스를 미리 캐시할 수 있습니다. 모든 것이
 오프라인에서도 작동하고 추가적인 노력 없이도 다음 방문 시 빠르게 로드됩니다.
 
-다음은 
+다음은
 [gulp](http://gulpjs.com) 빌드 프로세스에서 sw-precache를 사용하는 기본적 예시입니다.
 
     gulp.task('generate-service-worker', function(callback) {

--- a/src/content/pt-br/fundamentals/architecture/app-shell.md
+++ b/src/content/pt-br/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description: A arquitetura de shell dos aplicativos mantém sua IU local e carrega conteúdo dinamicamente, sem sacrificar o potencial da web de oferecer links e de descobrir e encontrar. 
+description: A arquitetura de shell dos aplicativos mantém sua IU local e carrega conteúdo dinamicamente, sem sacrificar o potencial da web de oferecer links e de descobrir e encontrar.
 
-{# wf_updated_on: 2017-07-12 #} 
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 # O modelo de shell dos aplicativos {: .page-title }
@@ -162,11 +162,11 @@ de índice completo. Vejamos o que ele contém.
       <header class="header">
         <h1 class="header__title">App Shell</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -197,8 +197,7 @@ de índice completo. Vejamos o que ele contém.
 <div class="clearfix"></div>
 
 
-Observação: Acesse [https://app-shell.appspot.com/](https://app-shell.appspot.com/)
-para ver um PWA real muito simples que usa um shell de aplicativo e renderização
+Observação: Acesse [The App Shell Model](/web/fundamentals/architecture/app-shell) para ver um PWA real muito simples que usa um shell de aplicativo e renderização
 no servidor para o conteúdo. Pode-se implementar um shell de aplicativo usando qualquer biblioteca
 ou estrutura, conforme explicado na nossa palestra <a
 href="https://www.youtube.com/watch?v=srdKq0DckXQ">Progressive Web Apps em
@@ -207,7 +206,7 @@ href="https://shop.polymer-project.org">Shop</a>) e o React (<a
 href="https://github.com/insin/react-hn">ReactHN</a>,
 <a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>).
- 
+
 
 ### Armazenar o shell do aplicativo em cache {: #app-shell-caching }
 

--- a/src/content/zh-cn/fundamentals/architecture/app-shell.md
+++ b/src/content/zh-cn/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description:App Shell 架构可保证 UI 的本地化和动态加载内容，同时不影响 Web 的可链接性和可检测性。 
+description:App Shell 架构可保证 UI 的本地化和动态加载内容，同时不影响 Web 的可链接性和可检测性。
 
-{# wf_updated_on: 2016-09-26 #} 
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 # App Shell 模型 {: .page-title }
@@ -140,11 +140,11 @@ Note: [Lighthouse](https://github.com/googlechrome/lighthouse) 审核扩展可�
       <header class="header">
         <h1 class="header__title">App Shell</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -175,13 +175,13 @@ Note: [Lighthouse](https://github.com/googlechrome/lighthouse) 审核扩展可�
 <div class="clearfix"></div>
 
 
-Note: 请参阅 [https://app-shell.appspot.com/](https://app-shell.appspot.com/)，查看一个非常简单的、使用 App Shell 和内容服务器端渲染的 PWA 的真实演示。App Shell 可通过使用任意内容库或框架实现（如我们的<a
+Note: 请参阅 [The App Shell Model](/web/fundamentals/architecture/app-shell)，查看一个非常简单的、使用 App Shell 和内容服务器端渲染的 PWA 的真实演示。App Shell 可通过使用任意内容库或框架实现（如我们的<a
 href="https://www.youtube.com/watch?v=srdKq0DckXQ">所有框架上的 Progressive Web App</a> 讲座中所述）。您可以使用 Polymer (<a
 href="https://shop.polymer-project.org">Shop</a>) 和 React （<a
 href="https://github.com/insin/react-hn">ReactHN</a>、<a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>）查看示例。
 
- 
+
 
 ### 缓存 App Shell {: #app-shell-caching }
 

--- a/src/content/zh-tw/fundamentals/architecture/app-shell.md
+++ b/src/content/zh-tw/fundamentals/architecture/app-shell.md
@@ -1,8 +1,8 @@
-project_path: /web/_project.yaml 
+project_path: /web/_project.yaml
 book_path: /web/fundamentals/_book.yaml
-description:App Shell 架構可保證 UI 的本地化和動態加載內容，同時不影響 Web 的可鏈接性和可檢測性。 
+description:App Shell 架構可保證 UI 的本地化和動態加載內容，同時不影響 Web 的可鏈接性和可檢測性。
 
-{# wf_updated_on: 2016-09-26 #} 
+{# wf_updated_on: 2019-05-02 #}
 {# wf_published_on: 2016-09-27 #}
 
 # App Shell 模型 {: .page-title }
@@ -140,11 +140,11 @@ Note: [Lighthouse](https://github.com/googlechrome/lighthouse) 審覈擴展可�
       <header class="header">
         <h1 class="header__title">App Shell</h1>
       </header>
-      
+
       <nav class="nav">
       ...
       </nav>
-      
+
       <main class="main">
       ...
       </main>
@@ -175,13 +175,13 @@ Note: [Lighthouse](https://github.com/googlechrome/lighthouse) 審覈擴展可�
 <div class="clearfix"></div>
 
 
-Note: 請參閱 [https://app-shell.appspot.com/](https://app-shell.appspot.com/)，查看一個非常簡單的、使用 App Shell 和內容服務器端渲染的 PWA 的真實演示。App Shell 可通過使用任意內容庫或框架實現（如我們的<a
+Note: 請參閱 [The App Shell Model](/web/fundamentals/architecture/app-shell)，查看一個非常簡單的、使用 App Shell 和內容服務器端渲染的 PWA 的真實演示。App Shell 可通過使用任意內容庫或框架實現（如我們的<a
 href="https://www.youtube.com/watch?v=srdKq0DckXQ">所有框架上的 Progressive Web App</a> 講座中所述）。您可以使用 Polymer (<a
 href="https://shop.polymer-project.org">Shop</a>) 和 React （<a
 href="https://github.com/insin/react-hn">ReactHN</a>、<a
 href="https://github.com/GoogleChrome/sw-precache/tree/master/app-shell-demo">iFixit</a>）查看示例。
 
- 
+
 
 ### 緩存 App Shell {: #app-shell-caching }
 


### PR DESCRIPTION
Same issue reported multiple times. Used the most logical replacement internal URL since the app-shell appspot URL does not exist.

What's changed, or what was fixed?
- updated appshell 404
- fixed a couple other broken links

**Fixes:** #7460 #7557

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
