### PR TITLE
Update file type used in "Relative sized images"

### DIFF
--- a/src/content/en/fundamentals/design-and-ux/responsive/images.md
+++ b/src/content/en/fundamentals/design-and-ux/responsive/images.md
@@ -216,37 +216,37 @@ browser would choose:
     <tr>
       <td data-th="Browser width">400px</td>
       <td data-th="Device pixel ratio">1</td>
-      <td data-th="Image used"><code>200.png</code></td>
+      <td data-th="Image used"><code>200.jpg</code></td>
       <td data-th="Effective resolution">1x</td>
     </tr>
     <tr>
       <td data-th="Browser width">400px</td>
       <td data-th="Device pixel ratio">2</td>
-      <td data-th="Image used"><code>400.png</code></td>
+      <td data-th="Image used"><code>400.jpg</code></td>
       <td data-th="Effective resolution">2x</td>
     </tr>
     <tr>
       <td data-th="Browser width">320px</td>
       <td data-th="Device pixel ratio">2</td>
-      <td data-th="Image used"><code>400.png</code></td>
+      <td data-th="Image used"><code>400.jpg</code></td>
       <td data-th="Effective resolution">2.5x</td>
     </tr>
     <tr>
       <td data-th="Browser width">600px</td>
       <td data-th="Device pixel ratio">2</td>
-      <td data-th="Image used"><code>800.png</code></td>
+      <td data-th="Image used"><code>800.jpg</code></td>
       <td data-th="Effective resolution">2.67x</td>
     </tr>
     <tr>
       <td data-th="Browser width">640px</td>
       <td data-th="Device pixel ratio">3</td>
-      <td data-th="Image used"><code>1000.png</code></td>
+      <td data-th="Image used"><code>1000.jpg</code></td>
       <td data-th="Effective resolution">3.125x</td>
     </tr>
     <tr>
       <td data-th="Browser width">1100px</td>
       <td data-th="Device pixel ratio">1</td>
-      <td data-th="Image used"><code>1400.png</code></td>
+      <td data-th="Image used"><code>1400.jpg</code></td>
       <td data-th="Effective resolution">1.27x</td>
     </tr>
   </tbody>


### PR DESCRIPTION
The demo and source code both use `.jpg` whilst the table uses `.png`. For consistency, I have changed these all to `.jpg` as per issue #8220.

**Fixes:** #8220 

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
