### PR TITLE
Improve instructions.

### DIFF
--- a/src/content/en/tools/chrome-devtools/beginners/html.md
+++ b/src/content/en/tools/chrome-devtools/beginners/html.md
@@ -58,7 +58,7 @@ You're going to build your site in an online code editor called Glitch.
 
 1. Open the <a class="external gc-analytics-event" target="_blank" rel="noopener"
    data-category="CTA" data-label="/web/tools/chrome-devtools/beginners/html"
-   href="https://glitch.com/edit/#!/dfb1?path=index.html">source code</a>.
+   href="https://glitch.com/edit/#!/dfb1?path=index.html">source code via this link</a>.
    This tab will be called the **editor tab** throughout this tutorial.
 
      <figure>


### PR DESCRIPTION
**Fixes:** #7665 
I think the problem here is a general one. In may cases, a link such as this one is tangential to the page it contains, creating the expectation the link does not need to be followed to understand the page's content. 

In this case, the link is central to what the page is trying to accomplish. This change make it clear that the link *must* be followed to start the task described on the page.

**CC:** @petele
