### PR TITLE
Add note about Media Capabilities in workers

### DIFF
--- a/src/content/en/updates/2017/12/chrome-63-64-media-updates.md
+++ b/src/content/en/updates/2017/12/chrome-63-64-media-updates.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A round up of the audio/video updates in Chrome 63/64.
 
-{# wf_updated_on: 2018-07-31 #}
+{# wf_updated_on: 2019-06-06 #}
 {# wf_published_on: 2017-12-08 #}
 {# wf_tags: news,chrome63,chrome64,media,audio,video,origintrials #}
 {# wf_featured_image: /web/updates/images/generic/play-outline.png #}
@@ -39,6 +39,8 @@ solve: An API to query the browser about the decoding abilities of the device
 based on information such as the codecs, profile, resolution, bitrates, etc. It
 would expose information such as whether the playback should be smooth and
 power efficient based on previous playback statistics recorded by the browser.
+
+Note: This API is available in all types of workers in [Chrome 76](https://www.chromestatus.com/feature/5730672977117184).
 
 In a nutshell, here’s how the Decoding Info API works for now. Check out the
 [official


### PR DESCRIPTION
This PR adds note below to the Media Capabilities article:

> Note: This API is available in all types of workers in [Chrome 76](https://www.chromestatus.com/feature/5730672977117184)