### PR TITLE
CDS Watch Live Banner & Landing

### DIFF
--- a/src/content/en/_index.yaml
+++ b/src/content/en/_index.yaml
@@ -42,31 +42,10 @@ landing_page:
 
   rows:
 
-  - classname: devsite-landing-row-100 devsite-landing-row-large-headings  cds2019
+  - classname: devsite-landing-row-100
     background: grey
     items:
-    - heading: >
-        <img src="https://www.gstatic.com/images/branding/product/2x/chrome_96dp.png">
-        <div>
-          <div class="cds-header"><span class="cds-cr">chrome://</span>dev-summit</div>
-          <div class="cds-dates">
-            november <span class="cds-blue">11<sup>th</sup>-12<sup>th</sup></span> 2019
-          </div>
-          <div class="cds-loc">Yerba Buena Center for the Arts</div>
-          <div class="cds-city">San Francisco, CA</div>
-        </div>
-      description: >
-        Chrome Dev Summit registration is now open! Join us for our annual
-        developer conference at the Yerba Buena Center for the Arts in San
-        Francisco, CA on November 11-12, 2019. Over the two days, you’ll
-        learn about the latest tools and updates coming to the web platform
-        and hear directly from the Chrome product & engineering teams.
-        Request your invite at the
-        <a href="https://developer.chrome.com/devsummit/">Chrome Dev Summit
-        2019 website</a>.
     - youtube_id: nImH_dq1NpM
-
-
 
   - classname: wf-landing-row
     items:

--- a/src/content/en/_project.yaml
+++ b/src/content/en/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on Nov. 11-12 in San Francisco to learn about the latest features and tools coming to the Web. Request an invite on the <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/content/en/_project.yaml
+++ b/src/content/en/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    </style> Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream, or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.

--- a/src/content/en/feedback/_project.yaml
+++ b/src/content/en/feedback/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on Nov. 11-12 in San Francisco to learn about the latest features and tools coming to the Web. Request an invite on the <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/content/en/feedback/_project.yaml
+++ b/src/content/en/feedback/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    </style> Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream, or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.

--- a/src/content/en/fundamentals/_project.yaml
+++ b/src/content/en/fundamentals/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on Nov. 11-12 in San Francisco to learn about the latest features and tools coming to the Web. Request an invite on the <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/content/en/fundamentals/_project.yaml
+++ b/src/content/en/fundamentals/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    </style> Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream, or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.

--- a/src/content/en/site-kit/_project.yaml
+++ b/src/content/en/site-kit/_project.yaml
@@ -29,4 +29,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on Nov. 11-12 in San Francisco to learn about the latest features and tools coming to the Web. Request an invite on the <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/content/en/site-kit/_project.yaml
+++ b/src/content/en/site-kit/_project.yaml
@@ -29,4 +29,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    </style> Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream, or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.

--- a/src/content/en/tools/_project.yaml
+++ b/src/content/en/tools/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on Nov. 11-12 in San Francisco to learn about the latest features and tools coming to the Web. Request an invite on the <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/content/en/tools/_project.yaml
+++ b/src/content/en/tools/_project.yaml
@@ -33,4 +33,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    </style> Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream, or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.

--- a/src/content/en/tools/workbox/_project.yaml
+++ b/src/content/en/tools/workbox/_project.yaml
@@ -32,4 +32,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    </style> Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream, or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.

--- a/src/content/en/tools/workbox/_project.yaml
+++ b/src/content/en/tools/workbox/_project.yaml
@@ -32,4 +32,4 @@ announcement:
         vertical-align: middle;
         margin-right: 8px;
       }
-    </style> Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on Nov. 11-12 in San Francisco to learn about the latest features and tools coming to the Web. Request an invite on the <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    </style> <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube. <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/data/announcement.yaml
+++ b/src/data/announcement.yaml
@@ -16,7 +16,5 @@ description: >
         margin-right: 8px;
       }
     </style>
-    Register for this year’s <b><code>#ChromeDevSummit</code></b> happening on
-    Nov. 11-12 in San Francisco to learn about the latest features and tools
-    coming to the Web. Request an invite on the
-    <a href="https://developer.chrome.com/devsummit">Chrome Dev Summit 2019 website</a>
+    <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube.
+    <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.

--- a/src/data/announcement.yaml
+++ b/src/data/announcement.yaml
@@ -16,5 +16,6 @@ description: >
         margin-right: 8px;
       }
     </style>
-    <b>Chrome Dev Summit 2019</b> is happening now and streaming live on YouTube.
-    <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Watch now</a>.
+    Can’t make the <code>#ChromeDevSummit</code> this year? Catch all the content (and more!) on the livestream,
+    or join your peers for a CDS Extended event at a hosted location nearby. To learn more, check out the
+    <a href="https://developer.chrome.com/devsummit/" class="gc-analytics-event" data-category="webFu" data-label="cds-banner-watch">Chrome Dev Summit 2019 website</a>.


### PR DESCRIPTION
What's changed, or what was fixed?
- Adds full screen watch to /web/ landing page
- Adds banner to all pages for day of

**TODO:** 
- [ ] Update YouTube live stream video id on day of.

**Target Live Date:** 2019-11-11

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

