### PR TITLE
Fixed link and typo

### DIFF
--- a/src/content/en/updates/2017/09/autoplay-policy-changes.md
+++ b/src/content/en/updates/2017/09/autoplay-policy-changes.md
@@ -56,7 +56,7 @@ Chrome's autoplay policies are simple:
 - Autoplay with sound is allowed if:
     - User has interacted with the domain (click, tap, etc.).
     - On desktop, the user's [Media Engagement Index](#mei) threshold has been crossed,
-      meaning the user has previously play video with sound.
+      meaning the user has previously played video with sound.
     - On mobile, the user has [added the site to their home screen].
 - Top frames can [delegate autoplay permission](#iframe) to their iframes to
   allow autoplay with sound.
@@ -273,7 +273,7 @@ Note: Web Audio FAQs can be found [here].
 ["AutoplayAllowed"]: http://dev.chromium.org/administrators/policy-list-3#AutoplayAllowed
 ["AutoplayWhitelist"]: http://dev.chromium.org/administrators/policy-list-3#AutoplayWhitelist
 [noticed]: https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/
-[added the site to his or her home screen]: /web/updates/2017/02/improved-add-to-home-screen
+[added the site to their home screen]: /web/updates/2017/02/improved-add-to-home-screen
 [Promise]: /web/fundamentals/getting-started/primers/promises
 [rejected]: /web/updates/2017/06/play-request-was-interrupted
 [200x140]: https://chromium.googlesource.com/chromium/src/+/1c63b1b71d28851fc495fdee9a2c724ea148e827/chrome/browser/media/media_engagement_contents_observer.cc#38


### PR DESCRIPTION
This PR fixes a link that was broken previously in https://github.com/google/WebFundamentals/pull/6639 and fixes a simple typo.