### PR TITLE
Migration review of getInstalledRelatedApps().

### DIFF
--- a/src/content/en/updates/2018/12/get-installed-related-apps.md
+++ b/src/content/en/updates/2018/12/get-installed-related-apps.md
@@ -1,12 +1,12 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
-description: The getInstalledRelatedApps API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa..
+description: The getInstalledRelatedApps() method allows your web app to check whether your native app is installed on a user's device, and vice versa.
 
 {# wf_published_on: 2018-12-20 #}
-{# wf_updated_on: 2019-10-01 #}
+{# wf_updated_on: 2019-10-10 #}
 {# wf_featured_image: /web/updates/images/generic/focus.png #}
 {# wf_tags: capabilities,progressive-web-apps,webapp,webapk,native,chrome73,origintrials #}
-{# wf_featured_snippet: As the capability gap between web and native gets smaller, it becomes easier to offer the same experience for both web and native users. This may lead to cases where users have both the web and native versions installed on the same device. Apps should be able to detect this situation. The <code>getInstalledRelatedApps</code> API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa.  #}
+{# wf_featured_snippet: As the capability gap between web and native gets smaller, it gets easier to offer the same experience for both web and native users. This may lead to cases where users have both web and native versions of the same app installed on the same device. Apps should be able to detect this situation. The <code>getInstalledRelatedApps()</code> API is a new web platform API that allows your web app to check to see if your native app is installed on the users device, and vice versa.  #}
 {# wf_blink_components: Mobile>WebAPKs #}
 
 {# When updating this post, don't forget to update /updates/capabilities.md #}
@@ -25,7 +25,7 @@ description: The getInstalledRelatedApps API is a new web platform API that allo
   <b>Last Updated:</b> March 12th, 2019
 </aside>
 
-## What is the `getInstalledRelatedApps` API? {: #what }
+## What is the `getInstalledRelatedApps()` API? {: #what }
 
 <figure class="attempt-right">
   <img src="/web/updates/images/2018/12/getinstalled-cropped.jpg">
@@ -35,16 +35,15 @@ description: The getInstalledRelatedApps API is a new web platform API that allo
   </figcaption>
 </figure>
 
-As the capability gap between web and native gets smaller, it becomes easier
-to offer the same experience for both web and native users. This may lead to
-cases where users have both the web and native versions installed on the same
-device. Apps should be able to detect this situation.
+As the capability gap between web and native gets smaller, it gets easier to
+offer the same experience for both web and native users. This may lead to cases
+where users have both web and native versions of the same app installed on the
+same device. Apps should be able to detect this situation.
 
-The `getInstalledRelatedApps` API is a new web platform API that allows
-your web app to check to see if your native app is installed on the users
-device, and vice versa. With the `getInstalledRelatedApps` API, you can
-disable some functionality of one app if it should be provided by the other
-app instead.
+The `getInstalledRelatedApps()` method allows your web app to check if your
+native app is installed on a user's device, and vice versa. With
+`getInstalledRelatedApps()`, you can disable some functionality of one app if it
+should be provided by the other app instead.
 
 If `getInstalledRelatedApps()` looks familiar, it is. We originally announced
 this feature in April 2017, when it first went to an origin trial. After that
@@ -57,14 +56,13 @@ on this design.
 
 ### Suggested use cases {: #use-cases }
 
-There may be some cases where there isn’t feature parity between the web and
-native apps. With the `getInstalledRelatedApps` API, you can check if the
-other version is installed, and switch to the other app, using the
-functionality there. For example, one of the most common scenarios we’ve
-heard, and the key reason behind this API is to help reduce duplicate
-notifications. Using the `getInstalledRelatedApps` API, allows you check to
-see if the user has the native app installed, then disable the notification
-functionality in the web app.
+There may be cases where there isn’t feature parity between your web and native
+apps. With `getInstalledRelatedApps()`, you can check if the other version is
+installed, and switch to it, using the functionality there. For example, one of
+the most common scenarios we’ve heard, and the key reason behind this method is
+to reduce duplicate notifications. Using `getInstalledRelatedApps()` allows you
+check to see if the user has the native app installed, then disable the
+notification functionality in the web app.
 
 Installable web apps can help prevent confusion between the web and native
 versions by checking to see if the native version is already installed and
@@ -77,53 +75,23 @@ either not prompting to install the PWA, or providing different prompts.
 | 1. Create explainer                          | [Complete][explainer]        |
 | **2. Create initial draft of specification** | [**In Progress**][spec]      |
 | **3. Gather feedback & iterate on design**   | [**In Progress**](#feedback) |
-| **4. Origin trial**                          | [**In Progress**](#ot)       |
-| 5. Launch                                    | Not started                  |
+| **4. Origin trial**                          | Complete                     |
+| 5. Launch                                    | In beta                      |
 
-### See it in action
+## See it in action
 
-1. Using Chrome 73 or later on Android, open the [`getInstalledRelatedApps()` demo][demo].
-   Note, this site uses an origin trial token to enable the API.
+1. Using Chrome 79 or later on Android, open the [`getInstalledRelatedApps()` demo][demo].
 2. Install the demo app from the Play store and refresh the [demo][demo] page.
    You should now see the app listed.
 
-## How to use the `getInstalledRelatedApps()` API {: #use }
+## How to use `getInstalledRelatedApps()` {: #use } {: #relationship }
 
-Starting in Chrome 73, the `getInstalledRelatedApps()` API is available as an
-origin trial for Android. [Origin trials][ot-what-is] allow you to try out
-new features and give feedback on usability, practicality, and effectiveness
-to us, and the web standards community. For more information, see the
-[Origin Trials Guide for Web Developers][ot-dev-guide].
+To use `getInstalledRelatedApps()`, you must first create a relationship between
+your two apps. This relationship prevents other apps from using the API to
+detect if your app is installed, and prevents sites from collecting information
+about the apps you have installed on your device.
 
-Check out the [`getInstalledRelatedApps()` API Demo][demo] and
-[`getInstalledRelatedApps()` API Demo source][demo-source]
-
-### Register for the origin trial {: #ot }
-
-1. [Request a token][ot-request] for your origin.
-2. Add the token to your pages. There are two ways to provide this token on
-   any pages in your origin:
-     * Add an `origin-trial` `<meta>` tag to the head of any page. For example,
-       this may look something like:
-       `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
-     * If you can configure your server, you can also provide the token on pages
-       using an `Origin-Trial` HTTP header. The resulting response header should
-       look something like: `Origin-Trial: TOKEN_GOES_HERE`
-
-### Alternatives to the origin trial
-
-If you want to experiment with the API locally, without an origin trial,
-enable the `#enable-experimental-web-platform-features` flag in `chrome://flags`.
-
-### Establish a relationship between your apps {: #relationship }
-
-In order to use the `getInstalledRelatedApps()`, you must first create a
-relationship between your two apps. This relationship is critical and prevents
-other apps from using the API to detect if your app is installed, and prevents
-sites from collecting information about the apps you have installed on your
-device.
-
-#### Define the relationship to your native app {: #relationship-web }
+### Define the relationship to your native app {: #relationship-web }
 
 In your [web app manifest](/web/fundamentals/web-app-manifest), add a
 `related_applications` property that contains a list of the apps that you want
@@ -146,12 +114,12 @@ your app on that platform.
 The `url` property is optional, and the API works fine without it. On Android,
 the `platform` must be `play`. On other devices, `platform` will be different.
 
-#### Define the relationship to your web app {: #relationship-native }
+### Define the relationship to your web app {: #relationship-native }
 
 Each platform has its own method of verifying a relationship. On Android, the
-[Digital Asset Links system](/digital-asset-links/v1/getting-started) is used
-to define the association between a website and an application. On other
-platforms, the way you define the relationship will differ slightly.
+[Digital Asset Links system](/digital-asset-links/v1/getting-started) defines
+the association between a website and an application. On other platforms, the
+way you define the relationship will differ slightly.
 
 In `AndroidManifest.xml`, add an asset statement that links back to your web
 app:
@@ -184,13 +152,14 @@ your domain. Be sure to include the escaping characters.
 ### Test for the presence of your native app {: #test-native }
 
 Once you’ve updated your native app and added the appropriate fields to the
-web app manifest, you can add the code to check for the presence of your native
-app to you web app. Calling `navigator.getInstalledRelatedApps()` returns a
-`Promise` that resolves with an array of your apps that are installed on the
+web app manifest, add code to check for the presence of your native
+app to your web app. Calling `navigator.getInstalledRelatedApps()` returns a
+`promise` that resolves with an array of your apps that are installed on the
 user's device.
 
 ```js
-navigator.getInstalledRelatedApps().then((relatedApps) => {
+navigator.getInstalledRelatedApps()
+.then((relatedApps) => {
   relatedApps.forEach((app) => {
     console.log(app.id, app.platform, app.url);
   });

--- a/src/content/en/updates/2018/12/get-installed-related-apps.md
+++ b/src/content/en/updates/2018/12/get-installed-related-apps.md
@@ -78,6 +78,34 @@ either not prompting to install the PWA, or providing different prompts.
 | **4. Origin trial**                          | Complete                     |
 | 5. Launch                                    | In beta                      |
 
+## Join the origin trial {: #origin-trial }
+
+Starting in Chrome 73, the `getInstalledRelatedApps()` API is available as an
+origin trial for Android. [Origin trials][ot-what-is] allow you to try out
+new features and give feedback on usability, practicality, and effectiveness
+to us, and the web standards community. For more information, see the
+[Origin Trials Guide for Web Developers][ot-dev-guide].
+
+Check out the [`getInstalledRelatedApps()` API Demo][demo] and
+[`getInstalledRelatedApps()` API Demo source][demo-source]
+
+### Register for the origin trial {: #ot }
+
+1. [Request a token][ot-request] for your origin.
+2. Add the token to your pages. There are two ways to provide this token on
+   any pages in your origin:
+     * Add an `origin-trial` `<meta>` tag to the head of any page. For example,
+       this may look something like:
+       `<meta http-equiv="origin-trial" content="TOKEN_GOES_HERE">`
+     * If you can configure your server, you can also provide the token on pages
+       using an `Origin-Trial` HTTP header. The resulting response header should
+       look something like: `Origin-Trial: TOKEN_GOES_HERE`
+
+### Alternatives to the origin trial
+
+If you want to experiment with the API locally, without an origin trial,
+enable the `#enable-experimental-web-platform-features` flag in `chrome://flags`.
+
 ## See it in action
 
 1. Using Chrome 79 or later on Android, open the [`getInstalledRelatedApps()` demo][demo].


### PR DESCRIPTION
What's changed, or what was fixed?
Review of getInstalledRelatedApps() in prep for migration to web.dev.

**Fixes:** https://github.com/GoogleChrome/web.dev/issues/1644

**Target Live Date:** 2019-10-31, on web.dev

- [ ] This has been reviewed and approved by @petele.
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
