### PR TITLE
Fixed "input" element typo #8402

### DIFF
--- a/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
+++ b/src/content/en/fundamentals/accessibility/semantics-builtin/the-accessibility-tree.md
@@ -147,14 +147,14 @@ touchscreen users. To associate a label with an element, either
 <div class="clearfix"></div>
 
     <label>
-      <input type="checkbox">Receive promotional offers?</input>
+      <input type="checkbox">Receive promotional offers?
     </label>
 
 
 {% framebox height="60px" %}
 <div style="margin: 10px;">
     <label style="font-size: 16px; color: #212121;">
-        <input type="checkbox">Receive promotional offers?</input>
+        <input type="checkbox">Receive promotional offers?
     </label>
 </div>
 {% endframebox %}
@@ -166,13 +166,13 @@ or
 
 <div class="clearfix"></div>
 
-    <input id="promo" type="checkbox"></input>
+    <input id="promo" type="checkbox">
     <label for="promo">Receive promotional offers?</label>
 
 
 {% framebox height="60px" %}
 <div style="margin: 10px;">
-    <input id="promo" type="checkbox"></input>
+    <input id="promo" type="checkbox">
     <label for="promo">Receive promotional offers?</label>
 </div>
 {% endframebox %}


### PR DESCRIPTION
some input elements in the code samples on https://developers.google.com/web/fundamentals/accessibility/semantics-builtin/the-accessibility-tree has a closing tag. For uniformity across the web and to avoid confusing newbies, i removed the closing tag.

What's changed, or what was fixed?
- "<input type="checkbox>Receive Promotional Offers?"</input> changed to <input type="checkbox>Receive Promotional Offers?"

**Fixes:** #8402

**CC:** @petele
