### PR TITLE
Fix unbalanced tags causing a rendering error

### DIFF
--- a/src/content/en/fundamentals/codelabs/offline/index.md
+++ b/src/content/en/fundamentals/codelabs/offline/index.md
@@ -216,10 +216,9 @@ The next step is to program our service worker to return the intercept the reque
 <li>Why do you have ?homescreen=1</li>
 <li>
 <p>URLs with query string parameters are treated as individual URLs and need to be cached separately.</p>
-</aside>
 </li>
 </ul>
-
+</aside>
 
 
 ## Intercept the web page requests


### PR DESCRIPTION
Fixes rendering error where content after aside is shown in raw markdown (From "## Intercept the web page requests" onward)

Filed as https://github.com/google-developer-training/pwa-ecommerce-demo/issues/19

What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
