### PR TITLE
Update CDS landing page with 2016–2019 links

### DIFF
--- a/src/content/en/shows/cds/index.md
+++ b/src/content/en/shows/cds/index.md
@@ -2,10 +2,50 @@ project_path: /web/_project.yaml
 book_path: /web/shows/_book.yaml
 description: Get started or build your web design and development skills with these free Udacity courses taught by your friends at Google.
 
-{# wf_updated_on: 2016-08-24 #}
+{# wf_updated_on: 2019-11-18 #}
 {# wf_published_on: 2016-08-24 #}
 
 # Chrome Dev Summits {: .page-title }
+
+## Chrome Dev Summit 2019
+
+<a href="https://www.youtube.com/watch?v=F1UP7wRCPH8&list=PLNYkxOF6rcIDA1uGhqy45bqlul0VcvKMr">
+  <img src="../imgs/cds_rect.png" class="attempt-right">
+</a>
+
+[View Playlist](https://www.youtube.com/watch?v=F1UP7wRCPH8&list=PLNYkxOF6rcIDA1uGhqy45bqlul0VcvKMr)
+
+<div style="clear:both;"></div>
+
+## Chrome Dev Summit 2018
+
+<a href="https://www.youtube.com/playlist?list=PLNYkxOF6rcIDjlCx1PcphPpmf43aKOAdF">
+  <img src="../imgs/cds_rect.png" class="attempt-right">
+</a>
+
+[View Playlist](https://www.youtube.com/playlist?list=PLNYkxOF6rcIDjlCx1PcphPpmf43aKOAdF)
+
+<div style="clear:both;"></div>
+
+## Chrome Dev Summit 2017
+
+<a href="https://www.youtube.com/playlist?list=PLNYkxOF6rcICUD5nBfRdAR6Fveosnqa5m">
+  <img src="../imgs/cds_rect.png" class="attempt-right">
+</a>
+
+[View Playlist](https://www.youtube.com/playlist?list=PLNYkxOF6rcICUD5nBfRdAR6Fveosnqa5m)
+
+<div style="clear:both;"></div>
+
+## Chrome Dev Summit 2016
+
+<a href="https://www.youtube.com/playlist?list=PLNYkxOF6rcIBTs2KPy1E6tIYaWoFcG3uj">
+  <img src="../imgs/cds_rect.png" class="attempt-right">
+</a>
+
+[View Playlist](https://www.youtube.com/playlist?list=PLNYkxOF6rcIBTs2KPy1E6tIYaWoFcG3uj)
+
+<div style="clear:both;"></div>
 
 ## Chrome Dev Summit 2015
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Update CDS landing page https://developers.google.com/web/shows/cds with 2016–2019 links.

**Target Live Date:** ASAP

- [X] This has been reviewed and approved by (@petele )
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele