### PR TITLE
Changed backtick with <code> in Workbox shared files

### DIFF
--- a/src/content/en/tools/workbox/guides/_shared/install-webpack.html
+++ b/src/content/en/tools/workbox/guides/_shared/install-webpack.html
@@ -1,6 +1,6 @@
-<h2>Install `workbox-webpack-plugin`</h2>
+<h2>Install <code>workbox-webpack-plugin</code></h2>
 
-<p>Start by installing `workbox-webpack-plugin` from npm.</p>
+<p>Start by installing <code>workbox-webpack-plugin</code> from npm.</p>
 
 <pre class="devsite-terminal devsite-click-to-copy">
 npm install workbox-webpack-plugin --save-dev

--- a/src/content/en/tools/workbox/guides/_shared/install-workbox-build.html
+++ b/src/content/en/tools/workbox/guides/_shared/install-workbox-build.html
@@ -1,6 +1,6 @@
 <h2>Install <code>workbox-build</code></h2>
 
-<p>Start by installing `workbox-build` from npm.</p>
+<p>Start by installing <code>workbox-build</code> from npm.</p>
 
 <pre class="devsite-terminal devsite-click-to-copy">
 npm install workbox-build --save-dev


### PR DESCRIPTION
Since they are HTML files, not Markdown, `workbox-build` and similar should be wrapped in `<code>` rather than backticks.

**CC:** @petele
