### PR TITLE
Fix simple typo in Introduction to variable fonts

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/typography/variable-fonts/index.md
+++ b/src/content/en/fundamentals/design-and-ux/typography/variable-fonts/index.md
@@ -321,7 +321,7 @@ for more details.
 It is possible to use @supports in your CSS to create a viable fallback:
 
 ```
-@supports (font-variations-settings: 'wdth' 200) {
+@supports (font-variation-settings: 'wdth' 200) {
   @font-face {
     /* https://github.com/TypeNetwork/Amstelvar */
     font-family: AmstelvarAlpha;


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes a typo in the fallback example for using font-variation-settings
- Took me a few minutes to notice why that @support didn't work

**CC:** @petele
