### PR TITLE
Fixes to the KV Storage article

### DIFF
--- a/src/content/en/updates/2019/03/kv-storage.md
+++ b/src/content/en/updates/2019/03/kv-storage.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: An introduction to the new KV Storage API, built-in modules, and import maps.
 
-{# wf_updated_on: 2019-06-27 #}
+{# wf_updated_on: 2019-09-10 #}
 {# wf_published_on: 2019-03-11 #}
 {# wf_tags: chrome74, devtools, devtools-whatsnew #}
 {# wf_featured_image: /web/updates/images/generic/new-in-chrome.png #}
@@ -73,7 +73,7 @@ worker, or service worker), and they won't consume any memory or CPU unless
 they're actually imported. Furthermore, they don't run the risk of naming
 collisions with other variables defined in your code.
 
-To import a built-in module you use the prefix `std:` followed by the built-in
+To import a built-in module, you use the prefix `std:` followed by the built-in
 module's identifier. For example, in <a href="#browser-support">supported
 browsers</a>, you could import the KV Storage module with the following code
 (see below for [how to use a KV Storage polyfill in unsupported
@@ -105,7 +105,7 @@ and like `Map`, its keys do not have to be strings. They can be any
 Unlike `Map`, all KV Storage methods return either
 [promises](/web/fundamentals/primers/promises) or
 [async iterators](https://github.com/tc39/proposal-async-iteration) (since the
-main point of this module is it's not synchronous, in contrast to
+main point of this module is that it's not synchronous, in contrast to
 `localStorage`). To see the full API in detail, you can refer to the
 [specification](https://wicg.github.io/kv-storage/#storagearea).
 
@@ -198,13 +198,13 @@ module:
 </script>
 ```
 
-The key point in the above code is the URL `/path/to/kv-storage-polyfill.mjs`
+The key point in the above code is that the URL `/path/to/kv-storage-polyfill.mjs`
 is being mapped to _two_ different resources: `std:kv-storage` and then the
 original URL again, `/path/to/kv-storage-polyfill.mjs`.
 
 So when the browser encounters an import statement referencing that URL
 (`/path/to/kv-storage-polyfill.mjs`), it first tries to load `std:kv-storage`,
-and if it can't then it falls back to loading
+and if it can't, then it falls back to loading
 `/path/to/kv-storage-polyfill.mjs`.
 
 Again, the magic here is that the browser doesn't need to support import maps
@@ -223,7 +223,7 @@ Currently, [more than 80% of browsers support
 modules](https://caniuse.com/#feat=es6-module), and for browsers that don't,
 you can use the [module/nomodule
 technique](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/)
-to serve a legacy bundle to older browsers. Note that when generating your
+to serve a legacy bundle. Note that when generating your
 `nomodule` build, you'll need to include all polyfills because you know for sure
 that browsers that don't support modules will definitely not support built-in
 modules.
@@ -238,11 +238,11 @@ techniques described above and runs in all browsers today:
 * Browsers that support modules, import maps, and the built-in module do not
   load any unneeded code.
 * Browsers that support modules and import maps but do not support the built-in
-  module load the [KV Storage
+  module, load the [KV Storage
   polyfill](https://github.com/GoogleChromeLabs/kv-storage-polyfill) (via the
   browser's module loader).
 * Browsers that support modules but do not support import maps also load the
-  KV Storage polyfill (via the browser's module loader)
+  KV Storage polyfill (via the browser's module loader).
 * Browsers that do not support modules at all get the KV Storage polyfill in
   their legacy bundle (loaded via `<script nomodule>`).
 
@@ -266,12 +266,12 @@ Feel free to take a look if you're curious to see how it's built.
 </aside>
 
 In order to actually see the native built-in module in action, you have to load
-the demo in Chrome 74 (currently Chrome Dev or Canary) with the experimental web
+the demo in Chrome 74 or later with the experimental web
 platform features flag turned on
 (`chrome://flags/#enable-experimental-web-platform-features`).
 
 You can verify that the built-in module is being loaded because you won't see
-the polyfill script in the source panel in DevTools; instead you'll see the
+the polyfill script in the source panel in DevTools; instead, you'll see the
 built-in module version (fun fact: you can actually inspect the module's source
 code or even put breakpoints in it!):
 
@@ -286,7 +286,7 @@ code or even put breakpoints in it!):
 ## Please give us feedback
 
 This introduction should have given you a taste of what may be possible with
-built-in modules. And hopefully you're excited! We'd really love for developers
+built-in modules. And hopefully, you're excited! We'd really love for developers
 to try out the KV Storage module (as well as all the new features discussed
 here) and give us feedback.
 
@@ -305,5 +305,7 @@ trial](https://developers.chrome.com/origintrials/#/trials/active), you can
 actually deploy these features today. All your users should benefit from better
 storage performance, and Chrome 74+ users won't have to pay any extra download
 cost.
+
+{% include "web/_shared/helpful.html" %}
 
 {% include "web/_shared/rss-widget-updates.html" %}

--- a/src/content/en/updates/2019/03/kv-storage.md
+++ b/src/content/en/updates/2019/03/kv-storage.md
@@ -238,7 +238,7 @@ techniques described above and runs in all browsers today:
 * Browsers that support modules, import maps, and the built-in module do not
   load any unneeded code.
 * Browsers that support modules and import maps but do not support the built-in
-  module, load the [KV Storage
+  module load the [KV Storage
   polyfill](https://github.com/GoogleChromeLabs/kv-storage-polyfill) (via the
   browser's module loader).
 * Browsers that support modules but do not support import maps also load the


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*KV Storage: the Web's First Built-in Module*](https://developers.google.com/web/updates/2019/03/kv-storage) article,

- Added missing commas/periods.
- Made some sentences clearer by adding "that" conjunctions.
- Removed redundant "to older browsers" in a sentence.
- Replaced "load the demo in Chrome 74 (currently Chrome Dev or Canary)" with "load the demo in Chrome 74 or later".
- Added missing "Was this page helpful?" block.

**CC:** @petele
