### PR TITLE
Fixes and improvements to Share files article

### DIFF
--- a/src/content/en/updates/2019/05/web-share-files.md
+++ b/src/content/en/updates/2019/05/web-share-files.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Chrome 75 introduces file sharing from a web app, which lets your web app can share with virtually anything on a user's device.
 
 {# wf_published_on: 2019-05-02 #}
-{# wf_updated_on: 2019-05-06 #}
+{# wf_updated_on: 2019-05-25 #}
 {# wf_featured_image: /web/updates/images/generic/share.png #}
 {# wf_tags: capabilities,sharing,chrome75 #}
 {# wf_featured_snippet: Chrome 75 introduces file sharing from a web app, which lets your web app can share with virtually anything on a user's device. #}
@@ -29,23 +29,23 @@ see. The
 allows web apps to receive data from a share.
 
 The only resource previously supported by these APIs was links. Chrome 75 adds
-support for Web [Web Share API - Level
+support for the [Web Share API - Level
 2](https://wicg.github.io/web-share/level-2/), making it easy for web apps to
-share files to other apps using the system provided picker.[In the
+share files to other apps using the system provided picker. [In the
 future](https://www.chromestatus.com/feature/6124071381106688), you'll also be
 able to use web apps as a share target. For now, your web app can share files
 with other web share targets registered on your device.
 
-This article assumes some familiarity with the web share APIs. If this is new to
+This article assumes some familiarity with the Web Share API. If this is new to
 you, check out the links above or [the demo](http://wicg.github.io/web-share/demos/share-files.html). 
 
-## The canShare() method
+## The navigator.canShare() method
 
 If you're familiar with the earlier API, you're used to doing feature detection
 by testing for `navigator.share()`. With files it's more complicated. You need
 to know whether the file a user is sharing is sharable on the current system. To
-find out, you test for the presence of `canShare()`, then pass it a reference to
-the files you want to share. 
+find out, you test for the presence of `navigator.canShare()`, and if present,
+you call it with a reference to the files you want to share. 
 
 ```javascript
 const shareData = { files: filesArray };
@@ -56,7 +56,7 @@ if (navigator.canShare && navigator.canShare(shareData)) {
 }
 ```
 
-Take note of what's not in `shareData`. When calling `canShare()` for files,
+Take note of what's not in `shareData`. When calling `navigator.canShare()` for files,
 `shareData` cannot contain other members. If you need title, text, or url you'll
 need to add them afterwards.
 
@@ -69,9 +69,10 @@ You're now ready to share:
 ```javascript
 if (navigator.canShare && navigator.canShare( { files: filesArray } )) {
   navigator.share({
-    files: files,
+    files: filesArray,
     title: 'Vacation Pictures',
-    text: 'Barb\nHere are the pictures from our vacation.\n\nJoe',  })
+    text: 'Barb\nHere are the pictures from our vacation.\n\nJoe',
+  })
   .then(() => console.log('Share was successful.'))
   .catch((error) => console.log('Sharing failed', error));
 } else {
@@ -80,20 +81,21 @@ if (navigator.canShare && navigator.canShare( { files: filesArray } )) {
 ```
 
 It may seem odd to include other data members when sharing files. Allowing these
-members explands the flexibility of use cases. Imagine if after running the code
+members expands the flexibility of use cases. Imagine if after running the code
 above, the user chose an email application as the target. The `title` parameter
 might become an email subject, the `text`, the body of the message, and the
 `files`, attachments.
 
-Note: The `shareData` argument is required for both `canShare()` and `share()`
-even though the specification labels it as optional in both cases. As the
-specification itself states, this is because of a quirk of the Web IDL rules.
+Note: The `shareData` argument is required for both `navigator.canShare()` and
+`navigator.share()` even though the specification labels it as optional in both
+cases. As the specification itself states, this is because of a quirk of the Web
+IDL rules.
 
 ## More information
 
-+   [Web share demo](http://wicg.github.io/web-share/demos/share-files.html)
-+   [Web share explainer](https://github.com/WICG/web-share/blob/master/docs/explainer.md)
-+   [Web share on Chrome Status](https://www.chromestatus.com/feature/4777349178458112)
++   [Web Share demo](http://wicg.github.io/web-share/demos/share-files.html)
++   [Web Share explainer](https://github.com/WICG/web-share/blob/master/docs/explainer.md)
++   [Web Share on Chrome Status](https://www.chromestatus.com/feature/4777349178458112)
 
 ## Feedback {: .hide-from-toc }
 


### PR DESCRIPTION
What's changed, or what was fixed?

In the article "Share files with Web Share",

* Fixed some typos
* Made all references to `navigator.canShare()` and `navigator.share()` explicit rather than just `canShare()` and `share()` which may lead to confusion
* Improved wording in a sentence
* Changed `files` to `filesArray` since that is how the files array is referred to in all previous instances
* Added a new line which improves code indentation


**CC:** @petele
