### PR TITLE
Fixes to CSS in the Animating Modal Views article

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/animations/animating-modal-views.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animating-modal-views.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Learn how to animate modal views in your apps.
 
 {# wf_blink_components: Blink>Animation #}
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2019-08-07 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Animating Modal Views {: .page-title }
@@ -30,31 +30,31 @@ Modal views are for important messages, and for which you have very good reasons
 
 The modal overlay should be aligned to the viewport, so set its `position` to `fixed`:
 
+```css
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 
-    .modal {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    
-      pointer-events: none;
-      opacity: 0;
-    
-      will-change: transform, opacity;
-    }
-    
+  pointer-events: none;
+  opacity: 0;
+
+  will-change: transform, opacity;
+}
+```
 
 It has an initial `opacity` of 0, so it's hidden from view, but then it also needs `pointer-events` set to `none` so that clicks and touches pass through. Without that, it blocks all interactions, rendering the whole page unresponsive. Finally, because it animates its `opacity` and `transform`, those need to be marked as changing with `will-change` (see also [Using the will-change property](animations-and-performance#using-the-will-change-property)).
 
 When the view is visible, it needs to accept interactions and have an `opacity` of 1:
 
-
-    .modal.visible {
-      pointer-events: auto;
-      opacity: 1;
-    }
-    
+```css
+.modal.visible {
+  pointer-events: auto;
+  opacity: 1;
+}
+```
 
 Now whenever the modal view is required, you can use JavaScript to toggle the "visible" class:
 
@@ -65,42 +65,29 @@ Now whenever the modal view is required, you can use JavaScript to toggle the "v
 At this point, the modal view appears without any animation, so you can now add that in
 (see also [Custom Easing](custom-easing)):
 
+```css
+.modal {
+  transform: scale(1.15);
 
-    .modal {
-      -webkit-transform: scale(1.15);
-      transform: scale(1.15);
-    
-      -webkit-transition:
-        -webkit-transform 0.1s cubic-bezier(0.465, 0.183, 0.153, 0.946),
-        opacity 0.1s cubic-bezier(0.465, 0.183, 0.153, 0.946);
-    
-      transition:
-        transform 0.1s cubic-bezier(0.465, 0.183, 0.153, 0.946),
-        opacity 0.1s cubic-bezier(0.465, 0.183, 0.153, 0.946);
-    
-    }
-    
+  transition:
+    transform 0.1s cubic-bezier(0.465, 0.183, 0.153, 0.946),
+    opacity 0.1s cubic-bezier(0.465, 0.183, 0.153, 0.946);
+}
+```
 
 Adding `scale` to the transform makes the view appear to drop onto the screen slightly, which is a nice effect. The default transition applies to both transform and opacity properties with a custom curve and a duration of 0.1 seconds.
 
 The duration is pretty short, though, but it's ideal for when the user dismisses the view and wants to get back to your app. The downside is that it’s probably too aggressive for when the modal view appears. To fix this, override the transition values for the `visible` class:
 
+```css
+.modal.visible {
+  transform: scale(1);
 
-    .modal.visible {
-    
-      -webkit-transform: scale(1);
-      transform: scale(1);
-    
-      -webkit-transition:
-        -webkit-transform 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946),
-        opacity 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946);
-    
-      transition:
-        transform 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946),
-        opacity 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946);
-    
-    }
-    
+  transition:
+    transform 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946),
+    opacity 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946);
+}
+```
 
 Now the modal view takes 0.3 seconds to come onto the screen, which is a bit less aggressive, but it is dismissed quickly, which the user will appreciate.
 


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Animating Modal Views*](https://developers.google.com/web/fundamentals/design-and-ux/animations/animating-modal-views) article,

- Removed vendor prefixed CSS `transform` and `transition` properties because they are supported without vendor prefixes in modern browsers. This makes the CSS easier to read and most users who need to support older browsers, use tools to create the prefixed version of CSS properties anyway.
- Wrapped CSS code that is not auto-detected as CSS in a ```` ```css ... ``` ```` block so that it is properly highlighted.

**CC:** @petele
