### PR TITLE
404 error correction for beforeinstallprompt link

### DIFF
--- a/src/content/en/updates/2019/05/mini-infobar-update.md
+++ b/src/content/en/updates/2019/05/mini-infobar-update.md
@@ -38,7 +38,7 @@ Android, a Chrome system dialog called  the mini-infobar will appear at the
 bottom of the browser window.
 
 Today the Add to Home screen mini-infobar is shown at the same time as the
-[`beforeinstallprompt`](web/fundamentals/app-install-banners/#listen_for_beforeinstallprompt)
+[`beforeinstallprompt`](/web/fundamentals/app-install-banners/#listen_for_beforeinstallprompt)
 event.
 
 ## Changes in Chrome 76

--- a/src/content/en/updates/2019/05/mini-infobar-update.md
+++ b/src/content/en/updates/2019/05/mini-infobar-update.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Adding more control to the mini-infobar for PWAs in Chrome 76.
 
-{# wf_updated_on: 2019-05-20 #}
+{# wf_updated_on: 2019-06-08 #}
 {# wf_published_on: 2019-05-20 #}
 {# wf_tags: chrome76,addtohomescreen,android,progressive-web-apps,install #}
 {# wf_blink_components: Platform>Apps>AppLauncher>Install #}


### PR DESCRIPTION
Currently, the beforeinstallprompt link responds with 404, as it misses a forward slash.

What's changed, or what was fixed?
- added a forward slash to the link, which currently responds [404 error](https://developers.google.com/web/updates/2019/05/web/fundamentals/app-install-banners/#listen_for_beforeinstallprompt)

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
