### PR TITLE
Update broken link

### DIFF
--- a/src/content/en/fundamentals/performance/http2/index.md
+++ b/src/content/en/fundamentals/performance/http2/index.md
@@ -571,7 +571,7 @@ For full details of the HPACK compression algorithm, see
 
 * [“HTTP/2”](https://hpbn.co/http2/){: .external }
     – The full article by Ilya Grigorik
-* [“Setting up HTTP/2”](https://surma.link/things/h2setup/){: .external }
+* [“Setting up HTTP/2”](https://dassur.ma/things/h2setup/){: .external }
     – How to set up HTTP/2 in different backends by Surma
 * [“HTTP/2 is here,
 let’s optimize!”](https://docs.google.com/presentation/d/1r7QXGYOLCh4fcUq0jDdDwKJWNqWK1o4xMtYpKZCJYjM/edit#slide=id.p19)

--- a/src/content/en/fundamentals/performance/http2/index.md
+++ b/src/content/en/fundamentals/performance/http2/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: HTTP/2 (or h2) is a binary protocol that brings push, multiplexing streams and frame control to the web.
 
-{# wf_updated_on: 2018-08-17 #}
+{# wf_updated_on: 2019-09-01 #}
 {# wf_published_on: 2016-09-29 #}
 {# wf_blink_components: Blink>Network,Internals>Network>HTTP2 #}
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Updated Surma's link to HTTP2 setup guide

**Fixes:** #8061 

**CC:** @petele @surma 