### PR TITLE
Add new Site Kit page for obtaining API Key

### DIFF
--- a/src/content/en/site-kit/_footer.yaml
+++ b/src/content/en/site-kit/_footer.yaml
@@ -14,6 +14,6 @@ footer:
     icon_name: bug_report
     contents:
     - label: File an Issue
-      path: https://github.com/google/wp-site-kit/issues
+      path: https://github.com/google/site-kit-wp/issues
     - label: View Plugin Source
-      path: https://github.com/google/wp-site-kit
+      path: https://github.com/google/site-kit-wp

--- a/src/content/en/site-kit/_project.yaml
+++ b/src/content/en/site-kit/_project.yaml
@@ -1,6 +1,6 @@
 parent_project_metadata_path: /web/_project.yaml
 name: Site Kit
-description: Set up the Site Kit plugin for your WordPress site by creating a Google Cloud Platform project.
+description: Set up the Site Kit plugin for your WordPress site by obtaining credentials for your Google Cloud Platform project.
 home_url: /web/site-kit/
 buganizer_id: 488674
 color: google-blue

--- a/src/content/en/site-kit/apikey.html
+++ b/src/content/en/site-kit/apikey.html
@@ -1,0 +1,55 @@
+<html devsite>
+  <head>
+    <title>Site Kit API Key</title>
+    <meta name="project_path" value="/web/site-kit/_project.yaml" />
+    <meta name="book_path" value="/web/site-kit/_book.yaml" />
+    <meta name="page_type" value="landing" />
+    <meta name="hide_last_updated" value="true" />
+    <meta name="no_page_title" value="true" />
+    <style>
+      .button-large {
+        height: 52px;
+        padding: 16px 36px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="site-kit-setup">
+      {% dynamic if request.query_string.sitename %}
+        {% dynamic setvar projectName %}{% dynamic print request.query_string.sitename|escape %}{% dynamic endsetvar %}
+      {% dynamic endif %}
+      {% dynamic if request.query_string.siteurl %}
+        {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
+      {% dynamic endif %}
+      <ol>
+        <li>
+          {% dynamic if user.signed_in and setvar.projectName and setvar.productName %}
+            Click the button below to obtain a new API key for your Google Cloud Platform project <strong>{% dynamic print setvar.projectName|escape%}</strong> that you can use on your WordPress site. By clicking the button, you are confirming that your site is running the official <a href="https://sitekit.withgoogle.com" target="_blank">Site Kit plugin for WordPress</a>.
+          {% dynamic else %}
+            Click the button below to create a new Google Cloud Platform project and obtain an API key that you can use on your WordPress site. By clicking the button, you are confirming that your site is running the official <a href="https://sitekit.withgoogle.com" target="_blank">Site Kit plugin for WordPress</a>.
+          {% dynamic endif %}
+        </li>
+        <li>
+          Once the project has been created, you will see the API key. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
+        </li>
+      </ol>
+      <p>
+        <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"
+          data-henhouse-header-text="Site Kit: Get API Key"
+          data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
+          data-henhouse-use-updated-header="true"
+          data-api-id="servicemanagement.googleapis.com"
+          data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
+          data-henhouse-credential-type="API_KEY"
+          {% dynamic if user.signed_in and setvar.projectName and setvar.productName %}
+            data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"
+            data-henhouse-product-name="{% dynamic print setvar.productName|escape %}"
+            data-henhouse-create-new-project-by-default="true"
+          {% dynamic endif %}
+        >
+          Get API Key
+        </a>
+      </p>
+    </div>
+  </body>
+</html>

--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -1,6 +1,6 @@
 <html devsite>
   <head>
-    <title>Site-Kit</title>
+    <title>Site Kit</title>
     <meta name="project_path" value="/web/site-kit/_project.yaml" />
     <meta name="book_path" value="/web/site-kit/_book.yaml" />
     <meta name="page_type" value="landing" />


### PR DESCRIPTION
Similar to the previously added section for the Site Kit plugin for WordPress, this PR adds a new sub-page that allows setting up an API key.

Note that even though there are now two pages in that section, there shouldn't be any cross-linking or additional navigation, as these pages are very targeted and should have as little distractions as possible. They are directly linked to from the Site Kit plugin.

**Target Live Date:** 2019-05-10

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
