### PR TITLE
Correct example used for "Relative sized images"

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/responsive/images.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/images.md
@@ -246,8 +246,8 @@ browser would choose:
     <tr>
       <td data-th="Browser width">1100px</td>
       <td data-th="Device pixel ratio">1</td>
-      <td data-th="Image used"><code>1400.png</code></td>
-      <td data-th="Effective resolution">1.27x</td>
+      <td data-th="Image used"><code>800.png</code></td>
+      <td data-th="Effective resolution">1.45x</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Changes the last example on "Relative sized images" to ensure it shows the correct results, as per issue #8219.

**Fixes:** #8219

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
