### PR TITLE
Fixes to Workbox Background Sync page

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-background-sync.md
+++ b/src/content/en/tools/workbox/modules/workbox-background-sync.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-background-sync.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2019-02-27 #}
+{# wf_updated_on: 2019-07-12 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Background Sync {: .page-title }
@@ -20,7 +20,7 @@ is an ideal solution to this problem. When a service worker detects that a
 network request has failed, it can register to receive a `sync` event,
 which gets delivered when the browser thinks connectivity has returned.
 Note that the sync event can be delivered *even if the user has left the
-application*, making it a much more effective than traditional method of
+application*, making it much more effective than the traditional method of
 retrying failed requests.
 
 Workbox Background Sync is designed to make it easier to use the
@@ -31,7 +31,7 @@ BackgroundSync.
 Browsers that support the BackgroundSync API will automatically replay failed
 requests on your behalf at an
 [interval managed by the browser](/web/updates/2015/12/background-sync#how_to_request_a_background_sync),
-and likely using exponential backoff between replay attempts. In browsers that
+likely using exponential backoff between replay attempts. In browsers that
 don't natively support the BackgroundSync API, Workbox Background Sync will
 automatically attempt a replay whenever your service worker starts up.
 
@@ -43,7 +43,7 @@ events are fired.
 
 ```javascript
 const bgSyncPlugin = new workbox.backgroundSync.Plugin('myQueueName', {
-  maxRetentionTime: 24 * 60 // Retry for max of 24 Hours
+  maxRetentionTime: 24 * 60 // Retry for max of 24 Hours (specified in minutes)
 });
 
 workbox.routing.registerRoute(
@@ -81,9 +81,8 @@ also used as the
 [Object Store](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore) name for
 the IndexedDB database.
 
-**Note**: it's not important that you know these
-details, but they're the reason the queue name has to be unique to your
-origin.
+Note: it's not important that you know these details, but they're the reason
+the queue name has to be unique to your origin.
 
 ### Adding a request to the Queue
 
@@ -95,7 +94,7 @@ the following code catches any requests that fail and adds them to the queue:
 const queue = new workbox.backgroundSync.Queue('myQueueName');
 
 self.addEventListener('fetch', (event) => {
-  // Clone the request to ensure it's save to read when
+  // Clone the request to ensure it's safe to read when
   // adding to the Queue.
   const promiseChain = fetch(event.request.clone())
   .catch((err) => {
@@ -115,13 +114,13 @@ running, so it won't be quite as effective.
 
 ## Testing Workbox Background Sync
 
-Sadly, testing BackgroundSync sync is somewhat unintuitive and difficult
+Sadly, testing BackgroundSync is somewhat unintuitive and difficult
 for a number of reasons.
 
 The best approach to test your implementation is to do the following:
 
 1. Load up a page and register your service worker.
-1. Turn off your computers network or turn off your web server.
+1. Turn off your computer's network or turn off your web server.
     - ⚠️ **DO NOT USE CHROME DEVTOOLS OFFLINE** ⚠️ The offline checkbox in
     DevTools only affects requests from the page. Service Worker requests
     will continue to go through.
@@ -130,10 +129,9 @@ The best approach to test your implementation is to do the following:
     `Chrome DevTools > Application > IndexedDB > workbox-background-sync > requests`
 1. Now turn on your network or web server.
 1. Force an early `sync` event by going to
-  `Chrome DevTools > Application > Service Workers`, enter the tag name of
-  `workbox-background-sync:<your queue name>` where "<your queue name>" should be
-  the name of the queue you set and then clicking the 'Sync'
-  button.
+  `Chrome DevTools > Application > Service Workers`, entering the tag name of
+  `workbox-background-sync:<your queue name>` where `<your queue name>` should be
+  the name of the queue you set, and then clicking the 'Sync' button.
 
     ![Example of Sync button in Chrome DevTools](../images/modules/workbox-background-sync/devtools-sync.png)
 


### PR DESCRIPTION
What's changed, or what was fixed?

In the *Workbox Background Sync* page,

- Explicitly mentioned that `maxRetentionTime` is specified in minutes to avoid confusion
- Replaced double quotes with backticks in `"<your queue name>"`, otherwise that is interpreted as `"`, followed by the opening of a `<your>` tag that has the `queue` and `name` attributes, followed by `"`. The result was shown as `""`.
- Changed `**Note**:` to `Note:` so that the content appears inside a note block
- Improved some sentences
- Removed extra words
- Fixed some typos

**CC:** @petele @jeffposnick 
