### PR TITLE
Add redirect for prefers-reduced-motion article

### DIFF
--- a/src/content/en/updates/_redirects.yaml
+++ b/src/content/en/updates/_redirects.yaml
@@ -2,6 +2,9 @@
 
 redirects:
 
+- from: /web/updates/2019/03/prefers-reduced-motion
+  to: https://web.dev/prefers-reduced-motion/
+
 - from: /web/updates/2019/08/periodic-background-sync
   to: https://web.dev/periodic-background-sync/
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Redirect from https://developers.google.com/web/updates/2019/03/prefers-reduced-motion to https://web.dev/prefers-reduced-motion/

**Target Live Date:** any

- [X] This has been reviewed and approved by (tsteiner)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
