### PR TITLE
Change word in PWA Address Bar Install on Desktop

### DIFF
--- a/src/content/en/updates/2019/06/pwa-install-addressbar.md
+++ b/src/content/en/updates/2019/06/pwa-install-addressbar.md
@@ -56,7 +56,7 @@ There are three key ways you can promote the installation of your PWA:
 
 Check out Patterns for [Promoting PWA Installation (mobile)][install-patterns]
 for more details. It’s focus is mobile, but many of the patterns are applicable
-for desktop, or can be easily modified to work for mobile experiences.
+for desktop, or can be easily modified to work for desktop experiences.
 
 [pwa-install-criteria]: /web/fundamentals/app-install-banners/#criteria
 [appinstalled-event]: /web/fundamentals/app-install-banners/#appinstalled


### PR DESCRIPTION
What's changed, or what was fixed?

In the "Address Bar Install for Progressive Web Apps on the Desktop",

- Changed the word "mobile" to "desktop" as it seems more appropriate in
that context

**CC:** @petele
