### PR TITLE
Fixes to the Expand & collapse animations article

### DIFF
--- a/src/content/en/updates/2017/03/performant-expand-and-collapse.md
+++ b/src/content/en/updates/2017/03/performant-expand-and-collapse.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: When making expand and collapse effects you can use scale transforms to keep your UI performant.
 
-{# wf_updated_on: 2017-11-07 #}
+{# wf_updated_on: 2019-10-21 #}
 {# wf_published_on: 2017-03-23 #}
 {# wf_tags: performance #}
 {# wf_featured_image: /web/updates/images/2017/03/performant-expand-and-collapse/featured-image.jpg #}
@@ -22,7 +22,7 @@ stretched and skewed during the animation by counter-scaling them.
 Previously we’ve posted updates on how to create performant
 [parallax effects](/web/updates/2016/12/performant-parallaxing) and
 [infinite scrollers](/web/updates/2016/07/infinite-scroller). In this
-post we’re going to look over what’s involved if you want performant clip
+post, we’re going to look over what’s involved if you want performant clip
 animations. If you want to see a
 [demo](https://googlechromelabs.github.io/ui-element-samples/animated-clip/),
 check out the [Sample UI Elements GitHub
@@ -45,20 +45,22 @@ Some options for building this are more performant than others.
 
 You could imagine using a bit of CSS to animate the width and height on the container element.
 
-    .menu {
-      overflow: hidden;
-      width: 350px;
-      height: 600px;
-      transition: width 600ms ease-out, height 600ms ease-out;
-    }
+```css
+.menu {
+  overflow: hidden;
+  width: 350px;
+  height: 600px;
+  transition: width 600ms ease-out, height 600ms ease-out;
+}
 
-    .menu--collapsed {
-      width: 200px;
-      height: 60px;
-    }
+.menu--collapsed {
+  width: 200px;
+  height: 60px;
+}
+```
 
 The immediate problem with this approach is that it requires animating `width` and `height`.
-These properties require calculating layout and paint the results on every frame of the animation,
+These properties require calculating layout and paint on every frame of the animation,
 which can be very expensive, and will typically cause you to miss out on 60fps. If that’s news to
 you then read our
 [Rendering Performance](/web/fundamentals/performance/rendering/)
@@ -72,15 +74,17 @@ instead. Using `clip-path`, however, is [less well supported](http://caniuse.com
 than `clip`. But `clip` is deprecated. Right. But don’t despair, this isn’t the solution you wanted
 anyway!
 
-    .menu {
-      position: absolute;
-      clip: rect(0px 112px 175px 0px);
-      transition: clip 600ms ease-out;
-    }
+```css
+.menu {
+  position: absolute;
+  clip: rect(0px 112px 175px 0px);
+  transition: clip 600ms ease-out;
+}
 
-    .menu--collapsed {
-      clip: rect(0px 70px 34px 0px);
-    }
+.menu--collapsed {
+  clip: rect(0px 70px 34px 0px);
+}
+```
 
 While better than animating the `width` and `height` of the menu element, the downside of this
 approach is that it still triggers paint. Also the `clip` property, should you go that route,
@@ -118,11 +122,11 @@ since they were last run.
       return {
         x: collapsed.width / expanded.width,
         y: collapsed.height / expanded.height
-      }
+      };
     }
 
 In the case of something like a menu, we can make the reasonable assumption that it will start out
-being its natural scale (1, 1). This natural scale represents its expanded state meaning you will
+being in its natural scale (1, 1). This natural scale represents its expanded state, meaning you will
 need to animate from a scaled down version (which was calculated above) back up to that natural
 scale.
 
@@ -150,7 +154,7 @@ browsers, `backface-visiblity: hidden`.
 
 2. **The counter-transform must be calculated per frame.** This is where things can get a little
 trickier, because assuming that the animation is in CSS and uses an easing function, the easing
-itself need to be countered when animating the counter-transform. However, calculating the inverse
+itself needs to be countered when animating the counter-transform. However, calculating the inverse
 curve for — say — `cubic-bezier(0, 0, 0.3, 1)` isn’t all that obvious.
 
 It may be tempting, then, to consider animating the effect using JavaScript. After all, you could
@@ -167,7 +171,7 @@ Robert Flack for pointing this out!) The primary benefit of this is that a keyfr
 mutates transforms can be run on the compositor, meaning that it isn’t affected by tasks on the
 main thread.
 
-To make the keyframe animation we step from 0 to 100 and calculate what scale values would be
+To make the keyframe animation, we step from 0 to 100 and calculate what scale values would be
 needed for the element and its contents. These can then be boiled down to a string, which can
 be injected into the page as a style element. Injecting the styles will cause a Recalculate Styles
 pass on the page, which is additional work that the browser has to do, but it will do it only
@@ -219,7 +223,7 @@ something like this to map values from 0 to 1 to an eased equivalent.
 
 You can use [Google search to plot what that looks
 like](https://www.google.com/search?q=1%20-%20%28%281-x%29%5E4%29%20from%200%20to%201)
-as well. Handy! If you’re in need of other easing equations do check out
+as well. Handy! If you’re in need of other easing equations, do check out
 [Tween.js by Soledad Penadés](https://github.com/tweenjs/tween.js/blob/master/src/Tween.js#L421-L737),
 which contains a whole heap of them.
 
@@ -228,25 +232,27 @@ which contains a whole heap of them.
 With these animations created and baked out to the page in JavaScript, the final step is to
 toggle classes enabling the animations.
 
-    .menu--expanded {
-      animation-name: menuAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: linear;
-    }
+```css
+.menu--expanded {
+  animation-name: menuAnimation;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+}
 
-    .menu__contents--expanded {
-      animation-name: menuContentsAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: linear;
-    }
+.menu__contents--expanded {
+  animation-name: menuContentsAnimation;
+  animation-duration: 0.2s;
+  animation-timing-function: linear;
+}
+```
 
-This causes the animations to run that were created in the previous step. Because the baked
+This causes the animations that were created in the previous step to run. Because the baked
 animations are already eased, the timing function needs to be set to `linear` otherwise you’ll
 ease between each keyframe which will look very weird!
 
-When it comes to collapsing the element back down there are two options: update the CSS animation
+When it comes to collapsing the element back down, there are two options: update the CSS animation
 to run in reverse rather than forwards. This will work just fine, but the "feel" of the animation
-will be reversed, so if you used an ease-out curve the reverse will feel eased *in*, which will
+will be reversed, so if you used an ease-out curve, the reverse will feel eased *in*, which will
 make it feel sluggish. A more appropriate solution is to create a *second pair* of animations for
 collapsing the element. These can be created in exactly the same way as the expand keyframe
 animations, but with swapped start and end values.
@@ -268,13 +274,13 @@ It’s also possible to use this technique to make circular expand and collapse 
 </div>
 
 The principles are largely the same as the previous version, where you scale an element, and
-counter-scale its immediate children. In this case the element that’s scaling up has
+counter-scale its immediate children. In this case, the element that’s scaling up has
 a `border-radius` of 50%, making it circular, and is wrapped by *another* element that
 has `overflow: hidden`, meaning that you don’t see the circle expand outside of the element bounds.
 
 A word of warning on this particular variant: Chrome has blurry text on low DPI screens during the
 animation because of rounding errors due to the scale and counter-scale of the text. If you’re
-interested in the details for that
+interested in the details for that,
 [there’s a bug filed that you can star and follow](https://crbug.com/704067).
 
 The code for the circular expand effect can be found in
@@ -283,16 +289,16 @@ The code for the circular expand effect can be found in
 ## Conclusions
 
 So there you have it, a way to do performant clip animations using scale transforms. In a perfect
-world it would be great to see clip animations be accelerated (there’s
+world, it would be great to see clip animations be accelerated (there’s
 [a Chromium bug for that](https://bugs.chromium.org/p/chromium/issues/detail?id=686074) made by
-Jake Archibald), but until we get there you should be cautious when animating `clip` or `clip-path`,
+Jake Archibald), but until we get there, you should be cautious when animating `clip` or `clip-path`,
 and definitely avoid animating `width` or `height`.
 
 It would also be handy to use
 [Web Animations](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API)
 for effects like this, because they have a JavaScript
 API but can run on the compositor thread if you only animate `transform` and `opacity`.
-Unfortunately [support for Web Animations isn’t great](http://caniuse.com/#feat=web-animation),
+Unfortunately, [support for Web Animations isn’t great](http://caniuse.com/#feat=web-animation),
 though you could use progressive enhancement to use them if they’re available.
 
     if ('animate' in HTMLElement.prototype) {
@@ -303,10 +309,10 @@ though you could use progressive enhancement to use them if they’re available.
 
 Until that changes, while you *can* use JavaScript-based libraries to do the animation, you might
 find that you get more reliable performance by baking a CSS animation and using that instead.
-Equally, if your app already relies on JavaScript for its animations you may be better served by
+Equally, if your app already relies on JavaScript for its animations, you may be better served by
 being at least consistent with your existing codebase.
 
-If you want to have a look through the code for this effect take a look at the
+If you want to have a look through the code for this effect, take a look at the
 [UI Element Samples Github repo](https://github.com/GoogleChromeLabs/ui-element-samples/tree/gh-pages/animated-clip)
 and, as always, let us know how you get on in the comments below.
 

--- a/src/content/en/updates/2017/03/performant-expand-and-collapse.md
+++ b/src/content/en/updates/2017/03/performant-expand-and-collapse.md
@@ -60,7 +60,7 @@ You could imagine using a bit of CSS to animate the width and height on the cont
 ```
 
 The immediate problem with this approach is that it requires animating `width` and `height`.
-These properties require calculating layout and paint on every frame of the animation,
+These properties require calculating layout, and paint the results on every frame of the animation,
 which can be very expensive, and will typically cause you to miss out on 60fps. If that’s news to
 you then read our
 [Rendering Performance](/web/fundamentals/performance/rendering/)


### PR DESCRIPTION
What's changed, or what was fixed?

In the [*Building performant expand & collapse animations*](https://developers.google.com/web/updates/2017/03/performant-expand-and-collapse) article,

- Added missing commas.
- Wrapped CSS code that is not auto-detected as CSS in a ```` ```css ... ``` ```` block so that it is properly highlighted.
- Added missing semicolon.
- Added missing "in".
- Changed the verb "need" to "needs" when the subject is "the easing".
- Moved "to run" to the end in "This causes the animations to run that were created in the previous step".

**CC:** @petele
