### PR TITLE
Fix capitalisation in a section's title

### DIFF
--- a/src/content/en/fundamentals/primers/service-workers/index.md
+++ b/src/content/en/fundamentals/primers/service-workers/index.md
@@ -119,7 +119,7 @@ so check your server's documentation and be sure to check out
 [Mozilla's SSL config generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/)
 for best practices.
 
-## Register A service worker
+## Register a service worker
 
 To install a service worker you need to kick start the process by
 **registering** it in your page. This tells the browser where your


### PR DESCRIPTION
What's changed, or what was fixed?
- Capitalisation of "Register A service worker" in the ServiceWorkers' doc

**Fixes:** #7975

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
