### PR TITLE
Updated image format table in Image Optimization

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/image-optimization.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/image-optimization.md
@@ -286,13 +286,13 @@ In addition to different lossy and lossless compression algorithms, different im
   <td data-th="format"><a href="http://en.wikipedia.org/wiki/JPEG_XR">JPEG XR</a></td>
   <td data-th="transparency">Yes</td>
   <td data-th="animation">Yes</td>
-  <td data-th="browser">IE</td>
+  <td data-th="browser">Edge, IE</td>
 </tr>
 <tr>
   <td data-th="format"><a href="http://en.wikipedia.org/wiki/WebP">WebP</a></td>
   <td data-th="transparency">Yes</td>
   <td data-th="animation">Yes</td>
-  <td data-th="browser">Chrome, Opera, Android</td>
+  <td data-th="browser">Chrome, Opera, Android, and latest Firefox and Edge</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
What's changed, or what was fixed?

In the "Image Optimization" article,

* Added Firefox and Edge to the list of browsers supporting WebP since the latest versions of those browsers added support for WebP.
* Specified that JPEG XR is supported in Edge besides IE.

**Fixes:** #7673

**CC:** @petele
