### PR TITLE
Fixes to Generate Service Worker w/ workbox-build

### DIFF
--- a/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
@@ -103,8 +103,8 @@ The full set of available options can be found on the
 [`workbox-build` module page](/web/tools/workbox/modules/workbox-build).
 
 <aside class="note"><b>Note:</b> Please ensure that whenever you update your
-site, you re-run <code>workbox generateSW</code> as this will unsure your service worker
-caches the latest files.</aside>
+site, you re-run <code>workboxBuild.generateSW()</code> as this will unsure
+your service worker caches the latest files.</aside>
 
 ## Using with Gulp
 

--- a/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
@@ -13,7 +13,7 @@ complete service worker with precaching and runtime caching.
 
 <aside class="note"><b>Note:</b> You'll need to have
 <a href="https://nodejs.org/en/download/">Node installed</a> to use
-  <code>workbox-build</code>.</aside>
+<code>workbox-build</code>.</aside>
 
 {% include "web/tools/workbox/guides/_shared/install-workbox-build.html" %}
 
@@ -49,7 +49,7 @@ In your web page, you can register this service worker by adding:
 ## Adding Runtime Caching
 
 There may be files that you don't want to precache but will be used by
-your webapp that you'd like to cache at runtime. Images are a great example.
+your web app that you'd like to cache at runtime. Images are a great example.
 
 Instead of precaching all images for your site, which will take up a lot of
 space in the cache, you can cache them as they are used and limit the number

--- a/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
@@ -103,7 +103,7 @@ The full set of available options can be found on the
 [`workbox-build` module page](/web/tools/workbox/modules/workbox-build).
 
 <aside class="note"><b>Note:</b> Please ensure that whenever you update your
-site, you re-run <code>workboxBuild.generateSW()</code> as this will unsure
+site, you re-run <code>workboxBuild.generateSW()</code> as this will ensure
 your service worker caches the latest files.</aside>
 
 ## Using with Gulp

--- a/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/generate-service-worker/workbox-build.md
@@ -3,23 +3,23 @@ book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to generate a complete service worker with workbox-build.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-07-06 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Generate a Service Worker with workbox-build {: .page-title }
 
-This page explains how to use the workbox-build Node module to generate a
+This page explains how to use the `workbox-build` Node module to generate a
 complete service worker with precaching and runtime caching.
 
 <aside class="note"><b>Note:</b> You'll need to have
 <a href="https://nodejs.org/en/download/">Node installed</a> to use
-workbox-build.</aside>
+  <code>workbox-build</code>.</aside>
 
 {% include "web/tools/workbox/guides/_shared/install-workbox-build.html" %}
 
 ## Call <code>generateSW()</code>
 
-To generate a service worker, you need to add `workbox-build.generateSW()`
+To generate a service worker, you need to add `workboxBuild.generateSW()`
 to your build process or Node script:
 
 ```javascript
@@ -31,11 +31,11 @@ const buildSW = () => {
   return workboxBuild.generateSW({
     globDirectory: 'build',
     globPatterns: [
-      '**\/*.{html,json,js,css}',
+      '**/*.{html,json,js,css}',
     ],
     swDest: 'build/sw.js',
   });
-}
+};
 ```
 
 This command will output a service worker to `build/sw.js` which
@@ -49,7 +49,7 @@ In your web page, you can register this service worker by adding:
 ## Adding Runtime Caching
 
 There may be files that you don't want to precache but will be used by
-your webapp that you'd like cache at runtime. Images are a great example.
+your webapp that you'd like to cache at runtime. Images are a great example.
 
 Instead of precaching all images for your site, which will take up a lot of
 space in the cache, you can cache them as they are used and limit the number
@@ -71,13 +71,13 @@ const buildSW = () => {
   return workboxBuild.generateSW({
     globDirectory: 'build',
     globPatterns: [
-      '**\/*.{html,json,js,css}',
+      '**/*.{html,json,js,css}',
     ],
     swDest: 'build/sw.js',
 
     // Define runtime caching rules.
     runtimeCaching: [{
-      // Match any request ends with .png, .jpg, .jpeg or .svg.
+      // Match any request that ends with .png, .jpg, .jpeg or .svg.
       urlPattern: /\.(?:png|jpg|jpeg|svg)$/,
 
       // Apply a cache-first strategy.
@@ -94,22 +94,22 @@ const buildSW = () => {
       },
     }],
   });
-}
+};
 
 buildSW();
 ```
 
 The full set of available options can be found on the
-[workbox-build module page](/web/tools/workbox/modules/workbox-build).
+[`workbox-build` module page](/web/tools/workbox/modules/workbox-build).
 
 <aside class="note"><b>Note:</b> Please ensure that whenever you update your
-site you re-run `workbox generateSW` as this will unsure your service worker
+site, you re-run <code>workbox generateSW</code> as this will unsure your service worker
 caches the latest files.</aside>
 
 ## Using with Gulp
 
 Using `workbox-build` with your Gulp process is simply a case of using the same
-code as above as a Gulp task..
+code as above as a Gulp task.
 
 ```javascript
 const gulp = require('gulp');
@@ -119,7 +119,7 @@ gulp.task('service-worker', () => {
   return workboxBuild.generateSW({
     globDirectory: 'build',
     globPatterns: [
-      '**\/*.{html,json,js,css}',
+      '**/*.{html,json,js,css}',
     ],
     swDest: 'build/sw.js',
   });


### PR DESCRIPTION
What's changed, or what was fixed?

In the *Generate a Service Worker with workbox-build* guide,

- Changed the `workbox generateSW` CLI command to `workboxBuild.generateSW()` since in this guide we're talking about using the `workbox-build` node module, not `workbox-cli`
- Removed unnecessary backslashes in glob pattern strings
- Wrapped `workbox-build` in backticks/`<code>`
- Added missing semicolons
- Added missing punctuation/conjunctions
- Fixed some typos

**CC:** @petele @jeffposnick 
