### PR TITLE
Fix typo

### DIFF
--- a/src/content/en/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/en/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -107,7 +107,7 @@ You should now see the function definition in the **Sources** panel.
 ![function definition in sources panel](imgs/definition.png)
 
 The `update()` function is the callback handler for 
-`requestAnimationCallback()`. The handler computes each image's `left` property
+`requestAnimationFrame()`. The handler computes each image's `left` property
 based off of the image's `offsetTop` value. This forces the browser to perform
 a new layout immediately to make sure that it provides the correct value. 
 Forcing a layout during every animation frame is the cause of the janky

--- a/src/content/es/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/es/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -102,7 +102,7 @@ Verás la definición en el panel **Sources**.
 ![Definición de la función en el panel Sources](imgs/definition.png)
 
 La función `update()` es el controlador de callbacks de 
-`requestAnimationCallback()`. El controlador computa la propiedad `left` de cada imagen
+`requestAnimationFrame()`. El controlador computa la propiedad `left` de cada imagen
 según su valor `offsetTop`. Esto fuerza el navegador a realizar
 un diseño nuevo de inmediato para garantizar que proporcione el valor correcto.
 La realización forzosa de diseños en cada fotograma de la animación es la causa del bloqueo de las animaciones

--- a/src/content/id/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/id/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -102,7 +102,7 @@ Anda sekarang seharusnya melihat definisi fungsi di panel **Sources**.
 ![definisi fungsi dalam panel sources](imgs/definition.png)
 
 Fungsi `update()` adalah penangan callback untuk 
-`requestAnimationCallback()`. Penangan menghitung setiap properti `left` gambar
+`requestAnimationFrame()`. Penangan menghitung setiap properti `left` gambar
 berdasarkan nilai `offsetTop` gambar. Ini memaksa browser melakukan
 layout baru segera untuk memastikan tersedianya nilai yang benar.
 Pemaksaan layout pada setiap bingkai animasi adalah penyebab tersendatnya

--- a/src/content/ja/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/ja/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -96,7 +96,7 @@ Timeline 記録の [**Summary**] ペインを見ると、ブラウザは大半�
 
 ![[Sources] パネルの関数定義](imgs/definition.png)
 
-`update()` 関数は `requestAnimationCallback()` のコールバック ハンドラです。
+`update()` 関数は `requestAnimationFrame()` のコールバック ハンドラです。
 ハンドラは、イメージの `offsetTop` 値に基づいて各イメージの `left` プロパティを計算します。
 この計算により、ブラウザは新しいレイアウトの即時実行を強制され、正確な値になるようにします。
 アニメーションのフレームで毎回レイアウトの適用が強制されると、ページのアニメーションが不自然になる原因になります。

--- a/src/content/ko/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/ko/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -102,7 +102,7 @@ DevTools 경고를 볼 수 있습니다. 강제 리플로우는
 ![Sources 패널에 표시된 함수 정의](imgs/definition.png)
 
 `update()` 함수는
-`requestAnimationCallback()`의 콜백 핸들러입니다. 이 핸들러는 이미지의 `offsetTop` 값을 기준으로 각 이미지의 
+`requestAnimationFrame()`의 콜백 핸들러입니다. 이 핸들러는 이미지의 `offsetTop` 값을 기준으로 각 이미지의 
 `left` 속성을 계산합니다. 따라서 브라우저가 즉시 강제로 새로운 레이아웃을 수행하여
 올바른 값을 제공하도록 보장합니다.
 애니메이션 프레임마다 레이아웃을 강제 적용하면 페이지 애니메이션에 버벅거림이 발생하는 원인이 

--- a/src/content/pt-br/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/pt-br/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -102,7 +102,7 @@ A definição da função deve estar exibida no painel **Sources**.
 ![definição da função no painel sources](imgs/definition.png)
 
 A função `update()` é o gerenciador de retorno de chamada de 
-`requestAnimationCallback()`. O gerenciador computa cada propriedade `left` da imagem
+`requestAnimationFrame()`. O gerenciador computa cada propriedade `left` da imagem
 com base no valor `offsetTop` da imagem. Isso força o navegador a executar
 um novo layout imediatamente para garantir que ele forneça o valor correto.
 Forçar um layout em todo quadro da animação é a causa das animações

--- a/src/content/zh-cn/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/zh-cn/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -96,7 +96,7 @@ Note: 这是您之前启用 **JS Profile** 选项的作用。
 
 ![Sources 面板中的函数定义](imgs/definition.png)
 
-`update()` 函数是 `requestAnimationCallback()` 的回调处理程序。
+`update()` 函数是 `requestAnimationFrame()` 的回调处理程序。
 处理程序会根据每个图像的 `offsetTop` 值计算其 `left` 属性。
 这将强制浏览器立即执行新布局，以便确保其提供正确的值。在每个动画帧期间强制布局是导致页面上出现动画卡顿的原因。
 

--- a/src/content/zh-tw/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
+++ b/src/content/zh-tw/tools/chrome-devtools/rendering-tools/forced-synchronous-layouts.md
@@ -96,7 +96,7 @@ Note: 這是您之前啓用 **JS Profile** 選項的作用。
 
 ![Sources 面板中的函數定義](imgs/definition.png)
 
-`update()` 函數是 `requestAnimationCallback()` 的回調處理程序。
+`update()` 函數是 `requestAnimationFrame()` 的回調處理程序。
 處理程序會根據每個圖像的 `offsetTop` 值計算其 `left` 屬性。
 這將強制瀏覽器立即執行新佈局，以便確保其提供正確的值。在每個動畫幀期間強制佈局是導致頁面上出現動畫卡頓的原因。
  


### PR DESCRIPTION
What's changed, or what was fixed?
- `requestAnimationCallback` => `requestAnimationFrame`

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
