### PR TITLE
Improved comment in Workbox register-sw.html

### DIFF
--- a/src/content/en/tools/workbox/guides/_shared/register-sw.html
+++ b/src/content/en/tools/workbox/guides/_shared/register-sw.html
@@ -2,7 +2,7 @@
 
 <pre class="prettyprint js">
 &lt;script>
-// Check that service workers are registered
+// Check that service workers are supported
 if ('serviceWorker' in navigator) {
   // Use the window load event to keep the page load performant
   window.addEventListener('load', () => {


### PR DESCRIPTION
Since the outer block is used to check if service workers are supported, not registered, I changed "registered" to "supported".

**CC:** @petele
