### PR TITLE
Remove future API from Site Kit services to enable

### DIFF
--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -68,7 +68,7 @@
           data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
           data-henhouse-use-updated-header="true"
           data-api-id="servicemanagement.googleapis.com"
-          data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,lighthouse.googleapis.com,pagespeedonline.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
+          data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
           data-henhouse-credential-type="OAUTH"
           data-henhouse-client-type="WEB_SERVER"
           {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}


### PR DESCRIPTION
On developers.google.com/web/site-kit/, the button for obtaining client credentials currently tries enabling the lighthouse.googleapis.com service API. However, it was noticed that this API is not rolled out publicly yet, therefore the process was causing an error for non google.com accounts. It is unnecessary for our current purposes, so this PR removes it from the list of services to enable.

**Target Live Date:** 2019-05-03

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
