### PR TITLE
Update cache-policy.md to account for leap years

### DIFF
--- a/src/content/en/tools/lighthouse/audits/cache-policy.md
+++ b/src/content/en/tools/lighthouse/audits/cache-policy.md
@@ -20,7 +20,7 @@ resource, the browser uses its local copy, rather than going to the network to g
 
 Configure your server to return the `Cache-Control` HTTP response header.
 
-     Cache-Control: max-age=31536000
+     Cache-Control: max-age=31557600
 
 [Invalidate]: /web/fundamentals/performance/optimizing-content-efficiency/http-caching#invalidating_and_updating_cached_responses
 
@@ -28,8 +28,8 @@ Caution: Make sure to provide yourself a way to [invalidate and update
 cached responses][Invalidate].
 
 The `max-age` directive tells the browser how long it should cache the resource, in seconds.
-`31536000` corresponds to 1 year: 60 seconds * 60 minutes * 24 hours * 365 days = 
-31536000 seconds.
+`31557600` corresponds to 1 year: 60 seconds * 60 minutes * 24 hours * 365.25 days = 
+31557600 seconds.
 
 [webpack]: https://webpack.js.org/guides/caching/
 


### PR DESCRIPTION
1 year: 60 seconds * 60 minutes * 24 hours * 365.25 days = 31557600 seconds.
we need the 1/4 day to account for leap years

What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
