### PR TITLE
fix console.debug log level

### DIFF
--- a/src/content/en/tools/chrome-devtools/console/api.md
+++ b/src/content/en/tools/chrome-devtools/console/api.md
@@ -78,9 +78,9 @@ Resets a count.
 
 ## console.debug(object [, object, ...]) {: #debug }
 
-[Log level][level]: `Info`
+[Log level][level]: `Verbose`
 
-Identical to [`console.log(object [, object, ...])`](#log).
+Identical to [`console.log(object [, object, ...])`](#log) except different log level.
 
     console.debug('debug');
 


### PR DESCRIPTION
What's changed, or what was fixed?
for `console.debug`
- Changed **Log level** to `Verbose`
- It mentioned in description

**Fixes:** #8479 

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
