### PR TITLE
Fix typo in navigationPreload.html

### DIFF
--- a/src/content/en/tools/workbox/_shared/config/single/navigationPreload.html
+++ b/src/content/en/tools/workbox/_shared/config/single/navigationPreload.html
@@ -14,7 +14,7 @@
     <p>
       When set to <code>true</code>, you must also use
       <a href="#generateSW-runtimeCaching"><code>runtimeCaching</code></a> to
-      set up an appropriate reesponse strategy that will match navigation
+      set up an appropriate response strategy that will match navigation
       requests, and make use of the preloaded response.
     </p>
     <p>


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed a typo in the `navigationPreload.html` file

**Fixes:** N/A

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (N/A)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele