### PR TITLE
Remove *-starter-kit content

### DIFF
--- a/src/content/en/tools/_index.yaml
+++ b/src/content/en/tools/_index.yaml
@@ -88,21 +88,3 @@ landing_page:
       buttons:
       - label: Learn more
         path: /speed/pagespeed/module/
-
-  - heading: More
-    classname: devsite-landing-row-no-image-background
-    items:
-    - heading: Polymer Starter Kit
-      description: >
-        The Polymer Starter Kit is a starting point for building apps using a
-        drawer-based layout. The layout is provided by app-layout elements.
-      icon:
-        path: images/polymer-logo-1x1.png
-      path: https://www.polymer-project.org/2.0/start/toolbox/set-up
-    - heading: Setting Up Your Dev Environment
-      description: >
-        Set up your workspace to include a good editor, debugging, and build
-        tools for the multi-device web.
-      icon:
-        path: images/pagespeed.svg
-      path: /web/tools/setup/

--- a/src/content/en/tools/polymer-starter-kit/index.md
+++ b/src/content/en/tools/polymer-starter-kit/index.md
@@ -1,107 +1,17 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Polymer Starter Kit.
+description: This page is no longer supported.
 
 {# wf_published_on: 2015-01-01 #}
-{# wf_updated_on: 2016-09-12 #}
+{# wf_updated_on: 2019-07-31 #}
+{# wf_blink_components: N/A #}
 
 # Polymer Starter Kit {: .page-title }
 
-[Download Polymer Starter Kit](https://github.com/polymerelements/polymer-starter-kit/releases){: .button .button-primary }
+Warning: Polymer Starter Kit is no longer supported. If you are interested in
+building apps out of Web Components, try the
+[PWA Starter Kit](https://pwa-starter-kit.polymer-project.org/). The PWA
+Starter Kit uses [LitElement](https://lit-element.polymer-project.org/), a
+lightweight base class for Web Components brought to you by the Polymer Project.
 
-## What is the Polymer Starter Kit?
-
-The [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit){: .external }
-is a starting point for building apps using a drawer-based layout. The layout 
-is provided by `app-layout` elements.
-
-This template, along with the `polymer-cli` toolchain, also demonstrates use
-of the "PRPL pattern" This pattern allows fast first delivery and interaction with
-the content at the initial route requested by the user, along with fast subsequent
-navigation by pre-caching the remaining components required by the app and
-progressively loading them on-demand as the user navigates through the app.
-
-The PRPL pattern, in a nutshell:
-
-* **Push** components required for the initial route
-* **Render** initial route ASAP
-* **Pre-cache** components for remaining routes
-* **Lazy-load** and progressively upgrade next routes on-demand
-
-### Migrating from Polymer Starter Kit v1?
-
-[Check out our blog post that covers what's changed in PSK2 and how to migrate!](https://www.polymer-project.org/1.0/blog/2016-08-18-polymer-starter-kit-or-polymer-cli.html){: .external }
-
-## Setup
-
-### Prerequisites
-
-Install [polymer-cli](https://github.com/Polymer/polymer-cli){: .external }:
-
-    npm install -g polymer-cli
-
-### Initialize project from template
-
-    mkdir my-app
-    cd my-app
-    polymer init starter-kit
-
-### Start the development server
-
-This command serves the app at `http://localhost:8080` and provides basic URL
-routing for the app:
-
-    polymer serve --open
-
-
-### Build
-
-This command performs HTML, CSS, and JS minification on the application
-dependencies, and generates a service-worker.js file with code to pre-cache the
-dependencies based on the entrypoint and fragments specified in `polymer.json`.
-The minified files are output to the `build/unbundled` folder, and are suitable
-for serving from a HTTP/2+Push compatible server.
-
-In addition the command also creates a fallback `build/bundled` folder,
-generated using fragment bundling, suitable for serving from non
-H2/push-compatible servers or to clients that do not support H2/Push.
-
-    polymer build
-
-### Preview the build
-
-This command serves the minified version of the app at `http://localhost:8080`
-in an unbundled state, as it would be served by a push-compatible server:
-
-    polymer serve build/unbundled
-
-This command serves the minified version of the app at `http://localhost:8080`
-generated using fragment bundling:
-
-    polymer serve build/bundled
-
-### Run tests
-
-This command will run
-[Web Component Tester](https://github.com/Polymer/web-component-tester){: .external } against the
-browsers currently installed on your machine.
-
-    polymer test
-
-### Adding a new view
-
-You can extend the app by adding more views that will be demand-loaded
-e.g. based on the route, or to progressively render non-critical sections
-of the application.  Each new demand-loaded fragment should be added to the
-list of `fragments` in the included `polymer.json` file.  This will ensure
-those components and their dependencies are added to the list of pre-cached
-components (and will have bundles created in the fallback `bundled` build).
-
-## Next Steps
-
-Check out the [getting started guide](https://www.polymer-project.org/1.0/start/toolbox/set-up){: .external }
-
-## Learn More
-
-To learn more, see the code, submit an issue, or to get involved, check out
-our Git repo at [https://github.com/polymerelements/polymer-starter-kit](https://github.com/polymerelements/polymer-starter-kit){: .external }
+&nbsp;

--- a/src/content/en/tools/starter-kit/index.md
+++ b/src/content/en/tools/starter-kit/index.md
@@ -1,87 +1,17 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
-description: Web Starter Kit is boilerplate and tooling for multi-device development
+description: This page is no longer supported.
 
 {# wf_published_on: 2015-01-01 #}
-{# wf_updated_on: 2017-07-24 #}
+{# wf_updated_on: 2019-07-31 #}
+{# wf_blink_components: N/A #}
 
 # Web Starter Kit {: .page-title }
 
-Warning: Web Starter Kit is no longer supported.
+Warning: The Web Starter Kit is no longer supported. If you are interested in
+building apps out of Web Components, try the
+[PWA Starter Kit](https://pwa-starter-kit.polymer-project.org/). The PWA
+Starter Kit uses [LitElement](https://lit-element.polymer-project.org/), a
+lightweight base class for Web Components brought to you by the Polymer Project.
 
-[Download Web Starter Kit (beta)](https://github.com/google/web-starter-kit/releases/latest){: .button .button-primary }
-
-## What is Web Starter Kit?
-
-[Web Starter Kit](https://github.com/google/web-starter-kit) is an opinionated boilerplate for web development. Tools for building a great experience across many devices and [performance oriented](#web-performance). Helping you to stay productive following the best practices outlined in Google's [Web Fundamentals](/web/fundamentals/). A solid starting point for both professionals and newcomers to the industry.
-
-### Features
-
-| Feature                                | Summary                                                                                                                                                                                                                                                     |
-|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Responsive boilerplate | A responsive boilerplate optimized for the multi-screen web. Powered by [Material Design Lite](http://getmdl.io).  You're free to use either this or a completely clean-slate  via [basic.html](https://github.com/google/web-starter-kit/blob/master/app/basic.html).                          |
-| Sass support                           | Compile [Sass](http://sass-lang.com/) into CSS with ease, bringing support for variables, mixins and more. (Run `gulp serve` or `gulp` for production)                                                                                                      |
-| Performance optimization               | Minify and concatenate JavaScript, CSS, HTML and images to help keep your pages lean. (Run `gulp` to create an optimized version of your project to `/dist`)                                                                                                |
-| Code Linting               | JavaScript code linting is done using [ESLint](http://eslint.org) - a pluggable linter tool for identifying and reporting on patterns in JavaScript. Web Starter Kit uses ESLint with [eslint-config-google](https://github.com/google/eslint-config-google), which tries to follow the Google JavaScript style guide.                                                                                                |
-| ES2015 via Babel 6.0                   | Optional ES2015 support using [Babel](https://babeljs.io/){: .external }. To enable ES2015 support remove the line `"only": "gulpfile.babel.js",` in the [.babelrc](https://github.com/google/web-starter-kit/blob/master/.babelrc) file. ES2015 source code will be automatically transpiled to ES5 for wide browser support.  |
-| Built-in HTTP Server                   | A built-in server for previewing your site locally while you develop and iterate                                                                                                                                                                            |
-| Live Browser Reloading                 | Reload the browser in real-time anytime an edit is made without the need for an extension. (Run `gulp serve` and edit your files)                                                                                                                           |
-| Cross-device Synchronization           | Synchronize clicks, scrolls, forms and live-reload across multiple devices as you edit your project. Powered by [BrowserSync](http://browsersync.io). (Run `gulp serve` and open up the IP provided on other devices on your network)                       |
-| Offline support                     | Thanks to our baked in [Service Worker](/web/fundamentals/getting-started/primers/service-workers) [pre-caching](https://github.com/google/web-starter-kit/blob/master/gulpfile.babel.js#L226), sites deploying `dist` to a HTTPS domain will enjoy offline support. This is made possible by [sw-precache](https://github.com/GoogleChrome/sw-precache/).                                                                                                                                              |
-| PageSpeed Insights                     | Web performance metrics showing how well your site performs on mobile and desktop (Run `gulp pagespeed`)                                                                                                                                                    |
-
-## Quickstart
-
-[Download](https://github.com/google/web-starter-kit/releases/latest) the kit
-or clone [the](https://github.com/google/web-starter-kit) repository and build
-on what is included in the `app` directory.
-
-There are two HTML starting points, from which you can choose:
-
-- `index.html` - the default starting point, containing Material Design layout.
-- `basic.html` - no layout, but still includes our minimal mobile best-practices
-
-Be sure to look over the [installation docs](https://github.com/google/web-starter-kit/blob/master/docs/install.md) to verify your environment is prepared to run WSK.
-Once you have verified that your system can run WSK, check out the [commands](https://github.com/google/web-starter-kit/blob/master/docs/commands.md) available to get started.
-
-## Web Performance
-
-Web Starter Kit strives to give you a high performance starting point out of the box. Our median Web Page Test [scores](http://www.webpagetest.org/result/151201_VW_XYC/){: .external } for the default template have a [Speed Index](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/metrics/speed-index) of ~1100 (1000 is ideal) and a repeat-visit Speed Index of ~550 thanks to Service Worker precaching. 
-
-## Browser Support
-
-At present, we officially aim to support the last two versions of the following browsers:
-
-* Chrome
-* Edge
-* Firefox
-* Safari
-* Opera
-* Internet Explorer 9+
-
-This is not to say that Web Starter Kit cannot be used in browsers older than those reflected, but merely that our focus will be on ensuring our layouts work great in the above.
-
-## Troubleshooting
-
-If you find yourself running into issues during installation or running the tools, please check our [Troubleshooting](https://github.com/google/web-starter-kit/wiki/Troubleshooting) guide and then open an [issue](https://github.com/google/web-starter-kit/issues). We would be happy to discuss how they can be solved.
-
-## A Boilerplate-only Option
-
-If you would prefer not to use any of our tooling, delete the following files from the project: `package.json`, `gulpfile.babel.js`, `.jshintrc` and `.travis.yml`. You can now safely use the boilerplate with an alternative build-system or no build-system at all if you choose.
-
-## Docs and Recipes
-
-* [File Appendix](https://github.com/google/web-starter-kit/blob/master/docs/file-appendix.md) - What do the different files here do?
-* [Using Material Design Lite's Sass](https://github.com/google/web-starter-kit/blob/master/docs/mdl-sass.md) - how to get MDL's Sass working with WSK
-* [Deployment guides](https://github.com/google/web-starter-kit/blob/master/docs/deploy.md) - available for Firebase, Google App Engine and other services.
-* [Gulp recipes](https://github.com/gulpjs/gulp/tree/master/docs/recipes) - the official Gulp recipes directory includes a comprehensive list of guides for different workflows you can add to your project.
-
-## Inspiration
-
-Web Starter Kit is inspired by [Mobile HTML5 Boilerplate](https://html5boilerplate.com/mobile/){: .external } and Yeoman's [generator-gulp-webapp](https://github.com/yeoman/generator-webapp), having taken input from contributors to both projects during development. Our [FAQs](https://github.com/google/web-starter-kit/wiki/FAQ) attempt to answer commonly asked questions about the project.
-
-
-## Learn More
-
-To learn more, see the code, submit an issue, or to get involved, check out
-our Git repo at [https://github.com/google/web-starter-kit](https://github.com/google/web-starter-kit)
+&nbsp;


### PR DESCRIPTION
What's changed, or what was fixed?
- Removes polymer-starter-kit content
- Remove starter-kit content

**Target Live Date:** ASAP

- [ ] This has been reviewed and approved by (@arthurevans)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

Will replace #7489