### PR TITLE
Update unused-css.md

### DIFF
--- a/src/content/en/tools/lighthouse/audits/unused-css.md
+++ b/src/content/en/tools/lighthouse/audits/unused-css.md
@@ -129,7 +129,7 @@ You are welcome to [add your own tool to this list][doc]{:.external}.
 Caution: None of these tools have been vetted. Make sure to do your own due diligence.
 
 * [loadCSS](https://github.com/filamentgroup/loadCSS){: .external }
-* [asyncCSS](https://github.com/style-tools/async-css/wiki/Defer-Unused-CSS-for-Google-Lighthouse-Optimization){: .external }
+* [$async](https://github.com/style-tools/async/){: .external }
 
 ## More information {: #more-info }
 


### PR DESCRIPTION
PR https://github.com/google/WebFundamentals/pull/7214 was published yesterday but the link was changed.

URL: https://developers.google.com/web/tools/lighthouse/audits/unused-css
New link: https://github.com/style-tools/async

The repository has been changed in the mean time. The async loader was further improved and it combines both the stylesheet and script loader in `$async()`. By using an GCC based IIFE generator it would be possible to select only the modules that are needed and to exclude the javascript loader.

The key USP of the loader may be the ability to use a HTML `data-c` attribute with 100% JSON based control over the loader. It will enable to use the loader with complex page-based config and the fastest startup time in combination with a strict `Content-Security-Policy`.

https://github.com/style-tools/async

What's also unique is that you can capture async scripts and rewrite or remove them, for example rewrite `analytics.js` to bypass the header issues in the Google Lighthouse audit.
