### PR TITLE
fix: wrong translate

### DIFF
--- a/src/content/zh-cn/tools/chrome-devtools/rendering-tools/js-execution.md
+++ b/src/content/zh-cn/tools/chrome-devtools/rendering-tools/js-execution.md
@@ -130,7 +130,7 @@ description:使用 Chrome DevTools CPU 分析器识别开销大的函数。
 *  **Total time**。完成此函数和其调用的任何函数当前的调用所需的时间。
 *  **URL**。形式为 `file.js:100` 的函数定义的位置，其中 `file.js` 是定义函数的文件名称，`100` 是定义的行号。
 *  **Aggregated self time**。记录中函数所有调用的总时间，不包含此函数调用的函数。
-*  **Aggregated total time**。函数所有调用的总时间，不包含此函数调用的函数。
+*  **Aggregated total time**。函数所有调用的总时间，包含此函数调用的函数。
 *  **Not optimized**。如果分析器已检测出函数存在潜在的优化，会在此处列出。
 
 


### PR DESCRIPTION
In English Version:
> Aggregated total time. Aggregate total time for all invocations of the function, including functions called by this function.

In simple Chinese Verison:
> **Aggregated total time**。函数所有调用的总时间，不包含此函数调用的函数。

it's meaning that the former translator translate 'including' to chinese meaning '不包含', but actually it's antonym, it really change the **Aggregated total time** conception meaning

What's changed, or what was fixed?
- **Aggregated total time**。函数所有调用的总时间，包含此函数调用的函数。

