### PR TITLE
Fixes #7799: Remove the 30 seconds heuristic

### DIFF
--- a/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
+++ b/src/content/en/fundamentals/app-install-banners/_a2hs-criteria.html
@@ -17,8 +17,8 @@
     </ul>
   </li>
   <li>
-    Meets a user engagement heuristic (currently, the user has interacted
-    with the domain for at least 30 seconds)
+    Meets a user engagement heuristic (previously, the user had to interact
+    with the domain for at least 30 seconds, this is not a requirement anymore)
   </li>
   <li>
     Includes a <a href="/web/fundamentals/web-app-manifest/">


### PR DESCRIPTION
What's changed, or what was fixed?
- Reading @slightlyoff [tweet](https://twitter.com/slightlylate/status/1138836352957444096), and checking with actual tests, the 30 seconds heuristic doesn't exist anymore

**Target Live Date:** YYYY-MM-DD

**Fixes:** #7799 

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
