### PR TITLE
Typo fix in Workbox docs

### DIFF
--- a/src/content/en/tools/workbox/modules/_index.yaml
+++ b/src/content/en/tools/workbox/modules/_index.yaml
@@ -84,7 +84,7 @@ landing_page:
       - heading: workbox.backgroundSync
         description: >
           Use background sync to reliably make a network request even if the
-          user if offline.
+          user is offline.
         buttons:
         - label: Learn more
           path: /web/tools/workbox/modules/workbox-background-sync


### PR DESCRIPTION
Very small typo fix.

**Fixes:** https://github.com/GoogleChrome/workbox/issues/2286