### PR TITLE
Fix anchor test. Fixes #7875.

### DIFF
--- a/gulp-tasks/tests/validateMarkdown.js
+++ b/gulp-tasks/tests/validateMarkdown.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Validates a file is a valid YAML file.
+ * @fileoverview Validates a file is a valid Markdown file.
  *
  * @author Pete LePage <petele@google.com>
  */
@@ -278,10 +278,10 @@ function test(filename, contents, options) {
     });
 
     // Error on bad anchor tags
-    matches = wfRegEx.getMatches(/{#\w+}/gm, contents);
+    matches = wfRegEx.getMatches(/{#[-\w]+}/gm, contents);
     matches.forEach(function(match) {
       const position = {line: getLineNumber(contents, match.index)};
-      const msg = `Unsupported anchor style used, use '{: #anchor }', found: `;
+      const msg = `Unsupported anchor style used, use '{: #anchor }', found: ` +
         `'${match[0]}'`;
       logError(msg, position);
     });

--- a/src/tests/anchor-bad.md
+++ b/src/tests/anchor-bad.md
@@ -20,7 +20,7 @@ Phasellus quis nunc leo. Donec lacus mauris, placerat sed turpis ac, eleifend
 iaculis ipsum. Curabitur convallis felis vel lectus mattis, a accumsan magna
 consectetur. Etiam eleifend eget nisi a faucibus.
 
-### This is a level 3 heading
+### This is a level 3 heading {#another-bad-anchor}
 
 Sed porttitor ex eget dolor fringilla, eget rutrum odio tempus. Curabitur
 feugiat vitae ex eu tempor. Praesent fermentum leo quis tellus feugiat


### PR DESCRIPTION
What's changed, or what was fixed?
Bad anchor test missed anchors that included hyphens, like `{#bad-anchor}`.

**Fixes:** #7875 

**Target Live Date:** N/A

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly. (N/A, I believe).

**CC:** @petele
