### PR TITLE
Update simplify-paint-complexity, tiny typo

### DIFF
--- a/src/content/en/fundamentals/performance/rendering/simplify-paint-complexity-and-reduce-paint-areas.md
+++ b/src/content/en/fundamentals/performance/rendering/simplify-paint-complexity-and-reduce-paint-areas.md
@@ -74,7 +74,7 @@ If you have promoted an element to a new layer, use DevTools to confirm that doi
 
 ## Reduce paint areas
 
-Sometimes, however, despite promoting elements, paint work is still necessary. A large challenge of paint issues is that browsers union together two areas that need painting, and that can result in the entire screen being repainted. So, for example, if you have a fixed header at the top of the page, and something being painted at the bottom the screen, the entire screen may end up being repainted.
+Sometimes, however, despite promoting elements, paint work is still necessary. A large challenge of paint issues is that browsers union together two areas that need painting, and that can result in the entire screen being repainted. So, for example, if you have a fixed header at the top of the page, and something being painted at the bottom of the screen, the entire screen may end up being repainted.
 
 Note: On High DPI screens elements that are fixed position are automatically promoted to their own compositor layer. This is not the case on low DPI devices because the promotion changes text rendering from subpixel to grayscale, and layer promotion needs to be done manually.
 


### PR DESCRIPTION
What's changed, or what was fixed?

- "So, for example, if you have a fixed header at the top of the page, and something being painted at `the bottom the screen`, the entire screen may end up being repainted."

->

- "So, for example, if you have a fixed header at the top of the page, and something being painted at `the bottom of the screen`, the entire screen may end up being repainted."

**Fixes:** Typo

**Target Live Date:** Whenever

It's just a single word, so I didn't do this stuff:

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele

Thanks for maintaining these awesome articles