### PR TITLE
Update Site Kit GA property

### DIFF
--- a/gulp-tasks/tests/projectYaml.js
+++ b/gulp-tasks/tests/projectYaml.js
@@ -10,7 +10,7 @@ const JSONValidator = require('jsonschema').Validator;
 
 const VALID_ANALYTICS_UA_STRINGS = [
   'UA-52746336-1',
-  'UA-130569087-4',
+  'UA-130569087-3',
 ];
 
 JSONValidator.prototype.customFormats.wfUAString = function(input) {

--- a/src/content/en/site-kit/_project.yaml
+++ b/src/content/en/site-kit/_project.yaml
@@ -11,4 +11,4 @@ icon:
 hide_ratings_widget: true
 google_analytics_ids:
   - UA-52746336-1
-  - UA-130569087-4
+  - UA-130569087-3


### PR DESCRIPTION
The team decided to migrate our Devsite pages to using the same GA property the plugin uses, hence this change.

**Target Live Date:** 2019-06-12

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
