### PR TITLE
fix external url reference typo

### DIFF
--- a/src/content/en/tools/workbox/guides/troubleshoot-and-debug.md
+++ b/src/content/en/tools/workbox/guides/troubleshoot-and-debug.md
@@ -90,7 +90,7 @@ worker like so:
 navigator.serviceWorker.register('/blog/sw.js', {scope: '/'});
 ```
 
-You can [learn more about service worker scope here]('/web/fundamentals/primers/service-workers/lifecycle#scope_and_control').
+You can [learn more about service worker scope here](/web/fundamentals/primers/service-workers/lifecycle#scope_and_control).
 
 **_Q:_** Why are changes to my service worker not shown?
 


### PR DESCRIPTION
What's changed, or what was fixed?
- fix external url reference typo on `learn more about service worker scope here`

**Fixes:**
https://github.com/google/WebFundamentals/issues/8226

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
