### PR TITLE
$ no longer an alias for document.querySelector

### DIFF
--- a/src/content/en/tools/chrome-devtools/console/utilities.md
+++ b/src/content/en/tools/chrome-devtools/console/utilities.md
@@ -64,7 +64,7 @@ while `$1` returns the previously selected one:
 
 `$(selector)` returns the reference to the first DOM element
 with the specified CSS selector.
-This function is an alias for the
+When called with one argument, this function is an alias for the
 [document.querySelector()](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
 function.
 


### PR DESCRIPTION
It could be in the past, the function is an alias for `document.querySelector`, but if the statement  $: "this function is an alias for the document.querySelector() function" is passed around, it might cause some confusion...

```
// not exactly an alias
document.querySelector === $   // false
```   

The real situation is, when called with one argument, this function (`$`) calls `document.querySelector()`
But when called with `$(sel, node)`, calls `node.querySelector(sel)`, so it would not be accurate to call this an alias. I think in the past, it doesn't accept a second argument, and it was an alias for `document.querySelector()` but not any more.

What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
