### PR TITLE
Fixes to the workbox-strategies module page

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-strategies.md
+++ b/src/content/en/tools/workbox/modules/workbox-strategies.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-routing.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-07-10 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Strategies {: .page-title }
@@ -22,12 +22,12 @@ but you can [learn more in the Offline Cookbook](/web/fundamentals/instant-and-o
 
 ## Using Strategies
 
-In the following examples we’ll show you how to use the Workbox caching
+In the following examples, we’ll show you how to use the Workbox caching
 strategies with `workbox-routing`. There are some options you can define with
-each strategy that is covered in the
+each strategy that are covered in the
 [Configuring Strategies section of this doc](#configuring_strategies).
 
-In the [Advanced Usage section](#advanced_usage) we’ll cover how you can use
+In the [Advanced Usage section](#advanced_usage), we’ll cover how you can use
 the caching strategies directly without `workbox-routing`.
 
 ### Stale-While-Revalidate
@@ -35,7 +35,7 @@ the caching strategies directly without `workbox-routing`.
 ![Stale While Revalidate Diagram](../images/modules/workbox-strategies/stale-while-revalidate.png)
 
 The [stale-while-revalidate](/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate)
-pattern allows you to respond the request as quickly as possible with a
+pattern allows you to respond to the request as quickly as possible with a
 cached response if available, falling back to the network request if it’s
 not cached. The network request is then used to update the cache.
 
@@ -59,8 +59,8 @@ non-critical and can be gradually cached, a
 is the best option.
 
 If there is a Response in the cache, the Request will be fulfilled using the
-cached response, the network will not be used at all. If there isn't a cached
-response, the Request will be fulfilled by a a network request and the response
+cached response and the network will not be used at all. If there isn't a cached
+response, the Request will be fulfilled by a network request and the response
 will be cached so that the next request is served directly from the cache.
 
 ```javascript
@@ -76,9 +76,9 @@ workbox.routing.registerRoute(
 
 For requests that are updating frequently, the
 [network first](/web/fundamentals/instant-and-offline/offline-cookbook/#network-falling-back-to-cache)
-strategy is the ideal solution. By default it will try and fetch the latest
-request from the network. If the request is successful, it’ll put the response
-in the cache. If the network fails to return a response, the caches response
+strategy is the ideal solution. By default, it will try to fetch the latest
+response from the network. If the request is successful, it’ll put the response
+in the cache. If the network fails to return a response, the cached response
 will be used.
 
 ```javascript
@@ -108,7 +108,7 @@ workbox.routing.registerRoute(
 ![Cache Only Diagram](../images/modules/workbox-strategies/cache-only.png)
 
 The [cache only](/web/fundamentals/instant-and-offline/offline-cookbook/#cache-only)
-strategy ensures that requests are obtained from a cache. This is less common
+strategy ensures that responses are obtained from a cache. This is less common
 in workbox, but can be useful if you have your own precaching step.
 
 ```javascript
@@ -170,10 +170,10 @@ workbox.routing.registerRoute(
 
 ## Advanced Usage
 
-If you want to use the strategies in your own fetch event logic you can use
+If you want to use the strategies in your own fetch event logic, you can
 use the strategy classes to run a request through a specific strategy.
 
-For example, to implement the stale-while-revalidate class you can do the
+For example, to use the stale-while-revalidate strategy, you can do the
 following:
 
 ```javascript


### PR DESCRIPTION
What's changed, or what was fixed?

In the `workbox-strategies` module page,

- Improved some sentences
- Removed extra words
- Added missing punctuation
- Fixed some typos

**CC:** @petele
