### PR TITLE
fix(capabilities): fix broken link to crbug.com

### DIFF
--- a/src/content/en/updates/capabilities.md
+++ b/src/content/en/updates/capabilities.md
@@ -47,7 +47,7 @@ apps should be able to do anything native apps can.
 
 ## The new capabilities
 
-You can see the [full list](crbug.com/?q=proj-fugu) of capabilities we're
+You can see the [full list](https://crbug.com/?q=proj-fugu) of capabilities we're
 considering on [crbug.com](https://crbug.com) and filtering issues with the
 `proj-fugu` label.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- added `https://` to the schemeless-thus-broken link to the crbug.com

**Fixes:** N/A

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
