### PR TITLE
Small fixes to the Workbox index page

### DIFF
--- a/src/content/en/tools/workbox/_index.yaml
+++ b/src/content/en/tools/workbox/_index.yaml
@@ -210,7 +210,7 @@ landing_page:
       workboxBuild.generateSW({
         swDest: './build/sw.js'
         globDirectory: './app',
-        globPatterns: '**\/*.{js,css,html,png}',
+        globPatterns: '**/*.{js,css,html,png}',
       });</pre>
         </section>
         <section>
@@ -283,7 +283,7 @@ landing_page:
 
   - heading: "Contributors"
     description: >
-      <p>Workbox is built and maintained by friendly bunch of contributors
+      <p>Workbox is built and maintained by a friendly bunch of contributors
       without whom none of this would be possible.</p>
 
       {% include 'web/tools/workbox/_shared/contributors.html' %}


### PR DESCRIPTION
What's changed, or what was fixed?

In the Workbox index page,

- Removed unnecessary backslash in glob patterns string
- Added missing determiner

**CC:** @petele @jeffposnick 
