### PR TITLE
Payment App: Restrict "default_applications"

### DIFF
--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/android-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/android-payment-apps.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Web Payments allows any Android payment apps to act as a payment handler for the Payment Request API. Learn how to do it.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2019-04-10 #}
+{# wf_updated_on: 2019-05-31 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Android payment apps developer guide {: .page-title }

--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/android-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/android-payment-apps.md
@@ -79,6 +79,9 @@ include:
 {"default_applications": ["https://bobpay.com/bobpay-app.json"]}
 ```
 
+Note: The origin of `default_applications` must be the same origin as the
+payment method manifest URL.
+
 The browser then downloads `https://bobpay.com/bobpay-app.json` and verifies the
 installed app against the version and signatures in it. The requirements for
 this verification are that all downloads must be over HTTPS, HTTP response codes


### PR DESCRIPTION
Add a note that `default_applications` URL must match the origin of where payment manifest file is hosted.

**CC:** @petele @rsolomakhin 
