### PR TITLE
Update KV Storage syntax to use default export

### DIFF
--- a/src/content/en/updates/2019/03/kv-storage.md
+++ b/src/content/en/updates/2019/03/kv-storage.md
@@ -80,7 +80,7 @@ browsers</a>, you could import the KV Storage module with the following code
 browsers](#what_if_a_browser_doesnt_support_a_built-in_module)):
 
 ```js
-import {storage, StorageArea} from 'std:kv-storage';
+import storage, {StorageArea} from 'std:kv-storage';
 ```
 
 ## The KV Storage module
@@ -110,7 +110,7 @@ main point of this module is it's not synchronous, in contrast to
 [specification](https://wicg.github.io/kv-storage/#storagearea).
 
 As you may have noticed from the code example above, the KV Storage module has
-two named exports: `storage` and `StorageArea`.
+one default export `storage` and one named export `StorageArea`.
 
 `storage` is an instance of the `StorageArea` class with the name `'default'`,
 and it's what developers will use most often in their application code. The
@@ -123,7 +123,7 @@ of the `StorageArea` instance.
 Here's an example of how to use the KV Storage module in your code:
 
 ```js
-import {storage} from 'std:kv-storage';
+import storage from 'std:kv-storage';
 
 const main = async () => {
   const oldPreferences = await storage.get('preferences');
@@ -192,7 +192,7 @@ module:
 
 <!-- Then any module scripts with import statements use the above map -->
 <script type="module">
-  import {storage} from '/path/to/kv-storage-polyfill.mjs';
+  import storage from '/path/to/kv-storage-polyfill.mjs';
 
   // Use `storage` ...
 </script>


### PR DESCRIPTION
As pointed out in this [pull request in the spec's GitHub repo for KV storage](https://github.com/WICG/kv-storage/pull/74). The KV storage api now uses a default export instead of a named export. This can be tested in Chrome Canary with experimental web features turned on and is also present in the current spec.

What's changed, or what was fixed?
- Updated a markdown file to reflect the current KV Storage API.

**Fixes:** https://github.com/google/WebFundamentals/issues/8015