### PR TITLE
fix: wrong translate

### DIFF
--- a/src/content/zh-tw/tools/chrome-devtools/rendering-tools/js-execution.md
+++ b/src/content/zh-tw/tools/chrome-devtools/rendering-tools/js-execution.md
@@ -130,7 +130,7 @@ description:使用 Chrome DevTools CPU 分析器識別開銷大的函數。
 *  **Total time**。完成此函數和其調用的任何函數當前的調用所需的時間。
 *  **URL**。形式爲 `file.js:100` 的函數定義的位置，其中 `file.js` 是定義函數的文件名稱，`100` 是定義的行號。
 *  **Aggregated self time**。記錄中函數所有調用的總時間，不包含此函數調用的函數。
-*  **Aggregated total time**。函數所有調用的總時間，不包含此函數調用的函數。
+*  **Aggregated total time**。函數所有調用的總時間，包含此函數調用的函數。
 *  **Not optimized**。如果分析器已檢測出函數存在潛在的優化，會在此處列出。
 
 


### PR DESCRIPTION
In English Version:
> Aggregated total time. Aggregate total time for all invocations of the function, including functions called by this function.


In tradition Chinese Verison:
> **Aggregated total time**。函数所有调用的总时间，不包含此函数调用的函数。

it's meaning that the former translator translate including to chinese meaning '不包含', but actually it's antonym, it really change the **Aggregated total time** conception meaning
same as this [Pr](https://github.com/google/WebFundamentals/pull/7686),but I modify in github web page so make two pr.

