### PR TITLE
Fixes to Third Party Requests Workbox guide

### DIFF
--- a/src/content/en/tools/workbox/guides/handle-third-party-requests.md
+++ b/src/content/en/tools/workbox/guides/handle-third-party-requests.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to handle third party requests with Workbox.
 
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-06-30 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -28,10 +28,10 @@ requests can be read in JavaScript if the server returns
 [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS), but a
 number of sites will not do this.
 
-In service workers you can make requests to third-parties and cache the
-responses. For opaque responses the contents of the Response will still
-be hidden. You can’t even check that status code of the response. Because
-of this Workbox treats opaque responses differently.
+In service workers, you can make requests to third-parties and cache the
+responses. For opaque responses, the contents of the Response will still
+be hidden. You can’t even check the status code of the response. Because
+of this, Workbox treats opaque responses differently.
 
 You can learn more about opaque responses from this
 [Stack Overflow Q&A](https://stackoverflow.com/questions/39109789/what-limitations-apply-to-opaque-responses).
@@ -86,7 +86,7 @@ The user will be in a broken state.
 However, it’s not a bad thing to want to try and add some fault tolerance to
 these requests so Workbox will allow opaque responses to be cached with the
 `NetworkFirst` and `StaleWhileRevalidate` strategies. Since these strategies
-regularly update the cached response it’s much safer to cache them as
+regularly update the cached response, it’s much safer to cache them as
 hopefully a bad request will be short lived and used rarely.
 
 ```javascript


### PR DESCRIPTION
What's changed, or what was fixed?

In the *Handle Third Party Requests* Workbox guide,

- Fixed typo
- Added missing punctuation

**CC:** @petele
