### PR TITLE
Fixes to the Animating a Blur article

### DIFF
--- a/src/content/en/updates/2017/10/animated-blur.md
+++ b/src/content/en/updates/2017/10/animated-blur.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: A few tricks are necessary to animate a blur efficiently.
 
-{# wf_updated_on: 2017-10-12 #}
+{# wf_updated_on: 2019-08-28 #}
 {# wf_published_on: 2017-10-11 #}
 {# wf_tags: performance #}
 {# wf_featured_image: /web/updates/images/2017/10/animated-blur/poster.jpg #}
@@ -17,7 +17,7 @@ Blurring is a great way to redirect a user's focus. Making some visual
 elements appear blurred while keeping other elements in focus naturally directs
 the user's focus. Users ignore the blurred content and instead focus on the
 content they can read. One example would be a list of icons that display details
-about the individual items when hovered over. During that time the remaining choices
+about the individual items when hovered over. During that time, the remaining choices
 could be blurred to redirect the user to the newly displayed information.
 
 ### TL;DR: {: .hide-from-toc }
@@ -55,13 +55,13 @@ deceptively powerful GPUs.
 As of now, we can't make animating a blur work efficiently. We can, however,
 find a work-around that looks *good enough*, but is, technically speaking, not
 an animated blur. To get started, let's first understand *why* the animated blur
-is slow. To blur elements on the web there are two techniques: The CSS `filter`
+is slow. To blur elements on the web, there are two techniques: The CSS `filter`
 property and SVG filters. Thanks to increased support and ease of use, CSS
 filters are typically used. Unfortunately, if you are required to support Internet
 Explorer, you have no choice but to use SVG filters as IE 10 and 11 support
 those but not CSS filters. The good news is that our workaround for animating a
 blur works with both techniques. So let's try to find the bottleneck by looking
-at DevTools:
+at DevTools.
 
 If you enable "Paint Flashing" in DevTools, you won’t see any flashes at all. It
 looks like no repaints are happening. And that's technically correct as a
@@ -84,7 +84,7 @@ well below 60fps.
 
 So what can we do to make this run smoothly? We can use sleight of hand! Instead
 of animating the actual blur value (the radius of the blur), we pre-compute a
-couple of blurred copies where the blur value increases exponentially then
+couple of blurred copies where the blur value increases exponentially, then
 cross-fade between them using `opacity`.
 
 The cross-fade is a series of overlapping opacity fade-ins and fade-outs. If we
@@ -96,8 +96,8 @@ in the fourth and final version. In this scenario, each stage would take ¼ of
 the total desired duration. Visually, this looks very similar to a real,
 animated blur.
 
-In our experiments increasing the blur radius exponentially per stage yielded
-the best visual results. Example: If we have four blur stages we'd apply
+In our experiments, increasing the blur radius exponentially per stage yielded
+the best visual results. Example: If we have four blur stages, we'd apply
 `filter: blur(2^n)` to each stage, i.e. stage 0: 1px, stage 1: 2px, stage 2: 4px
 and stage 3: 8px. If we force each of these blurred copies onto their own layer
 (called "promoting") using `will-change: transform`, changing opacity on these
@@ -119,7 +119,7 @@ promoted and blurred, the effect is applied by the GPU. So even though we are
 not animating the blur value anymore, the texture itself is still unblurred and
 needs to be re-blurred every frame by the GPU. The reason for the frame rate
 being even worse than before stems from the fact that compared to the naïve
-implementation the GPU actually has more work than before as most of the time two
+implementation, the GPU actually has more work than before, as most of the time two
 textures are visible that need to be blurred independently.
 
 What we came up with is not pretty, but it makes the animation blazingly fast.
@@ -142,7 +142,7 @@ Now we've got lots of headroom on the GPU and a silky-smooth 60fps. We did it!
 
 ## Productionizing
 
-In our demo we duplicated a DOM structure multiple times to have copies of the
+In our demo, we duplicated a DOM structure multiple times to have copies of the
 content to blur at different strengths. You might be wondering how this would
 work in a production environment as that might have some unintended side-effects
 with the author's CSS styles or even their JavaScript. You are right. Enter
@@ -156,7 +156,7 @@ isolation and performance primitive! JavaScript and CSS cannot pierce Shadow DOM
 boundaries which allows us to duplicate content without interfering with the
 developer's styles or application logic. We already have a `<div>` element for
 each copy to rasterize onto and now use these `<div>`s as shadow hosts. We
-create a `ShadowRoot` using `attachShadow({mode: closed'})` and attach a copy of
+create a `ShadowRoot` using `attachShadow({mode: 'closed'})` and attach a copy of
 the content to the `ShadowRoot` instead of the `<div>` itself. We have to make
 sure to also copy all stylesheets into the `ShadowRoot` to guarantee that our
 copies are styled the same way as the original.
@@ -165,24 +165,24 @@ Note: In most cases — especially when writing custom elements — we advise
 against using closed `ShadowRoots`. Find out more in [Eric's
 article](/web/fundamentals/web-components/shadowdom#closed).
 
-Some browsers do not support Shadow DOM v1 and for those we fall back to just
+Some browsers do not support Shadow DOM v1, and for those, we fall back to just
 duplicating the content and hoping for the best that nothing breaks. We could
 use the [Shadow DOM polyfill](https://github.com/webcomponents/shadydom) with
 [ShadyCSS](https://github.com/webcomponents/shadycss), but we did not implement
 this in our library.
 
-And there you go. After our journey down Chrome's rendering pipeline we figured
+And there you go. After our journey down Chrome's rendering pipeline, we figured
 out how we can animate blurs efficiently across browsers!
 
 ## Conclusion
 
 This kind of effect is not to be used lightly. Due to the fact that we copy DOM
-elements and force them onto their own layer we can push the limits of lower-end
+elements and force them onto their own layer, we can push the limits of lower-end
 devices. Copying *all* stylesheets into each `ShadowRoot` is a potential
 performance risk as well, so you should decide whether you would rather adjust
 your logic and styles to not be affected by copies in the `LightDOM` or use our
 `ShadowDOM` technique. But sometimes our technique might be a worthwhile
-investment. Take a look at the code in your [GitHub
+investment. Take a look at the code in our [GitHub
 repository](https://github.com/GoogleChromeLabs/ui-element-samples/tree/gh-pages/animated-blur)
 as well as the
 [demo](https://googlechromelabs.github.io/ui-element-samples/animated-blur/) and


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Animating a Blur*](https://developers.google.com/web/updates/2017/10/animated-blur) article,

- Added missing commas.
- Replaced a colon with a period at the end of a sentence.
- Added a missing opening quote.
- Changed "your GitHub repository" to "our GitHub repository" when referring to the `GoogleChromeLabs/ui-element-samples` repository.

**CC:** @petele
