### PR TITLE
Corrected "server worker" to "service worker"

### DIFF
--- a/src/content/en/fundamentals/media/video.md
+++ b/src/content/en/fundamentals/media/video.md
@@ -427,12 +427,12 @@ fullscreening of content, or the page.
 
 To full screen an element, like a video:
 
-    elem.requestFullScreen();
+    elem.requestFullscreen();
 
 
 To full screen the entire document:
 
-    document.body.requestFullScreen();
+    document.body.requestFullscreen();
 
 
 You can also listen for fullscreen state changes:
@@ -460,7 +460,7 @@ images as placeholders for video:
 To see this in action, check out the
 [demo](https://googlesamples.github.io/web-fundamentals/fundamentals/design-and-ux/responsive/fullscreen.html).
 
-Dogfood: `requestFullScreen()` may be vendor prefixed and may require extra code
+Dogfood: `requestFullscreen()` may be vendor prefixed and may require extra code
 for full cross browser compatibility.
 
 <div style="clear:both;"></div>

--- a/src/content/en/ilt/pwa/lab-indexeddb.md
+++ b/src/content/en/ilt/pwa/lab-indexeddb.md
@@ -154,7 +154,7 @@ var dbPromise = idb.open('couches-n-things', 2, function(upgradeDb) {
 
 Save the code and reload the page in the browser. [Open IndexedDB](tools-for-pwa-developers#indexeddb) in your browser's developer tools and expand the `couches-n-things` database. You should see the empty `products` object store.
 
-Open the QUnit test page, `localhost:8080/app/test/test.html`, in another browser tab. This page contains several tests for testing our app at each stage of the codelab. Passed tests are blue and failed tests are red. Your app should pass the first test that checks whether the `products` object store exists in the database. Note that you may not be able to delete the database while the testing page is open.
+Open the QUnit test page, `localhost:8080/test/test.html`, in another browser tab. This page contains several tests for testing our app at each stage of the codelab. Passed tests are blue and failed tests are red. Your app should pass the first test that checks whether the `products` object store exists in the database. Note that you may not be able to delete the database while the testing page is open.
 
 #### Explanation
 

--- a/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
+++ b/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
@@ -321,7 +321,7 @@ navigator.serviceWorker.register('/service-worker.js', {
 
 In the above example the scope of the service worker is set to `/kitten/`. The service worker intercepts requests from pages in `/kitten/` and `/kitten/lower/` but not from pages like `/kitten` or `/`.
 
-Note: You cannot set an arbitrary scope that is above the service worker's actual location. However, if your server worker is active on a client being served with the `Service-Worker-Allowed` header, you can specify a max scope for that service worker above the service worker's location.
+Note: You cannot set an arbitrary scope that is above the service worker's actual location. However, if your service worker is active on a client being served with the `Service-Worker-Allowed` header, you can specify a max scope for that service worker above the service worker's location.
 
 #### For more information
 


### PR DESCRIPTION
Fixed a typo on line 324 of "webfundamentals/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md" by changing "server worker" to "service worker"

What's changed, or what was fixed?
- "server worker" was changed to "service worker"

**Fixes:** #8359
