### PR TITLE
Fix devsite-v2 style issues in Site Kit pages

### DIFF
--- a/src/content/en/site-kit/apikey.html
+++ b/src/content/en/site-kit/apikey.html
@@ -9,47 +9,53 @@
     <style>
       .button-large {
         height: 52px;
-        padding: 16px 36px;
+        line-height: 52px;
       }
     </style>
   </head>
   <body>
-    <div id="site-kit-setup">
-      {% dynamic if request.query_string.sitename %}
-        {% dynamic setvar projectName %}{% dynamic print request.query_string.sitename|escape %}{% dynamic endsetvar %}
-      {% dynamic endif %}
-      {% dynamic if request.query_string.siteurl %}
-        {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
-      {% dynamic endif %}
-      {% dynamic if request.query_string.warn_adblocker %}
-        <aside class="warning">
-          <strong>Warning:</strong>
-          <span>It looks like you are using an adblocker. You must temporarily disable it before clicking the button below.</span>
-        </aside>
-      {% dynamic endif %}
-      <p>
-        Once the project has been created, you will see the API key. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
-      </p>
-      <p>
-        <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"
-          data-henhouse-header-text="Site Kit: Get API Key"
-          data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
-          data-henhouse-use-updated-header="true"
-          data-api-id="servicemanagement.googleapis.com"
-          data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
-          data-henhouse-credential-type="API_KEY"
-          {% dynamic if user.signed_in and setvar.projectName and setvar.productName %}
-            data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"
-            data-henhouse-product-name="{% dynamic print setvar.productName|escape %}"
-            data-henhouse-create-new-project-by-default="true"
-          {% dynamic endif %}
-        >
-          Get API Key
-        </a>
-      </p>
-      <p>
-        <small>By clicking the button, you are confirming that your site is running the official <a href="https://sitekit.withgoogle.com" target="_blank">Site Kit plugin for WordPress</a>.</small>
-      </p>
-    </div>
+    <section class="devsite-landing-row devsite-landing-row-1-up devsite-landing-row-50">
+      <div class="devsite-landing-row-group">
+        <div class="devsite-landing-row-item">
+          <div id="site-kit-setup">
+            {% dynamic if request.query_string.sitename %}
+              {% dynamic setvar projectName %}{% dynamic print request.query_string.sitename|escape %}{% dynamic endsetvar %}
+            {% dynamic endif %}
+            {% dynamic if request.query_string.siteurl %}
+              {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
+            {% dynamic endif %}
+            {% dynamic if request.query_string.warn_adblocker %}
+              <aside class="warning">
+                <strong>Warning:</strong>
+                <span>It looks like you are using an adblocker. You must temporarily disable it before clicking the button below.</span>
+              </aside>
+            {% dynamic endif %}
+            <p>
+              Once the project has been created, you will see the API key. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
+            </p>
+            <p>
+              <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"
+                data-henhouse-header-text="Site Kit: Get API Key"
+                data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
+                data-henhouse-use-updated-header="true"
+                data-api-id="servicemanagement.googleapis.com"
+                data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
+                data-henhouse-credential-type="API_KEY"
+                {% dynamic if user.signed_in and setvar.projectName and setvar.productName %}
+                  data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"
+                  data-henhouse-product-name="{% dynamic print setvar.productName|escape %}"
+                  data-henhouse-create-new-project-by-default="true"
+                {% dynamic endif %}
+              >
+                Get API Key
+              </a>
+            </p>
+            <p>
+              <small>By clicking the button, you are confirming that your site is running the official <a href="https://sitekit.withgoogle.com" target="_blank">Site Kit plugin for WordPress</a>.</small>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
   </body>
 </html>

--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -26,66 +26,72 @@
       }
       .button-large {
         height: 52px;
-        padding: 16px 36px;
+        line-height: 52px;
       }
     </style>
   </head>
   <body>
-    <div id="site-kit-setup">
-      {% dynamic if request.query_string.sitename %}
-        {% dynamic setvar projectName %}{% dynamic print request.query_string.sitename|escape %}{% dynamic endsetvar %}
-      {% dynamic endif %}
-      {% dynamic if request.query_string.siteurl %}
-        {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
-        {% dynamic setvar redirectURI %}{% dynamic print request.query_string.siteurl|escape %}?oauth2callback=1{% dynamic endsetvar %}
-      {% dynamic endif %}
-      {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}
-      <p>
-        Confirm that the below values apply to your WordPress site:
-      </p>
-      <dl class="dl-fields">
-        <dt><span class="dl-field-name">Project Name:</span> <span id="site-kit-setup-project-name" class="dl-field-value">{% dynamic print setvar.projectName|escape%}</span></dt>
-        <dd class="dl-field-description">The title of your new Google Cloud Platform project.</dd>
-        <dt><span class="dl-field-name">Application Name:</span> <span id="site-kit-setup-product-name" class="dl-field-value">{% dynamic print setvar.productName|escape%}</span></dt>
-        <dd class="dl-field-description">The name of the app asking for consent, as publicly displayed to authenticating users.</dd>
-        <dt><span class="dl-field-name">Support Email:</span> <span id="site-kit-setup-support-email" class="dl-field-value">{% dynamic print user.email%}</span></dt>
-        <dd class="dl-field-description">The email address shown on the consent screen for user support.</dd>
-        <dt><span class="dl-field-name">Redirect URI:</span> <span id="site-kit-setup-redirect-uri" class="dl-field-value">{% dynamic print setvar.redirectURI|escape%}</span></dt>
-        <dd class="dl-field-description">The URI to redirect to after an authenticating user has granted consent.</dd>
-      </dl>
-      {% dynamic endif %}
-      {% dynamic if request.query_string.warn_adblocker %}
-        <aside class="warning">
-          <strong>Warning:</strong>
-          <span>It looks like you are using an adblocker. You must temporarily disable it before clicking the button below.</span>
-        </aside>
-      {% dynamic endif %}
-      <p>
-        Once the project has been created, you will see a client configuration snippet. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
-      </p>
-      <p>
-        <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"
-          data-henhouse-header-text="Site Kit: Get OAuth Credentials"
-          data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
-          data-henhouse-use-updated-header="true"
-          data-api-id="servicemanagement.googleapis.com"
-          data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
-          data-henhouse-credential-type="OAUTH"
-          data-henhouse-client-type="WEB_SERVER"
-          data-henhouse-display-entire-oauth-client-config="true"
-          {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}
-            data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"
-            data-henhouse-product-name="{% dynamic print setvar.productName|escape %}"
-            data-henhouse-oauth-redirect-uri="{% dynamic print setvar.redirectURI|escape %}"
-            data-henhouse-create-new-project-by-default="true"
-          {% dynamic endif %}
-        >
-          Get OAuth Credentials
-        </a>
-      </p>
-      <p>
-        <small>By clicking the button, you are confirming that your site is running the official <a href="https://sitekit.withgoogle.com" target="_blank">Site Kit plugin for WordPress</a>.</small>
-      </p>
-    </div>
+    <section class="devsite-landing-row devsite-landing-row-1-up devsite-landing-row-50">
+      <div class="devsite-landing-row-group">
+        <div class="devsite-landing-row-item">
+          <div id="site-kit-setup">
+            {% dynamic if request.query_string.sitename %}
+              {% dynamic setvar projectName %}{% dynamic print request.query_string.sitename|escape %}{% dynamic endsetvar %}
+            {% dynamic endif %}
+            {% dynamic if request.query_string.siteurl %}
+              {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
+              {% dynamic setvar redirectURI %}{% dynamic print request.query_string.siteurl|escape %}?oauth2callback=1{% dynamic endsetvar %}
+            {% dynamic endif %}
+            {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}
+            <p>
+              Confirm that the below values apply to your WordPress site:
+            </p>
+            <dl class="dl-fields">
+              <dt><span class="dl-field-name">Project Name:</span> <span id="site-kit-setup-project-name" class="dl-field-value">{% dynamic print setvar.projectName|escape%}</span></dt>
+              <dd class="dl-field-description">The title of your new Google Cloud Platform project.</dd>
+              <dt><span class="dl-field-name">Application Name:</span> <span id="site-kit-setup-product-name" class="dl-field-value">{% dynamic print setvar.productName|escape%}</span></dt>
+              <dd class="dl-field-description">The name of the app asking for consent, as publicly displayed to authenticating users.</dd>
+              <dt><span class="dl-field-name">Support Email:</span> <span id="site-kit-setup-support-email" class="dl-field-value">{% dynamic print user.email%}</span></dt>
+              <dd class="dl-field-description">The email address shown on the consent screen for user support.</dd>
+              <dt><span class="dl-field-name">Redirect URI:</span> <span id="site-kit-setup-redirect-uri" class="dl-field-value">{% dynamic print setvar.redirectURI|escape%}</span></dt>
+              <dd class="dl-field-description">The URI to redirect to after an authenticating user has granted consent.</dd>
+            </dl>
+            {% dynamic endif %}
+            {% dynamic if request.query_string.warn_adblocker %}
+              <aside class="warning">
+                <strong>Warning:</strong>
+                <span>It looks like you are using an adblocker. You must temporarily disable it before clicking the button below.</span>
+              </aside>
+            {% dynamic endif %}
+            <p>
+              Once the project has been created, you will see a client configuration snippet. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
+            </p>
+            <p>
+              <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"
+                data-henhouse-header-text="Site Kit: Get OAuth Credentials"
+                data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
+                data-henhouse-use-updated-header="true"
+                data-api-id="servicemanagement.googleapis.com"
+                data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
+                data-henhouse-credential-type="OAUTH"
+                data-henhouse-client-type="WEB_SERVER"
+                data-henhouse-display-entire-oauth-client-config="true"
+                {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}
+                  data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"
+                  data-henhouse-product-name="{% dynamic print setvar.productName|escape %}"
+                  data-henhouse-oauth-redirect-uri="{% dynamic print setvar.redirectURI|escape %}"
+                  data-henhouse-create-new-project-by-default="true"
+                {% dynamic endif %}
+              >
+                Get OAuth Credentials
+              </a>
+            </p>
+            <p>
+              <small>By clicking the button, you are confirming that your site is running the official <a href="https://sitekit.withgoogle.com" target="_blank">Site Kit plugin for WordPress</a>.</small>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
This PR fixes most obvious styling issues on devsite-v2.

There are a couple of other issues to be figured out following the transition, for example the [`description`](https://github.com/google/WebFundamentals/blob/master/src/content/en/site-kit/_project.yaml#L3) is no longer visible in v2, and furthermore no `<title>` tag is present.

**Target Live Date:** 2019-09-20

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
