### PR TITLE
Fixes to Enabling HTTPS on Your Servers

### DIFF
--- a/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Enabling HTTPS on your servers is critical to securing your webpages.
 
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2019-09-08 #}
 {# wf_published_on: 2015-03-27 #}
 {# wf_blink_components: Blink>SecurityFeature,Internals>Network>SSL #}
 
@@ -402,8 +402,8 @@ solve it:
 * To work around a variety of problems with Referer headers, use the new
   [Referrer Policy standard](http://www.w3.org/TR/referrer-policy/#referrer-policy-delivery-meta).
 
-Because search engines are migrating to HTTPS, in the future you are likely
-see _more_ Referer headers when you migrate to HTTPS.
+Because search engines are migrating to HTTPS, in the future, you are likely
+to see _more_ Referer headers when you migrate to HTTPS.
 
 Caution: According to the [HTTP RFC](https://tools.ietf.org/html/rfc2616#section-15.1.3),
 clients **SHOULD NOT** include a Referer header field in a (non-secure) HTTP
@@ -419,7 +419,7 @@ site operators cannot migrate to HTTPS without losing ad revenue; but until site
 operators migrate to HTTPS, advertisers have little motivation to publish HTTPS.
 
 Advertisers should at least offer ad service via HTTPS (such as by completing
-the "Enable HTTPS on your servers" section on this page. Many already do. You
+the "Enable HTTPS on your servers" section on this page). Many already do. You
 should ask advertisers that do not serve HTTPS at all to at least start.
 You may wish to defer completing
 [Make IntraSite URLs relative](#make-intrasite-urls-relative) until enough


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Enabling HTTPS on Your Servers*](https://developers.google.com/web/fundamentals/security/encrypt-in-transit/enable-https) article,

- Added a missing comma.
- Added a missing "to".
- Added a missing closing round bracket.

**CC:** @petele
