### PR TITLE
Improve "see all" blurb.

### DIFF
--- a/src/content/en/updates/_shared/see-all-dep-rem.html
+++ b/src/content/en/updates/_shared/see-all-dep-rem.html
@@ -1,4 +1,5 @@
 <aside class="note">
-  To see deprecations and removals for this and previous versions of Chrome,
-  visit the <a href='/web/updates/tags/deprecations'>deprecations page</a> or the <a href='/web/updates/tags/removals'>removals page</a>.
+  Visit ChromeStatus.com for lists of 
+  <a href="https://www.chromestatus.com/features#browsers.chrome.status%3A%22Deprecated%22">current deprecations</a>
+  and <a href="https://www.chromestatus.com/features#browsers.chrome.status:%22Removed%22">previous removals</a>.  
 </aside>


### PR DESCRIPTION
What's changed, or what was fixed?
Changes the wording of the 'see all deps/rems' blurb. Readers should have to yo-yo in and out of a years worth of posts to learn what's currently deprecated.

- [ ] This has been reviewed and approved by @petele 
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
