### PR TITLE
Remove a Workbox nav link that 404s

### DIFF
--- a/src/content/en/tools/workbox/modules/_toc.yaml
+++ b/src/content/en/tools/workbox/modules/_toc.yaml
@@ -24,8 +24,6 @@ toc:
   path: /web/tools/workbox/modules/workbox-range-requests
 - title: workbox-routing
   path: /web/tools/workbox/modules/workbox-routing
-- title: workbox-streams
-  path: /web/tools/workbox/modules/workbox-streams
 - title: workbox-strategies
   path: /web/tools/workbox/modules/workbox-strategies
 


### PR DESCRIPTION
There is no `/modules/` docs page for the `workbox-streams` module.

C.f. https://github.com/GoogleChrome/workbox/issues/2387