### PR TITLE
emscripten-npm: improve --host & --target flags to configure

### DIFF
--- a/src/content/en/updates/2019/01/emscripten-npm.md
+++ b/src/content/en/updates/2019/01/emscripten-npm.md
@@ -305,11 +305,11 @@ commands `emconfigure` and `emmake`:
     echo "============================================="
     # ... below is unchanged ...
 
-Note: Some libraries provided a `--target` flag (or similar) to target a
-specific processor architecture. This will often pull in assembler code that
-takes advantage of features specific to that architecture and can't be compiled
-to WebAssembly. If a flag like that is present (check with `./configure
---help`), make sure to set it to a generic target.
+Note: Some projects provid a `--host` flag (or similar; libvpx uses non-standard
+`--target`) to build for a specific processor architecture. This will often pull
+in assembler code that takes advantage of features specific to that architecture
+and can't be compiled to WebAssembly. If a flag like that is present (check with
+`./configure --help`), make sure to set it to a generic target.
 
 A C/C++ library is split into two parts: The headers (traditionally `.h` or
 `.hpp` files) that define the data structures, classes, constants etc that a

--- a/src/content/en/updates/2019/01/emscripten-npm.md
+++ b/src/content/en/updates/2019/01/emscripten-npm.md
@@ -305,7 +305,7 @@ commands `emconfigure` and `emmake`:
     echo "============================================="
     # ... below is unchanged ...
 
-Note: Some projects provid a `--host` flag (or similar; libvpx uses non-standard
+Note: Some projects provide a `--host` flag (or similar; libvpx uses non-standard
 `--target`) to build for a specific processor architecture. This will often pull
 in assembler code that takes advantage of features specific to that architecture
 and can't be compiled to WebAssembly. If a flag like that is present (check with


### PR DESCRIPTION
When using standard autoconf configure scripts, the flags are:
* --build: The system where the project is being compiled.
* --host: The system where the compiled project will execute.
* --target: The system which the compiled project will generate for.

Thus, when cross-compiling, the standard flag to pass is --host.
Most projects don't even support --target as that tends to be for
projects like compilers.  The libvpx project is unfortunate in that
it provides an autoconf-like configure script but with the wrong
use of --host & --target options.

Clarify the article to focus on --host and mention --target as a
non-standard/uncommon thing which it is.

**CC:** @petele @surma 