### PR TITLE
Fix typo in Text Compression page

### DIFF
--- a/src/content/en/tools/lighthouse/audits/text-compression.md
+++ b/src/content/en/tools/lighthouse/audits/text-compression.md
@@ -59,7 +59,7 @@ To check if a server compressed a response:
 1. Go to the **Network** panel in DevTools.
 1. Click the request that caused the response you're interested in.
 1. Click the **Headers** tab.
-1. Check the `content-heading` header in the **Response Headers** section.
+1. Check the `content-encoding` header in the **Response Headers** section.
 
 <figure>
   <img src="images/content-encoding.svg"


### PR DESCRIPTION
What's changed, or what was fixed?
- Changes an instance of `content-heading` to `content-encoding`.

**Fixes:** Issue not filed. If required for workflow, please file a stub issue on my behalf.

**Target Live Date:** At your convenience

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele

I have signed an individual CLA.