### PR TITLE
Add link to web.dev article on image support to Async Clipboard article

### DIFF
--- a/src/content/en/updates/2018/03/clipboardapi.md
+++ b/src/content/en/updates/2018/03/clipboardapi.md
@@ -242,6 +242,9 @@ the specification, but these come with additional implementation complexity and
 security concerns (remember those image bombs?). For now, Chrome is rolling out
 the simpler text parts of the API.
 
+Success: Copy and paste support for images has landed in Chrome 76.
+Read all about this new capability of the Async Clipboard API in the article
+[Image support for the async clipboard API](https://web.dev/image-support-for-async-clipboard/#images).
 
 ## More Information
 


### PR DESCRIPTION
Triggered by https://twitter.com/_developit/status/1231958198371995648.

CC: @developit @addyosmani.

**Target Live Date:** asap.

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
