### PR TITLE
Changed variable name in Fix Memory Problems

### DIFF
--- a/src/content/en/tools/chrome-devtools/memory-problems/index.md
+++ b/src/content/en/tools/chrome-devtools/memory-problems/index.md
@@ -170,7 +170,7 @@ nodes.
 
 Here's a simple example of detached DOM nodes. 
 
-    var detachedNodes;
+    var detachedTree;
     
     function create() {
       var ul = document.createElement('ul');
@@ -178,7 +178,7 @@ Here's a simple example of detached DOM nodes.
         var li = document.createElement('li');
         ul.appendChild(li);
       }
-      detachedNodes = ul;
+      detachedTree = ul;
     }
     
     document.getElementById('create').addEventListener('click', create);


### PR DESCRIPTION
What's changed, or what was fixed?

In the section "Discover detached DOM tree memory leaks with Heap Snapshots" of the article "Fix Memory Problems",

* Changed the variable name `detachedNodes` to `detachedTree` so that it's consistent with a following paragraph and screenshot.

**Fixes:** #7681

**CC:** @petele
