### PR TITLE
Fix typo in Microsoft OS descriptor

### DIFF
--- a/src/content/en/fundamentals/native-hardware/build-for-webusb/index.md
+++ b/src/content/en/fundamentals/native-hardware/build-for-webusb/index.md
@@ -760,7 +760,7 @@ and `bNumDeviceCaps` to account for it.
    <td>Minimum compatible Windows version (Windows 8.1)</td>
   </tr>
   <tr>
-   <td><code>0xB2</code></td>
+   <td><code>0x00B2</code></td>
    <td>wMSOSDescriptorSetTotalLength</td>
    <td>Total length of the descriptor set</td>
   </tr>


### PR DESCRIPTION
The descriptor set length field is a 16-bit, rather than 8-bit, value and so should be written as 0x00B2.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

I am getting errors from `npm install` that seem unrelated to this change and so I haven't been able to test or stage this change locally. It is trivial enough I feel comfortable skipping these steps.

**CC:** @petele
