### PR TITLE
fix(chrome-devtools/coverage): typo "instrumeting"

### DIFF
--- a/src/content/en/tools/chrome-devtools/coverage/index.md
+++ b/src/content/en/tools/chrome-devtools/coverage/index.md
@@ -83,8 +83,8 @@ for the following reasons:
        if you want to see what code is needed to load the page.
      * Click **Instrument Coverage** ![Instrument Coverage][record]{: .inline-icon }
        if you want to see what code is used after interacting with the page.
-1. Click **Stop Instrumeting Coverage And Show Results** 
-   ![Stop Instrumeting Coverage And Show Results][stop]{: .inline-icon } when you want to 
+1. Click **Stop Instrumenting Coverage And Show Results** 
+   ![Stop Instrumenting Coverage And Show Results][stop]{: .inline-icon } when you want to 
    stop recording code coverage.
 
 ## Analyze code coverage {: #analyze }


### PR DESCRIPTION
What's changed, or what was fixed?
- fix typo: "instrumeting" → "instrumenting" 

**Fixes:** #8156

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
