### PR TITLE
Indicate browser support for constructable stylesheets

### DIFF
--- a/src/content/en/updates/2019/02/constructable-stylesheets.md
+++ b/src/content/en/updates/2019/02/constructable-stylesheets.md
@@ -17,6 +17,10 @@ description: Shipping in Chrome 73, Constructable Stylesheets provide a seamless
 new way to create and distribute reusable styles when using [Shadow
 DOM](/web/fundamentals/web-components/shadowdom). 
 
+> Note: As of October 2019, Constructable Stylesheets are only available in Chrome
+> (versions 73 and higher). [Support in other browsers can be tracked
+> here](https://chromestatus.com/feature/5394843094220800).
+
 It has always been possible to create stylesheets using JavaScript. However, the
 process has historically been to create a `<style>` element using
 `document.createElement('style')`, and then access its sheet property to obtain


### PR DESCRIPTION
What's changed, or what was fixed?
- Indicate browser support for constructable stylesheets, by linking to https://chromestatus.com/feature/5394843094220800

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
