### PR TITLE
Fix typo in the word "can"

### DIFF
--- a/src/content/en/updates/2016/10/resizeobserver.md
+++ b/src/content/en/updates/2016/10/resizeobserver.md
@@ -151,7 +151,7 @@ when a new message comes in.
 
 Another use case is for any kind of custom element that is doing its own layout.
 Until `ResizeObserver`, there was no reliable way to get notified when your own
-dimensions change so you ca re-layout your own children.
+dimensions change so you can re-layout your own children.
 
 ## Out now!
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Typo in the article "ResizeObserver: It’s Like document.onresize for Elements"
<br/>

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
