### PR TITLE
Update /nic to nic78 article

### DIFF
--- a/src/content/en/updates/_redirects.yaml
+++ b/src/content/en/updates/_redirects.yaml
@@ -6,7 +6,7 @@ redirects:
   to: /web/updates/2019/09/fresher-sw
 
 - from: /web/updates/nic
-  to: /web/updates/2019/09/nic77
+  to: /web/updates/2019/10/nic78
 
 - from: /web/updates/2018/11/writable-files
   to: /web/updates/2019/08/native-file-system


### PR DESCRIPTION
What's changed, or what was fixed?
- Updated /nic redirect to new in chrome 78 article

**CC:** @petele
