### PR TITLE
Fixes to the Save Credentials from Forms article

### DIFF
--- a/src/content/en/fundamentals/security/credential-management/save-forms.md
+++ b/src/content/en/fundamentals/security/credential-management/save-forms.md
@@ -53,8 +53,8 @@ Learn more about autofill in
 
 ## Prevent the form from submitting
 
-When the user presses the submit button, prevent the form from submitting, which would result
-in a page transition:
+When the user presses the submit button, prevent the form from submitting, which would otherwise
+result in a page transition:
 
     var f = document.querySelector('#signup');
     f.addEventListener('submit', e => {

--- a/src/content/en/fundamentals/security/credential-management/save-forms.md
+++ b/src/content/en/fundamentals/security/credential-management/save-forms.md
@@ -1,7 +1,7 @@
 project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2019-07-25 #}
 {# wf_published_on: 2016-11-08 #}
 {# wf_blink_components: Blink>SecurityFeature>CredentialManagement #}
 
@@ -26,7 +26,7 @@ so users won't have to sign in again when they return.
 To store user credentials from forms:
 
 1. Include `autocomplete` in the form.
-2. Interrupt the form submission event.
+2. Prevent the form from submitting.
 3. Authenticate by sending a request.
 4. Store the credential.
 5. Update the UI or proceed to the personalized page.
@@ -51,14 +51,14 @@ Learn more about autofill in
      <input type="submit" value="Sign Up!">
     </form>
 
-## Interrupt the form submission event
+## Prevent the form from submitting
 
-Interrupt the form submission event when the user presses the submit button,
-and prevent the default behavior.
+When the user presses the submit button, prevent the form from submitting, which would result
+in a page transition:
 
     var f = document.querySelector('#signup');
     f.addEventListener('submit', e => {
-     e.preventDefault();
+      e.preventDefault();
 
 By preventing a page transition,
 you can retain the credential information while verifying its authenticity.
@@ -157,7 +157,7 @@ or proceed to the personalized page.
         if (res.status == 200) {
           return Promise.resolve();
         } else {
-          return Promise.reject('Sign in failed');
+          return Promise.reject('Sign-in failed');
         }
       }).then(profile => {
 
@@ -170,13 +170,13 @@ or proceed to the personalized page.
         }
       }).then(profile => {
 
-        // Successful sign in
+        // Successful sign-in
         if (profile) {
           updateUI(profile);
         }
       }).catch(error => {
 
-        // Sign in failed
+        // Sign-in failed
         showError('Sign-in Failed');
       });
     });


### PR DESCRIPTION
What's changed, or what was fixed?

In the *Save Credentials from Forms* article,

- Replaced "Interrupt the form submission event" with "Prevent the form from submitting" because the form's `submit` event is not "interrupted". Instead, all we're doing is just calling `e.preventDefault()` in the `submit` event handler
- Improved the sentence that talks about preventing the form from submitting
- Added hyphen to "sign in" when used as a noun
- Fixed indentation

**CC:** @petele
