### PR TITLE
update first-interactive to first-cpu-idle link

### DIFF
--- a/src/content/en/tools/lighthouse/audits/first-cpu-idle.md
+++ b/src/content/en/tools/lighthouse/audits/first-cpu-idle.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: Reference documentation for the "First CPU Idle" Lighthouse audit.
 
-{# wf_updated_on: 2018-10-01 #}
+{# wf_updated_on: 2019-07-19 #}
 {# wf_published_on: 2017-06-23 #}
 {# wf_blink_components: N/A #}
 
@@ -44,7 +44,7 @@ Consistently Interactive][FIACI] for definitions.
 
 [Audit source][src]{:.external}
 
-[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/first-interactive.js
+[src]: https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/metrics/first-cpu-idle.js
 
 ## Feedback {: #feedback }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Updated the source link to match the new audit name

**Fixes:** #7905 

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
