### PR TITLE
Fixes to Making wheel scrolling fast by default

### DIFF
--- a/src/content/en/updates/2019/02/scrolling-intervention.md
+++ b/src/content/en/updates/2019/02/scrolling-intervention.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Scrolling responsiveness is critical to the user's engagement with a website on mobile, yet wheel event listeners often cause serious scrolling performance problems. Learn how we are helping users and developers to be fast by default.
 
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2019-09-14 #}
 {# wf_published_on: 2019-02-07 #}
 {# wf_tags: interventions,chrome73 #}
 {# wf_featured_image: /web/updates/images/generic/warning.png #}
@@ -13,7 +13,7 @@ description: Scrolling responsiveness is critical to the user's engagement with 
 
 {% include "web/_shared/contributors/sahel.html" %}
 
-To improve `wheel` scrolling/zooming performance developers are encouraged to
+To improve `wheel` scrolling/zooming performance, developers are encouraged to
 register `wheel` and `mousewheel` [event listeners as
 passive](/web/updates/2016/06/passive-event-listeners)
 by passing the `{passive: true}` option to `addEventListener()`. Registering
@@ -23,10 +23,10 @@ zooming without blocking on the listeners.
 
 The problem is that most often the wheel event listeners are conceptually
 passive (do not call `preventDefault()`) but are not explicitly specified as
-such requiring the browser to wait for the JS event handling to finish before
-it starts scrolling/zooming even though waiting is not necessary. In Chrome 56
-[we fixed this issue for touchStart and touchMove](/web/updates/2017/01/scrolling-intervention)
-, and that change was later adopted by both Safari and Firefox. As you can see
+such, requiring the browser to wait for the JS event handling to finish before
+it starts scrolling/zooming even though waiting is not necessary. In Chrome 56,
+[we fixed this issue for `touchstart` and `touchmove`](/web/updates/2017/01/scrolling-intervention),
+and that change was later adopted by both Safari and Firefox. As you can see
 from the demonstration video we made at that time, leaving the behavior as it
 was produced a noticeable delay in scroll response. Now in Chrome 73, we've
 applied the same intervention to `wheel` and `mousewheel` events.
@@ -44,7 +44,7 @@ after the user starts scrolling by wheel or touchpad without developers needing
 to change code. Our metrics show that 75% of the `wheel` and `mousewheel` event
 listeners that are registered on root targets (window, document, or body) do
 not specify any values for the passive option and more than 98% of such
-listeners do not call preventDefault(). In Chrome 73 we are changing the
+listeners do not call `preventDefault()`. In Chrome 73, we are changing the
 `wheel` and `mousewheel` listeners registered on root targets (window,
 document, or body) to be passive by default. It means that an event listener
 like:
@@ -56,23 +56,23 @@ window.addEventListener("wheel", func);
 becomes equivalent to:
 
 ```js
-window.addEventListener("wheel", func, {passive: true} );
+window.addEventListener("wheel", func, {passive: true});
 ```
 
 And calling `preventDefault()` inside the listener will be ignored with the
 following DevTools warning:
 
     [Intervention] Unable to preventDefault inside passive event listener due
-    to target being treated as passive.See https://www.chromestatus.com/features/6662647093133312
+    to target being treated as passive. See https://www.chromestatus.com/features/6662647093133312
 
 ## Breakage and Guidance
 
 In the vast majority of cases, no breakage will be observed. Only in rare cases
-(less than 0.3% of pages according to our metrics) unintended scrolling/zooming
-might happen due to `preventDefault()` call getting ignored inside the
+(less than 0.3% of pages according to our metrics), unintended scrolling/zooming
+might happen due to the `preventDefault()` call getting ignored inside the
 listeners that are treated as passive by default. Your application can
 determine whether it may be hitting this in the wild by checking if calling
-`preventDefault()` had any effect via the defaultPrevented property. The fix
+`preventDefault()` had any effect via the `defaultPrevented` property. The fix
 for the affected cases is relatively easy: pass `{passive: false}` to
 `addEventListener()` to override the default behavior and preserve the event
 listener as blocking.


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Making wheel scrolling fast by default*](https://developers.google.com/web/updates/2019/02/scrolling-intervention) article,

- Added missing commas.
- Changed the event names `touchStart` and `touchMove` to `touchstart` and `touchmove` and wrapped them in backticks.
- Added backticks where missing.
- Removed unnecessary spaces and added a missing one.
- Added missing "the" before "`preventDefault()` call".

**CC:** @petele
