### PR TITLE
Show warning on Site Kit pages if an adblocker is used

### DIFF
--- a/src/content/en/site-kit/apikey.html
+++ b/src/content/en/site-kit/apikey.html
@@ -21,6 +21,12 @@
       {% dynamic if request.query_string.siteurl %}
         {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
       {% dynamic endif %}
+      {% dynamic if request.query_string.warn_adblocker %}
+        <aside class="warning">
+          <strong>Warning:</strong>
+          <span>It looks like you are using an adblocker. You must temporarily disable it before clicking the button below.</span>
+        </aside>
+      {% dynamic endif %}
       <p>
         Once the project has been created, you will see the API key. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
       </p>

--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -54,6 +54,12 @@
         <dd class="dl-field-description">The URI to redirect to after an authenticating user has granted consent.</dd>
       </dl>
       {% dynamic endif %}
+      {% dynamic if request.query_string.warn_adblocker %}
+        <aside class="warning">
+          <strong>Warning:</strong>
+          <span>It looks like you are using an adblocker. You must temporarily disable it before clicking the button below.</span>
+        </aside>
+      {% dynamic endif %}
       <p>
         Once the project has been created, you will see a client configuration snippet. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
       </p>


### PR DESCRIPTION
We found out the setup flows on both pages fail if the user has an adblocker enabled (because it's blocking the request for provisioning the AdSense API). We can't detect adblockers dynamically from the page, therefore deferred that logic to the Site Kit plugin, which will forward the result of that detection via a `warn_adblocker` query parameter.

**Target Live Date:** 2019-06-14

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
