### PR TITLE
Fixes to the workbox-routing module page

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-routing.md
+++ b/src/content/en/tools/workbox/modules/workbox-routing.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-routing.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-07-19 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Routing {: .page-title }
@@ -14,7 +14,7 @@ A service worker can intercept network requests for a page. It may respond to
 the browser with cached content, content from the network or content generated
 in the service worker.
 
-`workbox-routing` is a module which makes is easy to "route" these requests to
+`workbox-routing` is a module which makes it easy to "route" these requests to
 different functions that provide responses.
 
 ## How Routing is Performed
@@ -24,10 +24,10 @@ will attempt to respond to the request using the supplied routes and handlers.
 
 ![Workbox Routing Diagram](../images/modules/workbox-routing/workbox-routing-diagram.png)
 
-The main things to note from the above is:
+The main things to note from the above are:
 
-- The method of request is important. By default, Routes are registered for
-  'GET' requests. If you wish to intercept other types of requests, you’ll need
+- The method of a request is important. By default, Routes are registered for
+  `GET` requests. If you wish to intercept other types of requests, you’ll need
   to specify the method.
 
 - The order of the Route registration is important. If multiple Routes are
@@ -60,7 +60,7 @@ const matchCb = ({url, event}) => {
 Most use cases can be covered by examining / testing either the `url` or the
 `event.request` to match against a Request.
 
-A "handler" will be given the url and event as well and you can determine how
+A "handler" will be given the URL and event as well and you can determine how
 to respond, whether it’s from the network, from the cache or generated in the
 service worker.
 
@@ -81,21 +81,21 @@ value is the value returned by the "match" function. This may
 be useful if you parsed the URL or request and want to pass values into
 the “handler” for a matching request.
 
-You can register these callbacks via like so:
+You can register these callbacks like so:
 
 ```js
 workbox.routing.registerRoute(matchCb, handlerCb);
 ```
 
-The only limitation is that "match" **must synchronously** return a truthy
+The only limitation is that the "match" callback **must synchronously** return a truthy
 value, you can’t perform any asynchronous work. The reason for this is that
 the `Router` must synchronously respond to the fetch event or allow falling
 through to other fetch events.
 
 The "handler" callback should return a Promise that resolves to a
 [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
-Where that Response comes from is up to you, the network, a cache or
-generated in the service worker.
+Where that Response comes from is up to you; it could come from the
+network, from a cache, or it could be generated in the service worker.
 
 Normally the "handler" callback would use one of the strategies provided
 by [workbox-strategies](./workbox-strategies) like so:
@@ -107,7 +107,7 @@ workbox.routing.registerRoute(
 );
 ```
 
-In this page we’ll focus on `workbox-routing` but you can
+In this page, we’ll focus on `workbox-routing` but you can
 [learn more about these strategies on workbox.strategies](./workbox-strategies).
 
 ## How to Register a Regular Expression Route
@@ -117,7 +117,7 @@ Workbox makes this easy to implement like so:
 
 ```js
 workbox.routing.registerRoute(
-  new RegExp('/styles/.*\.css'),
+  new RegExp('/styles/.*\\.css'),
   handlerCb
 );
 ```
@@ -133,17 +133,17 @@ regular expression.
 
 However, for cross-origin requests, regular expressions
 **must match the beginning of the URL**. The reason for this is that it’s
-unlikely that with a regular expression `new RegExp('/styles/.*\.css')`
-you intended to match a third-parties CSS files.
+unlikely that with a regular expression `new RegExp('/styles/.*\\.css')`
+you intended to match third-party CSS files.
 
 - <span style="color: #e74c3c">https://cdn.third-party-site.com</span><span style="color: #2ecc71">/styles/main.css</span>
 - <span style="color: #e74c3c">https://cdn.third-party-site.com</span><span style="color: #2ecc71">/styles/nested/file.css</span>
 - <span style="color: #e74c3c">https://cdn.third-party-site.com/nested</span><span style="color: #2ecc71">/styles/directory.css</span>
 
-If you *did* want this behaviour, you just need to ensure that regular
+If you *did* want this behaviour, you just need to ensure that the regular
 expression matches the beginning of the URL. If we wanted to match the
 requests for `https://cdn.third-party-site.com` we could use the regular
-expression `new RegExp('https://cdn.third-party-site.com.*/styles/.*\.css')`.
+expression `new RegExp('https://cdn\\.third-party-site\\.com.*/styles/.*\\.css')`.
 
 - <span style="color: #2ecc71">https://cdn.third-party-site.com/styles/main.css</span>
 - <span style="color: #2ecc71">https://cdn.third-party-site.com/styles/nested/file.css</span>
@@ -169,11 +169,11 @@ workbox.routing.registerNavigationRoute(
 ```
 
 Whenever a user goes to your site in the browser, the request for the page
-will be a navigation request and will be served the cached page
-'/single-page-app.html'. (Note: You should have the page cached via
-`workbox-precaching` or through your own installation step).
+will be a navigation request and it will be served the cached page
+`/single-page-app.html`. (Note: You should have the page cached via
+`workbox-precaching` or through your own installation step.)
 
-By default this will respond to *all* navigation requests. If you want to
+By default, this will respond to *all* navigation requests. If you want to
 restrict it to respond to a subset of URLs, you can use the `whitelist`
 and `blacklist` options to restrict which pages will match this route.
 
@@ -182,13 +182,14 @@ workbox.routing.registerNavigationRoute(
   // Assuming '/single-page-app.html' has been precached,
   // look up its corresponding cache key.
   workbox.precaching.getCacheKeyForURL('/single-page-app.html'), {
-  whitelist: [
-    new RegExp('/blog/')
-  ],
-  blacklist: [
-    new RegExp('/blog/restricted/'),
-  ]
-});
+    whitelist: [
+      new RegExp('/blog/'),
+    ],
+    blacklist: [
+      new RegExp('/blog/restricted/'),
+    ],
+  }
+);
 ```
 
 The only thing to note is that the `blacklist` will win if a URL is in both
@@ -218,10 +219,10 @@ workbox.routing.setCatchHandler(({url, event, params}) => {
 
 ## Defining a Route for Non-GET Requests
 
-All routes by default are assumed to be for 'GET' requests.
+All routes by default are assumed to be for `GET` requests.
 
-If you would like to route other requests, like a 'POST' request, you need
-to define the method when register the request, like so:
+If you would like to route other requests, like a `POST` request, you need
+to define the method when registering the route, like so:
 
 ```javascript
 workbox.routing.registerRoute(
@@ -230,7 +231,7 @@ workbox.routing.registerRoute(
   'POST'
 );
 workbox.routing.registerRoute(
-  new RegExp('/api/.*\.json'),
+  new RegExp('/api/.*\\.json'),
   handlerCb,
   'POST'
 );
@@ -244,7 +245,7 @@ through Workbox.
 
 ![Routing Logs](../images/modules/workbox-routing/workbox-routing-standard-logs.png)
 
-If you need more verbose information you can set the log level to `debug` to
+If you need more verbose information, you can set the log level to `debug` to
 view logs on requests not handled by the Router. See our
 [debugging guide](../guides/troubleshoot-and-debug) for more info on
 setting the log level.
@@ -254,9 +255,9 @@ setting the log level.
 ## Advanced Usage
 
 If you want to have more control over when the Workbox Router is given
-requests you can create your own
+requests, you can create your own
 [Router](/web/tools/workbox/reference-docs/latest/workbox.routing.Router) instance and call
-it’s [handleRequest()](/web/tools/workbox/reference-docs/latest/workbox.routing.Router#handleRequest)
+it’s [`handleRequest()`](/web/tools/workbox/reference-docs/latest/workbox.routing.Router#handleRequest)
 method whenever you want to use the router to respond to a request.
 
 ```javascript
@@ -272,7 +273,7 @@ self.addEventListener('fetch', (event) => {
 });
 ```
 
-When using the `Router` directly you will also need to use the `Route` class,
+When using the `Router` directly, you will also need to use the `Route` class,
 or any of the extending classes to register routes.
 
 ```javascript


### PR DESCRIPTION
What's changed, or what was fixed?

In the `workbox-routing` module page,

- Escaped periods in regular expressions
- Escaped backslashes in strings passed to `new RegExp()`
- In a code snippet, fixed code indentation and added trailing commas for consistency
- Added backticks around HTTP request methods and in other places where appropriate
- Fixed/improved some sentences
- Fixed some typos
- Added missing punctuation/determiners

**CC:** @petele @jeffposnick 
