### PR TITLE
Changed ` with <code> in Workbox install-cli.html

### DIFF
--- a/src/content/en/tools/workbox/guides/_shared/install-cli.html
+++ b/src/content/en/tools/workbox/guides/_shared/install-cli.html
@@ -6,7 +6,7 @@
 npm install workbox-cli --global
 </pre>
 
-<p>You should be able to run the command `workbox --help` after it's installed.</p>
+<p>You should be able to run the command <code>workbox --help</code> after it's installed.</p>
 
 <pre class="devsite-terminal">
 workbox --help


### PR DESCRIPTION
Since this is an HTML file, not Markdown, the inline command should be wrapped in `<code>` rather than backticks.

**CC:** @petele
