### PR TITLE
Fixes blogpost location

### DIFF
--- a/src/content/en/_redirects.yaml
+++ b/src/content/en/_redirects.yaml
@@ -61,3 +61,7 @@ redirects:
 
 - from: /web/g-co/twa
   to: /web/updates/2017/10/using-twa
+
+- from: /web/updates/2020/twa-android-browser-helper
+  to: /web/updates/2020/01/twa-android-browser-helper
+  

--- a/src/content/en/updates/2020/01/twa-android-browser-helper.md
+++ b/src/content/en/updates/2020/01/twa-android-browser-helper.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Introduces android-browser-helper, a new library to build Trusted Web Activities.
 
 {# wf_published_on: 2020-01-10 #}
-{# wf_updated_on: 2020-01-10 #}
+{# wf_updated_on: 2020-01-13 #}
 {# wf_tags: trusted-web-activity #}
 {# wf_featured_image: /web/updates/images/generic/devices.png #}
 {# wf_blink_components: N/A #}


### PR DESCRIPTION
The android-browser-helper post ended up in the wrong location. This PR:

- Moves twa-android-browser-helper.md from /updates/2020/ to
  /updates/2020/01/.
- Adds a Redirect from the old location to the new location.

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
