### PR TITLE
Site Kit: Go back to individual client ID and secret to paste and update instructions

### DIFF
--- a/src/content/en/site-kit/apikey.html
+++ b/src/content/en/site-kit/apikey.html
@@ -31,7 +31,7 @@
               </aside>
             {% dynamic endif %}
             <p>
-              Once the project has been created, you will see the API key. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
+              Once the project has been created, you will see the API key. You must copy this value into the corresponding field in your Site Kit Developer Settings plugin, open in the other browser tab.
             </p>
             <p>
               <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"

--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -64,7 +64,7 @@
               </aside>
             {% dynamic endif %}
             <p>
-              Once the project has been created, you will see a client configuration snippet. You must copy this value into the corresponding field in your Site Kit plugin, open in the other browser tab.
+              Once the project has been created, you will see your client ID and client secret. You must copy these values into the corresponding fields in your Site Kit Developer Settings plugin, open in the other browser tab.
             </p>
             <p>
               <a id="site-kit-setup-button" tabindex="0" class="devsite-api-getstarted-widget button button-primary button-large"
@@ -75,7 +75,6 @@
                 data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
                 data-henhouse-credential-type="OAUTH"
                 data-henhouse-client-type="WEB_SERVER"
-                data-henhouse-display-entire-oauth-client-config="true"
                 {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}
                   data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"
                   data-henhouse-product-name="{% dynamic print setvar.productName|escape %}"


### PR DESCRIPTION
What's changed, or what was fixed?
* Site Kit now uses an authentication service to streamline the setup.
* The pages on developers.google.com should now only be used to set up development sites, which are not supported by the authentication service.
* This PR makes the necessary updates to work accordingly.

**Target Live Date:** 2019-12-09

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
