### PR TITLE
fix heading in the deprecations in Chrome 79 article

### DIFF
--- a/src/content/en/updates/2019/10/chrome-79-deps-rems.md
+++ b/src/content/en/updates/2019/10/chrome-79-deps-rems.md
@@ -11,7 +11,7 @@ description: A round up of the deprecations and removals in Chrome 79 to help yo
 
 {% include "web/updates/_shared/see-all-dep-rem.html" %}
 
-# Deprecations and removals in Chrome 78 {: .page-title }
+# Deprecations and removals in Chrome 79 {: .page-title }
 
 {% include "web/_shared/contributors/josephmedley.html" %}
 


### PR DESCRIPTION
What's changed, or what was fixed?
- increment Chrome version by one 

**Fixes:** N/A

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
