### PR TITLE
Correct link to web share demo after wicg→w3c move

### DIFF
--- a/src/content/en/updates/2019/05/web-share-files.md
+++ b/src/content/en/updates/2019/05/web-share-files.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Chrome 75 introduces file sharing from a web app, which lets your web app can share with virtually anything on a user's device.
 
 {# wf_published_on: 2019-05-02 #}
-{# wf_updated_on: 2019-05-28 #}
+{# wf_updated_on: 2019-08-13 #}
 {# wf_featured_image: /web/updates/images/generic/share.png #}
 {# wf_tags: capabilities,sharing,chrome75 #}
 {# wf_featured_snippet: Chrome 75 introduces file sharing from a web app, which lets your web app can share with virtually anything on a user's device. #}

--- a/src/content/en/updates/2019/05/web-share-files.md
+++ b/src/content/en/updates/2019/05/web-share-files.md
@@ -37,7 +37,7 @@ able to use web apps as a share target. For now, your web app can share files
 with other web share targets registered on your device.
 
 This article assumes some familiarity with the Web Share API. If this is new to
-you, check out the links above or [the demo](http://wicg.github.io/web-share/demos/share-files.html). 
+you, check out the links above or [the demo](https://w3c.github.io/web-share/demos/share-files.html). 
 
 ## The navigator.canShare() method
 
@@ -93,7 +93,7 @@ IDL rules.
 
 ## More information
 
-+   [Web Share demo](http://wicg.github.io/web-share/demos/share-files.html)
++   [Web Share demo](https://w3c.github.io/web-share/demos/share-files.html)
 +   [Web Share explainer](https://github.com/WICG/web-share/blob/master/docs/explainer.md)
 +   [Web Share on Chrome Status](https://www.chromestatus.com/feature/4777349178458112)
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Correct link to web share demo after wicg→w3c move

**Target Live Date:** ASAP

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
