### PR TITLE
Move workbox-broadcast-cache-update module to workbox-broadcast-update

### DIFF
--- a/src/content/en/tools/_redirects.yaml
+++ b/src/content/en/tools/_redirects.yaml
@@ -239,3 +239,6 @@ redirects:
 
 - from: /web/tools/workbox/guides/migrate
   to: /web/tools/workbox/guides/migrations/migrate-from-sw
+
+- from: /web/tools/workbox/modules/workbox-broadcast-cache-update
+  to: /web/tools/workbox/modules/workbox-broadcast-update

--- a/src/content/en/tools/workbox/_shared/config/single/runtimeCaching.html
+++ b/src/content/en/tools/workbox/_shared/config/single/runtimeCaching.html
@@ -22,7 +22,7 @@
       </p>
       <p>
         The <code>options</code> properties can be used to configure instances of the cache
-        expiration, cacheable response, and broadcast cache update plugins to apply to a given route.
+        expiration, cacheable response, and broadcast update plugins to apply to a given route.
       </p>
       <p>
         <strong>Example:</strong>
@@ -54,7 +54,7 @@
         statuses: [0, 200],
         headers: {'x-test': 'true'},
       },
-      // Configure the broadcast cache update plugin.
+      // Configure the broadcast update plugin.
       broadcastUpdate: {
         channelName: 'my-update-channel',
       },

--- a/src/content/en/tools/workbox/modules/_index.yaml
+++ b/src/content/en/tools/workbox/modules/_index.yaml
@@ -123,11 +123,11 @@ landing_page:
           updated with a new response.
         buttons:
         - label: Learn more
-          path: ./workbox-broadcast-cache-update
+          path: ./workbox-broadcast-update
         - label: Reference
           path: ../reference-docs/latest/workbox.broadcastUpdate
         - label: Demo
-          path: https://workbox-demos.firebaseapp.com/demo/workbox-broadcast-cache-update/
+          path: https://workbox-demos.firebaseapp.com/demo/workbox-broadcast-update/
 
       - heading: workbox.rangeRequest
         description: >

--- a/src/content/en/tools/workbox/modules/_toc.yaml
+++ b/src/content/en/tools/workbox/modules/_toc.yaml
@@ -23,7 +23,7 @@ toc:
 - title: workbox.cacheableResponse
   path: /web/tools/workbox/modules/workbox-cacheable-response
 - title: workbox.broadcastUpdate
-  path: /web/tools/workbox/modules/workbox-broadcast-cache-update
+  path: /web/tools/workbox/modules/workbox-broadcast-update
 - title: workbox.navigationPreload
   path: /web/tools/workbox/modules/workbox-navigation-preload
 

--- a/src/content/en/tools/workbox/modules/workbox-broadcast-update.md
+++ b/src/content/en/tools/workbox/modules/workbox-broadcast-update.md
@@ -2,18 +2,18 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-background-sync.
 
-{# wf_updated_on: 2019-07-17 #}
+{# wf_updated_on: 2019-09-02 #}
 {# wf_published_on: 2017-11-29 #}
 {# wf_blink_components: N/A #}
 
-# Workbox Broadcast Cache Update {: .page-title }
+# Workbox Broadcast Update {: .page-title }
 
-## What is Broadcast Cache Update?
+## What is Broadcast Update?
 
 When responding to requests with cached entries, while being fast, it
 comes with a tradeoff that users may end up seeing stale data.
 
-The `workbox-broadcast-cache-update` module provides a standard way of
+The `workbox-broadcast-update` module provides a standard way of
 notifying Window Clients that a cached response has been updated. This is most
 commonly used along with the
 [staleWhileRevalidate strategy](./workbox-strategies#stale-while-revalidate).
@@ -44,7 +44,7 @@ Warning: Because Workbox needs to be able to read the header values,
 [opaque responses](https://stackoverflow.com/questions/39109789/what-limitations-apply-to-opaque-responses),
 whose headers are not accessible, will never trigger update messages.
 
-## Using Broadcast Cache Update
+## Using Broadcast Update
 
 The library is intended to be used along with the `staleWhileRevalidate`
 caching strategy, since that strategy involves returning a cached
@@ -95,7 +95,7 @@ When a `message` event listener is invoked in your web app, the
 ```js
 {
   type: 'CACHE_UPDATED',
-  meta: 'workbox-broadcast-cache-update',
+  meta: 'workbox-broadcast-update',
   // The two payload values vary depending on the actual update:
   payload: {
     cacheName: 'the-cache-name',
@@ -129,7 +129,7 @@ workbox.routing.registerRoute(
 
 ## Advanced Usage
 
-While most developers will use `workbox-broadcast-cache-update` as a plugin
+While most developers will use `workbox-broadcast-update` as a plugin
 of a particular strategy as shown above, it's possible to use the underlying
 logic in service worker code.
 

--- a/src/content/en/tools/workbox/modules/workbox-window.md
+++ b/src/content/en/tools/workbox/modules/workbox-window.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-routing.
 
 {# wf_published_on: 2019-02-24 #}
-{# wf_updated_on: 2019-05-09 #}
+{# wf_updated_on: 2019-09-02 #}
 {# wf_blink_components: N/A #}
 
 # Workbox Window {: .page-title }
@@ -205,7 +205,7 @@ wb.register();
 cache updates from the <code>workbox-broadcast-update</code> package</h4>
 
 The [`workbox-broadcast-update`
-package](/web/tools/workbox/modules/workbox-broadcast-cache-update) is a great
+package](/web/tools/workbox/modules/workbox-broadcast-update) is a great
 
 way to be able to serve content from the cache (for fast delivery) while also
 being able to inform the user of updates to that content (using the


### PR DESCRIPTION
What's changed, or what was fixed?
- Move `workbox-broadcast-cache-update` module to `workbox-broadcast-update`.

**Fixes:** https://github.com/GoogleChrome/workbox/pull/2212

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @philipwalton 

Test fail locally with an unrelated failure.

> ERROR: src/content/en/tools/workbox/_shared/config/single/runtimeCaching.html#1 Template tags ('{{'') should be escaped to '&#123;&#123;'
