### PR TITLE
update Japanese translation of the CSS Containment post

### DIFF
--- a/src/content/ja/updates/2016/06/css-containment.md
+++ b/src/content/ja/updates/2016/06/css-containment.md
@@ -3,18 +3,12 @@ book_path: /web/updates/_book.yaml
 description: CSS Containment という新しい仕様によって、ブラウザが行うスタイル、レイアウト、描画の範囲を制限できるようになります。
 
 {# wf_published_on: 2016-06-01 #}
-{# wf_updated_on: 2016-06-01 #}
+{# wf_updated_on: 2019-06-21 #}
 
 # Chrome 52 に CSS Containment が導入 {: .page-title }
 
 {% include "web/_shared/contributors/paullewis.html" %}
 
-
-<style>
-img.screenshot {
-  max-width: 100%;
-}
-</style>
 
 ### TL;DR {: .hide-from-toc }
 
@@ -26,13 +20,13 @@ Containament 仕様では次の構文と値が定義されています。
 
 
     contain: none | strict | content | [ size || layout || style || paint ]
-    
 
-CSS Containment は Chrome 52、Opera 40 で実装されました（[Firefox も支持を表明](https://www.chromestatus.com/features/6522186978295808)]しています）。ぜひ使ってみて、どうだったかを教えてください！
+
+CSS Containment は Chrome 52、Opera 40 で実装されました（[Firefox も支持を表明](https://www.chromestatus.com/features/6522186978295808)しています）。ぜひ使ってみて、どうだったかを教えてください！
 
 ## contain プロパティ
 
-Web アプリや複雑な Web サイトを開発するとき、スタイル、レイアウト、描画をどう抑えるかがパフォーマンス上の課題になります。多くの場合 DOM の**全体**が計算の「スコープ」になるため、Web アプリにおいて自己完結した「ビュー」を作るのが難しいのです。DOM の一部の変更が他の箇所に影響すること、ブラウザにどの箇所をスコープ（もしくはスコープ外）として伝える方法がないことがその理由です。
+Web アプリや複雑な Web サイトを開発するとき、スタイル、レイアウト、描画をどう抑えるかがパフォーマンス上の課題になります。多くの場合 DOM の**全体**が計算の「スコープ内」になるため、Web アプリにおいて自己完結した「ビュー」を作るのが難しいのです。これは、DOM の一部の変更が他の箇所にも影響すること、どの箇所がスコープ内（もしくはスコープ外）だとブラウザに伝える方法がないことが原因です。
 
 たとえば、こんな DOM があったとしましょう。
 
@@ -87,10 +81,11 @@ CSS Containment は `contain` という新しいプロパティに以下の値�
 ### レイアウト (contain: layout)
 
 > This value turns on layout containment for the element. This ensures that the containing element is totally opaque for layout purposes; nothing outside can affect its internal layout, and vice versa.
-> 訳：この値は要素に対し、レイアウトの封じ込めを有効にします。これにより、要素がレイアウト上不透明（opaque）であることが保証されます。つまり要素外のものが封じ込められた要素に影響することはありませんし、逆もまた同様です。
 > [Containment 仕様](https://drafts.csswg.org/css-containment/#valdef-contain-layout)
 
-レイアウトの封じ込めは `containt: paint` とともに、**最も**恩恵を受けるものでしょう。
+> 訳：この値は要素に対し、レイアウトの封じ込めを有効にします。これにより、要素がレイアウト上不透明（opaque）であることが保証されます。つまり要素外のものが封じ込められた要素に影響することはありませんし、逆もまた同様です。
+
+レイアウトの封じ込めは `contain: paint` とともに、**最も**恩恵を受けるものでしょう。
 
 基本的にレイアウトはドキュメント全体がスコープになるため、DOM の大きさに比例して大きくなります。つまり、要素の `left` プロパティを変更したとすると（[プロパティは一例です](https://csstriggers.com)）、DOM 内のすべての要素に対しチェックが働く可能性があります。
 
@@ -99,30 +94,33 @@ CSS Containment は `contain` という新しいプロパティに以下の値�
 ### 描画 (contain: paint)
 
 > This value turns on paint containment for the element. This ensures that the descendants of the containing element don’t display outside its bounds, so if an element is off-screen or otherwise not visible, its descendants are also guaranteed to be not visible.
-> 訳：この値は要素に対し、描画の封じ込めを有効にします。これにより、子孫要素が指定された要素の領域外に表示されないことが保証されます。もし指定された要素が画面外、もしくは非表示となる場合、子孫要素も表示されません。
 > [Containment 仕様](https://drafts.csswg.org/css-containment/#valdef-contain-paint)
+
+> 訳：この値は要素に対し、描画の封じ込めを有効にします。これにより、子孫要素が指定された要素の領域外に表示されないことが保証されます。もし指定された要素が画面外、もしくは非表示となる場合、子孫要素も表示されません。
 
 描画にスコープを設けることは、レイアウトに続きとても有益な封じ込めでしょう。描画の封じ込めは、適用された要素を切り取るようなものです。しかし副作用もあります。
 
 * **絶対配置され、さらに固定配置された要素のコンテナブロックのような挙動をとる** ― つまり `contain: paint` 内の要素は、ドキュメントをはじめ、親の要素と同じように配置されません
-* **スタッキングコンテキストになる** ― これにより、`z-hindex` などが作動し、子要素も新しく生成されたコンテキストに沿ってスタックされます
+* **スタッキングコンテキストになる** ― これにより、`z-index` などが作動し、子要素も新しく生成されたコンテキストに沿ってスタックされます
 * **フォーマティングコンテキストになる** ― これにより、たとえば描画の封じ込めを指定したブロックレベル要素がある場合、それは**独立した**レイアウト環境として扱われます。つまり、要素の外側のレイアウトが要素内の子に影響することは基本的にありません
 
 ### 大きさ (contain: size)
 
 > The value turns on size containment for the element. This ensures that the containing element can be laid out without needing to examine its descendants.
-> 訳：この値は要素に対し、大きさの封じ込めを有効にします。これにより、指定された要素が子孫要素の内容を調べずにレイアウトされることが保証されます。
 > [Containment 仕様](https://drafts.csswg.org/css-containment/#valdef-contain-size)
 
-`content: size` は、要素の子が**親要素の大きさに影響しない**ことを意味し、計算もしくは指定された大きさが使用されます。結果、`content: size` を指定しても、大きさを指定しなかった場合（直接もしくは Flexbox のプロパティ経由で）、要素は 0px × 0px で表示されます。
+> 訳：この値は要素に対し、大きさの封じ込めを有効にします。これにより、指定された要素が子孫要素の内容を調べずにレイアウトされることが保証されます。
+
+`contain: size` は、要素の子が**親要素の大きさに影響しない**ことを意味し、計算もしくは指定された大きさが使用されます。結果、`contain: size` を指定しても、大きさを指定しなかった場合（直接もしくは Flexbox のプロパティ経由で）、要素は 0px × 0px で表示されます。
 
 サイズの封じ込めは大きさの決定に子要素を考慮しないことを二重に保証するものです。しかし、これ自身だけではパフォーマンスにあまり寄与しません。
 
 ### スタイル (contain: style)
 
 > This value turns on style containment for the element. This ensures that, for properties which can have effects on more than just an element and its descendants, those effects don’t escape the containing element.
-> 訳：この値は要素に対し、スタイルの封じ込めを有効にします。これにより、
 > [Containment 仕様](https://drafts.csswg.org/css-containment/#valdef-contain-style)
+
+> 訳：この値は要素に対し、スタイルの封じ込めを有効にします。これにより、要素や子孫以外にも影響するプロパティにおいて、その影響が当該要素外に漏れ出さないことを保証します。
 
 要素のスタイルを変更した場合、DOM ツリーの上方にどう影響するのかを予想するのは大変でしょう。ひとつの例として[CSS のカウンタ](https://developer.mozilla.org/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters)があります。子のカウンタを変更すると、ドキュメント中にある同じ名前を持つカウンタの値に影響するのです。`contain: style` を指定すると、包含要素を超えてスタイルの変更が伝わることはありません。
 


### PR DESCRIPTION
What's changed, or what was fixed?
- fix bunch of typos
- fill the missing sentence
- align with the current English version

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
