### PR TITLE
Fixed a typo in the "How Push Works" article

### DIFF
--- a/src/content/en/fundamentals/push-notifications/how-push-works.md
+++ b/src/content/en/fundamentals/push-notifications/how-push-works.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
 {# wf_blink_components: Blink>PushAPI #}
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2019-05-30 #}
 {# wf_published_on: 2016-06-30 #}
 
 # How Push Works {: .page-title }
@@ -11,7 +11,7 @@ book_path: /web/fundamentals/_book.yaml
 
 
 
-Before getting into the API, let's look at push from a highlevel, start to finish. Then as we
+Before getting into the API, let's look at push from a high level, start to finish. Then as we
 step through individual topics or API's later on, you'll have an idea of how and why it's
 important.
 


### PR DESCRIPTION
What's changed, or what was fixed?

In the "How Push Works" article,

* Added missing space to "highlevel".

**CC:** @petele
