### PR TITLE
Fix to Fundamentals index page

### DIFF
--- a/src/content/en/fundamentals/_index.yaml
+++ b/src/content/en/fundamentals/_index.yaml
@@ -108,7 +108,7 @@ landing_page:
       path: web-components/
       buttons:
       - label: Learn more
-        path: web-components/
+        path: /web/fundamentals/web-components/
         classname: button button-white
 
     - image_path: images/pay-req.png


### PR DESCRIPTION
What's changed, or what was fixed?
- updated /web-components to /web/fundamentals/web-components on the Learn more button

**Fixes:** #8204 

**CC:** @petele
