### PR TITLE
Fixed layout worklet example: Const -> const

### DIFF
--- a/src/content/en/updates/2016/05/houdini.md
+++ b/src/content/en/updates/2016/05/houdini.md
@@ -169,8 +169,8 @@ performance gain.
           return [];
         }
         layout(children, constraintSpace, styleMap) {
-            Const width = constraintSpace.width;
-            Const height =constraintSpace.height;
+            const width = constraintSpace.width;
+            const height = constraintSpace.height;
             for (let child of children) {
                 const x = Math.random()*width;
                 const y = Math.random()*height;


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed JS typo which was preventing the [layout worklet example](https://developers.google.com/web/updates/2016/05/houdini#layout_worklet) from being run

**CC:** @petele
