### PR TITLE
Fixes to Aligned Input Events

### DIFF
--- a/src/content/en/updates/2017/06/aligning-input-events.md
+++ b/src/content/en/updates/2017/06/aligning-input-events.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Providing a smooth user experience is important for the web. Over the past few releases of Chrome we have driven down input latency across these devices.
 
-{# wf_updated_on: 2017-06-27 #}
+{# wf_updated_on: 2019-10-18 #}
 {# wf_published_on: 2017-06-22 #}
 {# wf_tags: chrome58,chrome60,events,performance,ux #}
 {# wf_featured_image: /web/updates/images/2017/06/jank.png #}
@@ -21,10 +21,10 @@ description: Providing a smooth user experience is important for the web. Over t
 
 Providing a smooth user experience is important for the web. The time between
 receiving an input event and when the visuals actually update is important and
-generally doing less work is important. Over the past few releases of Chrome we
+generally doing less work is important. Over the past few releases of Chrome, we
 have driven down input latency across these devices.
 
-In the interest of smoothness and performance, in Chrome 60 we are making a
+In the interest of smoothness and performance, in Chrome 60, we are making a
 change that causes these events to occur at a lower frequency while increasing
 the granularity of the information provided. Much like when [Jelly
 Bean](https://developer.android.com/about/versions/jelly-bean.html) was released
@@ -33,8 +33,8 @@ and brought the
 which aligns input on Android, we are bringing frame aligned input to the web
 on all platforms.
 
-But sometimes you need more events. So, in in
-[Chrome 58](https://www.chromestatus.com/feature/5853451217010688) we implemented
+But sometimes you need more events. So, in
+[Chrome 58](https://www.chromestatus.com/feature/5853451217010688), we implemented
 a method called
 [`getCoalescedEvents()`](https://w3c.github.io/pointerevents/extension.html), which
 lets your application retrieve the full path of the pointer even while it's
@@ -51,7 +51,7 @@ means that we receive input at a higher rate than we actually update the display
 at. So let's look at a performance timeline from devtools for a simple canvas
 [painting app](https://rbyers.github.io/paint.html).
 
-In the picture below with `requestAnimationFrame()`-aligned input disabled you
+In the picture below, with `requestAnimationFrame()`-aligned input disabled, you
 can see multiple processing blocks per frame with an inconsistent frame time.
 The small  yellow blocks indicate hit testing for such things as the target of
 the DOM event, dispatching the event, running javascript, updating the hovered
@@ -62,9 +62,9 @@ node and possibly re-calculating layout and styles.
        alt="A performance timeline showing inconsistent frame timing."/>
 </figure>
 
-So why are we doing extra work that doesn't cause any visual updates? Ideally we
+So why are we doing extra work that doesn't cause any visual updates? Ideally, we
 don't want to do any work that doesn't ultimately benefit the user. Starting in
-Chrome 60 the input pipeline will delay dispatching continuous events
+Chrome 60, the input pipeline will delay dispatching continuous events
 ([`wheel`](https://developer.mozilla.org/en/docs/Web/Events/wheel),
 [`mousewheel`](https://developer.mozilla.org/en/docs/Web/Events/mousewheel),
 [`touchmove`](https://developer.mozilla.org/en/docs/Web/Events/touchmove),
@@ -72,7 +72,7 @@ Chrome 60 the input pipeline will delay dispatching continuous events
 [`mousemove`](https://developer.mozilla.org/en/docs/Web/Events/mousemove)) and
 dispatch them right before the
 [`requestAnimationFrame()` callback](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)
-occurs. In the picture below (with the feature enabled) you see a more
+occurs. In the picture below (with the feature enabled), you see a more
 consistent frame time and less time processing events.
 
 We have been running an experiment with this feature enabled on the Canary and
@@ -87,7 +87,7 @@ event (such as [`keydown`](https://developer.mozilla.org/en/docs/Web/Events/keyd
 [`touchstart`](https://developer.mozilla.org/en/docs/Web/Events/touchstart),
 [`touchend`](https://developer.mozilla.org/en/docs/Web/Events/touchend)) that
 occurs will be dispatched right away along with any pending events, preserving
-the relative ordering. With this feature enabled a lot of the work is
+the relative ordering. With this feature enabled, a lot of the work is
 streamlined into the normal [event loop](https://github.com/atotic/event-loop)
 flow, providing a consistent input interval. This brings continuous events
 inline with [`scroll`](https://developer.mozilla.org/en-US/docs/Web/Events/scroll)
@@ -103,15 +103,15 @@ We've found that the vast majority of applications consuming such events have no
 use for the higher frequency. Android has already aligned events for a number of
 years so nothing there is new, but sites may experience less granular events on
 desktop platforms. There has always been a problem with janky main threads
-causing hiccups for input smoothness meaning that you might see jumps in
+causing hiccups for input smoothness, meaning that you might see jumps in
 position whenever the application is doing work, making it impossible to know
 how the pointer got from one spot to the other.
 
-## The getCoalescedEvents() method
+## The `getCoalescedEvents()` method
 
 As I said, there are rare scenarios where the application would prefer to know
 the full path of the pointer. So to fix the case where you see large jumps and
-the reduced frequency of events, in [Chrome 58](https://www.chromestatus.com/feature/5853451217010688)
+the reduced frequency of events, in [Chrome 58](https://www.chromestatus.com/feature/5853451217010688),
 we launched an extension to pointer events called
 [`getCoalescedEvents()`](https://w3c.github.io/pointerevents/extension.html). And
 below is an example of how jank on the main thread is hidden from the
@@ -128,11 +128,10 @@ application if you use this API.
   </iframe>
 </div>
  
-Instead of receiving a single event you can access the array of historical
-events that caused the event.
-[Android
-](https://developer.android.com/reference/android/view/MotionEvent.html#getHistoricalX(int,%20int))
-, [iOS](https://developer.apple.com/reference/uikit/uievent/1613808-coalescedtouchesfortouch)
+Instead of receiving a single event, you can access the array of historical
+events that caused the event. [Android](
+https://developer.android.com/reference/android/view/MotionEvent.html#getHistoricalX(int,%20int)),
+[iOS](https://developer.apple.com/reference/uikit/uievent/1613808-coalescedtouchesfortouch),
 and [Windows](https://msdn.microsoft.com/en-us/library/windows/desktop/hh454886(v=vs.85).aspx)
 all have very similar APIs in their native SDKs and we are exposing a similar
 API to the web.
@@ -141,7 +140,7 @@ Typically a drawing app may have drawn a point by looking at the offsets on the
 event:
 
     window.addEventListener("pointermove", function(event) {
-      drawPoint(event.pageX, event.pageY)
+      drawPoint(event.pageX, event.pageY);
     });
 
 This code can easily be changed to use the array of events:
@@ -149,13 +148,13 @@ This code can easily be changed to use the array of events:
     window.addEventListener("pointermove", function(event) {
       var events = 'getCoalescedEvents' in event ? event.getCoalescedEvents() : [event];
       for (let e of events) {
-        drawPoint(e.pageX, e.pageY)
+        drawPoint(e.pageX, e.pageY);
       }
     });
 
 Note that not every property on the coalesced events is populated. Since the
-coalesced events are not really dispatched but are just along for the ride they
-aren't hit tested. Some fields such as currentTarget, and eventPhase will have
+coalesced events are not really dispatched but are just along for the ride, they
+aren't hit tested. Some fields such as `currentTarget`, and `eventPhase` will have
 their default values. Calling dispatch related methods such as `stopPropagation()`
 or `preventDefault()` will have no effect on the parent event.
 


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Aligned Input Events*](https://developers.google.com/web/updates/2017/06/aligning-input-events) article,

- Added missing commas.
- Removed an extra "in".
- Added backticks where missing.
- Removed a space before a comma.
- Added missing semicolons in code snippets.

**CC:** @petele
