### PR TITLE
Update Audio Worklet articles

### DIFF
--- a/src/content/en/updates/2017/12/audio-worklet.md
+++ b/src/content/en/updates/2017/12/audio-worklet.md
@@ -2,9 +2,9 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
 {# wf_published_on: 2017-12-14 #}
-{# wf_updated_on: 2018-09-21 #}
+{# wf_updated_on: 2019-05-28 #}
 {# wf_featured_image: /web/updates/images/generic/audio.png #}
-{# wf_tags: chrome64,chrome66,webaudio #}
+{# wf_tags: chrome64,chrome66,webaudio,worklet #}
 {# wf_featured_snippet: Chrome 64 comes with a highly anticipated new feature in Web Audio API - Audio Worklet. Audio Worklet nicely keeps the user-supplied JavaScript code all within the audio processing thread — that is, it doesn’t have to jump over to the main thread to process audio. #}
 {# wf_blink_components: Blink>WebAudio #}
 

--- a/src/content/en/updates/2017/12/audio-worklet.md
+++ b/src/content/en/updates/2017/12/audio-worklet.md
@@ -19,7 +19,9 @@ Chrome 64 comes with a highly anticipated new feature in Web Audio API -
 article introduces its concept and usage for those who are eager to create a
 custom audio processor with JavaScript code. Please take a look at the [live
 demos](https://googlechromelabs.github.io/web-audio-samples/audio-worklet/) on
-GitHub or [the instruction](#experimental) on how to use this feature.
+GitHub. Also the next article in series, [Audio Worklet Design
+Pattern](/web/updates/2018/06/audio-worklet-design-pattern), might be an
+interesting read for building an advanced audio app.
 
 ### Background: ScriptProcessorNode
 

--- a/src/content/en/updates/2018/06/audio-worklet-design-pattern.md
+++ b/src/content/en/updates/2018/06/audio-worklet-design-pattern.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
 {# wf_published_on: 2018-06-18 #}
-{# wf_updated_on: 2018-07-12 #}
+{# wf_updated_on: 2019-05-28 #}
 {# wf_featured_image: /web/updates/images/generic/webaudio.png #}
 {# wf_tags: chrome68,webaudio,worklet #}
 {# wf_featured_snippet: Advanced design patterns to unlock Audio Worklet's fullest power with WebAssembly and SharedArrayBuffer. #}
@@ -153,12 +153,6 @@ of AudioWorkletNode. This pattern makes even more sense when you have to load
 the module dynamically after the AudioWorkletGlobalScope starts rendering the
 audio stream. Depending on the size of the module, compiling it in the middle of
 the rendering can cause glitches in the stream.
-
-Currently, the pattern B is only supported behind an experimental flag because
-it requires WebAssembly structured cloning.
-(`chrome://flags/#enable-webassembly`)
-If a WASM module should be a part of your AudioWorkletNode design, passing it
-through AudioWorkletNode constructor can definitely be useful.
 
 #### WASM Heap and Audio Data
 

--- a/src/content/en/updates/2018/06/audio-worklet-design-pattern.md
+++ b/src/content/en/updates/2018/06/audio-worklet-design-pattern.md
@@ -254,9 +254,6 @@ The RingBuffer class can be found
 
 ### WebAudio Powerhouse: Audio Worklet and SharedArrayBuffer
 
-Note: SharedArrayBuffer is disabled by default at the time of writing. Go to
-`chrome://flags` and enable _SharedArrayBuffer_ to play with this feature.
-
   - [Example code](https://googlechromelabs.github.io/web-audio-samples/audio-worklet/design-pattern/shared-buffer/)
 
 The last design pattern in this article is to put several cutting edge APIs into


### PR DESCRIPTION
Minor updates on two Audio Worklet articles:
- Link the second article from the first article.
- Over the past few months, some of experimental features have been shipped to the stable. To reflect this change, some paragraphs are removed.

**Target Live Date:** Anytime

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
