### PR TITLE
Fixed a typo #8359

### DIFF
--- a/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
+++ b/src/content/en/ilt/pwa/lab-scripting-the-service-worker.md
@@ -321,7 +321,7 @@ navigator.serviceWorker.register('/service-worker.js', {
 
 In the above example the scope of the service worker is set to `/kitten/`. The service worker intercepts requests from pages in `/kitten/` and `/kitten/lower/` but not from pages like `/kitten` or `/`.
 
-Note: You cannot set an arbitrary scope that is above the service worker's actual location. However, if your server worker is active on a client being served with the `Service-Worker-Allowed` header, you can specify a max scope for that service worker above the service worker's location.
+Note: You cannot set an arbitrary scope that is above the service worker's actual location. However, if your service worker is active on a client being served with the `Service-Worker-Allowed` header, you can specify a max scope for that service worker above the service worker's location.
 
 #### For more information
 


### PR DESCRIPTION
in the codelab  https://codelabs.developers.google.com/codelabs/pwa-scripting-the-service-worker/#5, there is typo where "service worker" is written as "server worker". fixed it by changing "server worker" to "service worker"

What's changed, or what was fixed?
- "server worker" was changed to "service worker"

**Fixes:** #8359 

**CC:** @petele
