### PR TITLE
Update /nic to nic77 article

### DIFF
--- a/src/content/en/updates/_redirects.yaml
+++ b/src/content/en/updates/_redirects.yaml
@@ -3,7 +3,7 @@
 redirects:
 
 - from: /web/updates/nic
-  to: /web/updates/2019/04/nic74
+  to: /web/updates/2019/09/nic77
 
 - from: /web/updates/2018/11/writable-files
   to: /web/updates/2019/08/native-file-system


### PR DESCRIPTION
What's changed, or what was fixed?
- Update /nic redirect to New In Chrome 77 article

**CC:** @petele
