### PR TITLE
Fixes to the workbox-sw module page

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-sw.md
+++ b/src/content/en/tools/workbox/modules/workbox-sw.md
@@ -3,16 +3,16 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-sw.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-07-08 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox {: .page-title }
 
 ## What is Workbox SW?
 
-The `workbox-sw` module provide an extremely easy way to get up and running
-with the Workbox modules and simplifies the loading of the Workbox modules and
-offers some simply helper methods.
+The `workbox-sw` module provides an extremely easy way to get up and running
+with the Workbox modules, simplifies the loading of the Workbox modules, and
+offers some simple helper methods.
 
 You can use `workbox-sw` via our CDN or you use it with a set of workbox files
 on your own server.
@@ -87,12 +87,12 @@ importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}
 
 // This will work!
 workbox.routing.registerRoute(
-  new RegExp('\.png$'),
+  new RegExp('\\.png$'),
   new workbox.strategies.CacheFirst()
 );
 </pre>
 
-But this code could be a problem if you have not referenced `workbox.strategies` elsewhere in your
+But the code below could be a problem if you have not referenced `workbox.strategies` elsewhere in your
 service worker:
 
 <pre class="prettyprint js">
@@ -152,15 +152,15 @@ a change to start disallowing this usage, bringing it in line with what other br
 
 ## Force Use of Debug or Production Builds
 
-All of the Workbox modules come with two builds, a debug build which is
+All of the Workbox modules come with two builds, a debug build which
 contains logging and additional type checking and a production build which
 strips the logging and type checking.
 
 By default, `workbox-sw` will use the debug build for sites on localhost,
 but for any other origin it’ll use the production build.
 
-If you want to force debug or production builds you set the `debug` config
-option.
+If you want to force debug or production builds, you can set the `debug` config
+option:
 
 <pre class="prettyprint js">
 workbox.setConfig({


### PR DESCRIPTION
What's changed, or what was fixed?

In the `workbox-sw` module page,

- Changed `new RegExp('\.png$')` to `new RegExp('\\.png$')` since the backslash needs to be escaped
- Changed "this code" to "the code below" because the sentence is talking about the code below and saying "this code" can be interpreted as referring to the code right above the sentence
- Improved some sentences
- Fixed some typos

**CC:** @petele @jeffposnick 
