### PR TITLE
[Async Clipboard article] Fix typo: blog==>blob

### DIFF
--- a/src/content/en/updates/2019/07/image-support-for-async-clipboard.md
+++ b/src/content/en/updates/2019/07/image-support-for-async-clipboard.md
@@ -133,16 +133,16 @@ To write an image to the clipboard, you need the image as a
 this is by requesting the image from an server by calling `fetch()` (or
 `XMLHTTPReuest()`). The `response` object returned by `fetch()` has a [`blob()`
 method][blob-method] and
-`XMLHTTPRequest()` let's you set `"blob"` as the [`responseType`][blog-response-type].
+`XMLHTTPRequest()` let's you set `"blob"` as the [`responseType`][blob-response-type].
 
 Calling the server may not be desireable or possible for a variety of reasons.
 Fortunately, you can also write the image to a canvas, then call
-[`HTMLCanvasElement.toBlog()`][to-blob].
+[`HTMLCanvasElement.toBlob()`][to-blob].
 
 [blob]: https://developer.mozilla.org/en-US/docs/Web/API/blob
 [blob-method]: https://developer.mozilla.org/en-US/docs/Web/API/Body/blob
 [to-blob]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
-[blog-response-type]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType#Value
+[blob-response-type]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType#Value
 
 Next, pass an array of `ClipboardItem` objects as a parameter to the `write()` method.
 Currently you can only pass one image at a time, but we plan to add support for

--- a/src/content/en/updates/2019/07/image-support-for-async-clipboard.md
+++ b/src/content/en/updates/2019/07/image-support-for-async-clipboard.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Starting in Chrome 76, the Asynchronous Clipboard API now handles some images, in addition to text.
 
 {# wf_published_on: 2019-07-03 #}
-{# wf_updated_on: 2019-09-06 #}
+{# wf_updated_on: 2019-09-18 #}
 {# wf_featured_image: /web/updates/images/generic/photo.png #}
 {# wf_tags: capabilities,chrome76,cutandcopy,execcommand,input,clipboard #}
 {# wf_featured_snippet: Chrome 76 adds expands the functionality of the Async Clipboard API to add support for png images. Copying and pasting images to the clipboard has never been easier. #}


### PR DESCRIPTION
Thanks, @ChristianLiebel for reporting this.

What's changed, or what was fixed?
- Fixes typo: blog ==> blob

**Target Live Date:** any

- [X] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
