### PR TITLE
Fix async clipboard link from capabilities page

### DIFF
--- a/src/content/en/updates/capabilities.md
+++ b/src/content/en/updates/capabilities.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Web apps should be able to do anything native apps can. Through Project Fugu, we want to make it possible to build and deliver any kind of app on the open web.
 
-{# wf_updated_on: 2019-08-07 #}
+{# wf_updated_on: 2019-08-13 #}
 {# wf_published_on: 2018-11-12 #}
 {# wf_tags: capabilities #}
 {# wf_featured_image: /web/updates/images/generic/thumbs-up.png #}

--- a/src/content/en/updates/capabilities.md
+++ b/src/content/en/updates/capabilities.md
@@ -182,7 +182,7 @@ considering on [crbug.com](https://crbug.com) and filtering issues with the
   <tbody>
     <tr>
       <td>
-        <a href="/web/updates/2019/06/image-support-for-async-clipboard">
+        <a href="/web/updates/2019/07/image-support-for-async-clipboard">
           Async&nbsp;Clipboard API (images)
         </a>
       </td>


### PR DESCRIPTION
What's changed, or what was fixed?
- Fix async clipboard link from capabilities page

**Target Live Date:** ASAP

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
