### PR TITLE
Add GitLocalize configuration file

### DIFF
--- a/.gitlocalize.yml
+++ b/.gitlocalize.yml
@@ -1,0 +1,3 @@
+settings:
+  advise_cla_signing: 
+    - "true"


### PR DESCRIPTION
.gitlocalize.yml is used to configure certain GitLocalize workflows and features implemented specifically for the WebFundamentals and web.dev projects. 
What the proposed change will affect:
When creating a new Review Request on GitLocalize, contributors will see a message telling them that they need to have a signed CLA before sending a PR to the repo. Here's a screenshot: https://prnt.sc/r4k16x 
CC: @agektmr @petele

