### PR TITLE
Fix background services URL hash to match what DevTools links to

### DIFF
--- a/src/content/en/tools/chrome-devtools/javascript/background-services.md
+++ b/src/content/en/tools/chrome-devtools/javascript/background-services.md
@@ -153,7 +153,7 @@ when DevTools is not open:
        </figcaption>
      </figure>
 
-## Push Messages {: #pushmessages }
+## Push Messages {: #push }
 
 To display a push notification to a user, a [service worker][serviceworker] must first use the
 [Push Message][push] API to receive data from a server. When the service worker is ready to display


### PR DESCRIPTION
What's changed, or what was fixed?
Table of contents links to #push but the section was using #pushmessage

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @kaycebasques 
