### PR TITLE
Replace apparently unsupported ~~ MD strike with <del>

### DIFF
--- a/src/content/en/updates/2015/04/cut-and-copy-commands.md
+++ b/src/content/en/updates/2015/04/cut-and-copy-commands.md
@@ -139,7 +139,7 @@ Safari does not support these commands.
 
 ## Known Bugs
 
-* ~~Calling queryCommandSupported() for cut or copy [always returns false until after a user interaction](//crbug.com/476508). This prevents you from disabling your UI for browsers which don't actually support it.~~ Fixed on Chrome 48.
+* <del>Calling queryCommandSupported() for cut or copy [always returns false until after a user interaction](//crbug.com/476508). This prevents you from disabling your UI for browsers which don't actually support it.</del> Fixed on Chrome 48.
 * [Calling queryCommandSupported() from devtools will always return
   false](//crbug.com/475868).
 * At the moment [cut only works when you programmatically select


### PR DESCRIPTION
What's changed, or what was fixed?

![Screen Shot 2019-06-26 at 10 40 43](https://user-images.githubusercontent.com/145676/60165022-e0c4ec00-97fe-11e9-95ea-75b4a5bb6e22.png)

**Target Live Date:** any

**CC:** @petele
