### PR TITLE
Update axe links

### DIFF
--- a/src/content/en/tools/lighthouse/audits/alt-attribute.md
+++ b/src/content/en/tools/lighthouse/audits/alt-attribute.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Every Image Element Has An alt Attribute" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-23 #}
 {# wf_blink_components: N/A #}
 
@@ -47,7 +47,7 @@ to convey the gist of the scene as efficiently as possible.
 This audit is powered by the aXe Accessibility Engine. See [Images must have
 alternate text][axe] for more information.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/image-alt
+[axe]: https://dequeuniversity.com/rules/axe/3.2/image-alt
 
 ## Feedback {: #feedback }
 

--- a/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/aria-allowed-attributes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Element aria-* Attributes Are Allowed For This Role" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-13 #}
 {# wf_blink_components: N/A #}
 
@@ -45,7 +45,7 @@ attributes.
 This audit is powered by the aXe Accessibility Engine. See [Elements must only
 use allowed ARIA attributes][axe] for more information.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/aria-allowed-attr
+[axe]: https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr
 
 ## Feedback {: #feedback }
 

--- a/src/content/en/tools/lighthouse/audits/button-name.md
+++ b/src/content/en/tools/lighthouse/audits/button-name.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Buttons have an accessible name" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-05-11 #}
 {# wf_blink_components: N/A #}
 
@@ -46,7 +46,7 @@ For `<input type="submit">` and `<input type="reset">`:
 This audit is powered by the aXe Accessibility Engine. See [Buttons must have
 discernible text][axe].
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/button-name
+[axe]: https://dequeuniversity.com/rules/axe/3.2/button-name
 
 ## Feedback {: #feedback }
 

--- a/src/content/en/tools/lighthouse/audits/form-labels.md
+++ b/src/content/en/tools/lighthouse/audits/form-labels.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Every Form Element Has A Label" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-23 #}
 {# wf_blink_components: N/A #}
 
@@ -44,7 +44,7 @@ Explicit labels:
 This audit is powered by the aXe Accessibility Engine. See [Form elements must
 have labels][axe] for more information.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/label
+[axe]: https://dequeuniversity.com/rules/axe/3.2/label
 
 
 ## Feedback {: #feedback }

--- a/src/content/en/tools/lighthouse/audits/tabindex.md
+++ b/src/content/en/tools/lighthouse/audits/tabindex.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "No Element Has a tabindex Attribute Greater Than 0" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-23 #}
 {# wf_blink_components: N/A #}
 
@@ -32,7 +32,7 @@ it earlier in the DOM.
 This audit is powered by the aXe Accessibility Engine. See [Elements should not
 have tabindex greater than zero][axe] for more information.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/tabindex
+[axe]: https://dequeuniversity.com/rules/axe/3.2/tabindex
 
 
 ## Feedback {: #feedback }

--- a/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-attributes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Element aria-* Attributes Are Valid And Not Misspelled Or Non-Existent" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-18 #}
 {# wf_blink_components: N/A #}
 
@@ -42,7 +42,7 @@ To find each listed element's invalid attribute names:
 This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid names][axe] for more information.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr
+[axe]: https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr
 
 
 ## Feedback {: #feedback }

--- a/src/content/en/tools/lighthouse/audits/valid-aria-values.md
+++ b/src/content/en/tools/lighthouse/audits/valid-aria-values.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "Element aria-* Attributes Have Valid Values" Lighthouse audit.
 
-{# wf_updated_on: 2018-07-23 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-18 #}
 {# wf_blink_components: N/A #}
 
@@ -41,7 +41,7 @@ To find each listed element's invalid attribute values:
 This audit is powered by the aXe Accessibility Engine. See [ARIA attributes
 must conform to valid values][axe] for more information.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr-value
+[axe]: https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr-value
 
 
 ## Feedback {: #feedback }

--- a/src/content/ko/tools/lighthouse/audits/aria-allowed-attributes.md
+++ b/src/content/ko/tools/lighthouse/audits/aria-allowed-attributes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Lighthouse 검사 항목 "역할을 위해 요소에 ARIA 속성을 허용합니다"를 위한 참조 문서
 
-{# wf_updated_on: 2017-02-20 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-13 #}
 
 # 역할을 위해 요소에 ARIA 속성을 허용합니다.  {: .page-title }
@@ -26,7 +26,7 @@ description: Lighthouse 검사 항목 "역할을 위해 요소에 ARIA 속성을
 1. **Required States and Properties**나 **Supported States and Properties** 목록에서
   요소의 `aria-*` 속성을 다시한번 체크하세요. 이 두 목록 중 하나에없는 속성은 유효하지 않습니다.
 
-유효하지 않은 조합을 수정하려면 요소에서 유효하지 않은 속성을 
+유효하지 않은 조합을 수정하려면 요소에서 유효하지 않은 속성을
 제거하거나 요소의 역할을 속성이 지원하는 것으로 변경하십시오.
 
 [qs]: /web/tools/chrome-devtools/console/command-line-reference#queryselector
@@ -39,4 +39,4 @@ description: Lighthouse 검사 항목 "역할을 위해 요소에 ARIA 속성을
 이 검사는 aXe 접근성 엔진에 의해 검사합니다.
 더 자세한 정보는 [Elements must only use allowed ARIA attributes][axe]를 참고하세요.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/aria-allowed-attr
+[axe]: https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr

--- a/src/content/ko/tools/lighthouse/audits/valid-aria-attributes.md
+++ b/src/content/ko/tools/lighthouse/audits/valid-aria-attributes.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Lighthouse 검사 항목 "요소의 ARIA 속성은 유효해야 한다"를 위한 참조 문서
 
-{# wf_updated_on: 2017-02-20 #}
+{# wf_updated_on: 2019-05-08 #}
 {# wf_published_on: 2017-01-18 #}
 
 # 요소의 ARIA 속성은 유효해야 한다 {: .page-title }
@@ -38,4 +38,4 @@ description: Lighthouse 검사 항목 "요소의 ARIA 속성은 유효해야 한
 이 검사는 aXe 접근성 엔진에 의해 검사합니다.
 더 자세한 정보는 [Elements must only use allowed ARIA attributes][axe]를 참고하세요.
 
-[axe]: https://dequeuniversity.com/rules/axe/1.1/aria-valid-attr
+[axe]: https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr


### PR DESCRIPTION
What's changed, or what was fixed?
- Updating all `https://dequeuniversity.com/*/axe/1.1/*` links to route to the proper  `https://dequeuniversity.com/*/axe/3.2/*` version

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
