### PR TITLE
workbox-expiration URL change

### DIFF
--- a/src/content/en/tools/_redirects.yaml
+++ b/src/content/en/tools/_redirects.yaml
@@ -242,3 +242,6 @@ redirects:
 
 - from: /web/tools/workbox/modules/workbox-broadcast-cache-update
   to: /web/tools/workbox/modules/workbox-broadcast-update
+
+- from: /web/tools/workbox/modules/workbox-cache-expiration
+  to: /web/tools/workbox/modules/workbox-expiration

--- a/src/content/en/tools/workbox/guides/migrations/migrate-from-v4.md
+++ b/src/content/en/tools/workbox/guides/migrations/migrate-from-v4.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to migrating from Workbox v4 to v5.
 
-{# wf_updated_on: 2020-01-17 #}
+{# wf_updated_on: 2020-01-30 #}
 {# wf_published_on: 2019-12-18 #}
 {# wf_blink_components: N/A #}
 
@@ -189,6 +189,10 @@ const cachedResponse = await matchPrecache(`/somethingPrecached`);
 In v5, the Workbox runtime libraries are written in [TypeScript](https://www.typescriptlang.org/). While we will continue to publish transpiled JavaScript modules and bundles to accommodate developers who have not adopted TypeScript, if you are using TypeScript, you should benefit from accurate, always up-to-date type information directly from the Workbox project.
 
 ## Example Migration
+
+[This commit](https://github.com/GoogleChromeLabs/so-pwa/commit/b1ecae0bc12b923506b4199dcabf4f15ca2a924e)
+illustrates is a fairly involved migration, with inline commentary. It uses Rollup to include a
+custom Workbox runtime in the final service worker instead of loading the runtime from the CDN.
 
 While it doesn't cover every breaking change, here's the [before](https://github.com/jeffposnick/jeffposnick.github.io/blob/ed13f6fc9feb60ee88434ccd3d53160d23ddac45/src/service-worker.js) and [after](https://github.com/jeffposnick/jeffposnick.github.io/blob/fedbdf87dc8ee26b66f0e12e2649d92b7a853d79/src/service-worker.ts) of upgrading one service worker file from v4 to v5, including a switch to TypeScript.
 

--- a/src/content/en/tools/workbox/modules/_index.yaml
+++ b/src/content/en/tools/workbox/modules/_index.yaml
@@ -66,7 +66,7 @@ landing_page:
           the age of the cached request.
         buttons:
         - label: Learn more
-          path: /web/tools/workbox/modules/workbox-cache-expiration
+          path: /web/tools/workbox/modules/workbox-expiration
         - label: Reference
           path: /web/tools/workbox/reference-docs/latest/module-workbox-expiration
         - label: Demo

--- a/src/content/en/tools/workbox/modules/workbox-expiration.md
+++ b/src/content/en/tools/workbox/modules/workbox-expiration.md
@@ -1,19 +1,19 @@
 project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
-description: The module guide for workbox-cache-expiration.
+description: The module guide for workbox-expiration.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-01-30 #}
 {# wf_published_on: 2017-11-27 #}
 
-# Workbox Cache Expiration {: .page-title }
+# Workbox Expiration {: .page-title }
 
 ## What is Cache Expiration?
 
 It’s fairly common to want to put restrictions on a cache in terms of how long
 it should allow items to be stored in a cache or how many items should be kept
 in a cache. Workbox provides this functionality through the
-`workbox-cache-expiration` plugin that allows you to limit the number of
+`workbox-expiration` plugin that allows you to limit the number of
 entries in a cache and / or remove entries that have been cached for a long
 period of time.
 


### PR DESCRIPTION
This fixes some inconsistencies that were never cleared up after we migrated from `workbox-cache-expiration` to `workbox-expiration`.

**Target Live Date:** 2020-01-30

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
