### PR TITLE
Fix issue where backslash doesn't render

### DIFF
--- a/src/content/en/updates/2015/01/ES6-Template-Strings.md
+++ b/src/content/en/updates/2015/01/ES6-Template-Strings.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Template String literals with embedded expressions. We've been waiting for this for ages. Literally
 
-{# wf_updated_on: 2019-03-16 #}
+{# wf_updated_on: 2019-07-16 #}
 {# wf_published_on: 2015-01-19 #}
 {# wf_tags: news,es6,javascript,ecmascript #}
 {# wf_blink_components: N/A #}
@@ -74,13 +74,13 @@ The `${}` works fine with any kind of expression, including member expressions a
 
     // => Say no to drugs. Although if you're talking to drugs you may already be on drugs.
 
-If you require backticks inside of your string, it can be escaped using the backslash character `\` as follows:
+If you require backticks inside of your string, it can be escaped using the backslash character `\ ` as follows:
 
     var greeting = `\`Yo\` World!`;
 
 ## Multiline Strings
 
-Multiline strings in JavaScript have required hacky workarounds for some time. Current solutions for them require that strings either exist on a single line or be split into multiline strings using a `\` (blackslash) before each newline. For example:
+Multiline strings in JavaScript have required hacky workarounds for some time. Current solutions for them require that strings either exist on a single line or be split into multiline strings using a `\ ` (backslash) before each newline. For example:
 
     var greeting = "Yo \
     World";


### PR DESCRIPTION
https://developers.google.com/web/updates/2015/01/ES6-Template-Strings#multiline_strings

`Current solutions for them require that strings either exist on a single line or be split into multiline strings using a \ (blackslash) before each newline` 
instead of 
`Current solutions for them require that strings either exist on a single line or be split into multiline strings using a `` (blackslash) before each newline.`

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
