### PR TITLE
Add modules article to TOC

### DIFF
--- a/src/content/en/fundamentals/_toc-base.yaml
+++ b/src/content/en/fundamentals/_toc-base.yaml
@@ -6,9 +6,11 @@ toc:
     section:
     - include: /web/fundamentals/web-components/_toc.yaml
   - title: JavaScript
-    section:  
+    section:
     - title: Async Functions
       path: /web/fundamentals/primers/async-functions
+    - title: Modules
+      path: /web/fundamentals/primers/modules
     - title: Promises
       path: /web/fundamentals/primers/promises
     - title: Service Workers


### PR DESCRIPTION
What's changed, or what was fixed?
- Modules article wasn't in the TOC


**Target Live Date:** ASAP

**CC:** @addyosmani @mathiasbynens 
