### PR TITLE
Fixes to the Animating Between Views article

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/animations/animating-between-views.md
+++ b/src/content/en/fundamentals/design-and-ux/animations/animating-between-views.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Learn how to animate between two views in your apps.
 
 {# wf_blink_components: Blink>Animation #}
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2019-08-11 #}
 {# wf_published_on: 2014-08-08 #}
 
 # Animating Between Views {: .page-title }
@@ -45,49 +45,46 @@ To achieve this effect, you need a container for both views that has `overflow: 
 
 The CSS for the container is:
 
-
-    .container {
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      position: relative;
-    }
-    
+```css
+.container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+```
 
 The position of the container is set as `relative`. This means that each view inside it can be positioned absolutely to the top left corner and then moved around with transforms. This approach is better for performance than using the `left` property (because that triggers layout and paint), and is typically easier to rationalize.
 
+```css
+.view {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
 
-    .view {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      left: 0;
-      top: 0;
-    
-      /* let the browser know we plan to animate
-         each view in and out */
-      will-change: transform;
-    }
-    
+  /* let the browser know we plan to animate
+     each view in and out */
+  will-change: transform;
+}
+```
 
 Adding a `transition` on the `transform` property provides a nice slide effect. To give it a nice feel, it’s using a custom `cubic-bezier` curve, which we discussed in the [Custom Easing guide](custom-easing).
 
-
-    .view {
-      /* Prefixes are needed for Safari and other WebKit-based browsers */
-      transition: -webkit-transform 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946);
-      transition: transform 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946);
-    }
-    
+```css
+.view {
+  transition: transform 0.3s cubic-bezier(0.465, 0.183, 0.153, 0.946);
+}
+```
 
 The view that is offscreen should be translated to the right, so in this case the details view needs to be moved:
 
-
-    .details-view {
-      -webkit-transform: translateX(100%);
-      transform: translateX(100%);
-    }
-    
+```css
+.details-view {
+  transform: translateX(100%);
+}
+```
 
 Now a small amount of JavaScript is necessary to handle the classes. This toggles the appropriate classes on the views.
 
@@ -115,17 +112,16 @@ Now a small amount of JavaScript is necessary to handle the classes. This toggle
 
 Finally, we add the CSS declarations for those classes.
 
+```css
+.view-change .list-view {
+  transform: translateX(-100%);
+}
 
-    .view-change .list-view {
-      -webkit-transform: translateX(-100%);
-      transform: translateX(-100%);
-    }
-    
-    .view-change .details-view {
-      -webkit-transform: translateX(0);
-      transform: translateX(0);
-    }
-    
+.view-change .details-view {
+  transform: translateX(0);
+}
+```
+
 [Try it](https://googlesamples.github.io/web-fundamentals/fundamentals/design-and-ux/animations/inter-view-animation.html){: target="_blank" .external }
 
 You could expand this to cover multiple views, and the basic concept should remain the same; each non-visible view should be offscreen and brought on as needed, and the currently onscreen view should be moved off.
@@ -144,6 +140,7 @@ In addition to transitioning between views, this technique can also be applied t
 
 For a larger screen, you should keep the list view around all the time rather than removing it, and slide on the details view from the right-hand side. It’s pretty much the same as dealing with a navigation view.
 
+<div class="clearfix"></div>
 
 
 ## Feedback {: #feedback }


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Animating Between Views*](https://developers.google.com/web/fundamentals/design-and-ux/animations/animating-between-views) article,

- Added a clearfix div after the last paragraph in the article so that the last image (when floated to the right) does not overlap with the Feedback block.
**Before:** 
![image-overlapping-with-feedback](https://user-images.githubusercontent.com/33955898/62839826-b33de000-bc90-11e9-913c-381df917a30b.png)
**After:**
![image-no-longer-overlapping-with-feedback](https://user-images.githubusercontent.com/33955898/62839829-d23c7200-bc90-11e9-96da-b911d4339fd7.png)


- Removed vendor prefixed CSS `transform` property because it is supported without vendor prefixes in modern browsers. This makes the CSS easier to read, and most users, who need to support older browsers, use tools to create the prefixed version of CSS properties anyway.
- Wrapped CSS code that is not auto-detected as CSS in a ```` ```css ... ``` ```` block so that it is properly highlighted.

**CC:** @petele
