### PR TITLE
link to issue templates for lighthouse

### DIFF
--- a/src/content/en/tools/lighthouse/index.md
+++ b/src/content/en/tools/lighthouse/index.md
@@ -72,7 +72,7 @@ You can also use [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci/b
   <a class="button button-primary gc-analytics-event"
      data-category="Lighthouse" data-action="click"
      data-label="Home / File Bug"
-     href="https://github.com/GoogleChrome/lighthouse/issues/new"
+     href="https://github.com/GoogleChrome/lighthouse/issues/new/choose"
      title="File an issue or feature request" target="_blank">
     <span class="material-icons">bug_report</span>
     File an issue

--- a/src/content/en/tools/lighthouse/scoring.md
+++ b/src/content/en/tools/lighthouse/scoring.md
@@ -37,7 +37,7 @@ score usually indicates an error in Lighthouse. If you see a 0 score repeatedly,
 [file a bug on the Lighthouse repo][bug]{:.external}. 100 is the best possible score. Typically
 a score above 90 represents the top 5 percent of top-performing pages.
 
-[bug]: https://github.com/GoogleChrome/lighthouse/issues/new
+[bug]: https://github.com/GoogleChrome/lighthouse/issues/new/choose
 
 ### Which Performance audits contribute to your score {: #perf-audits }
 

--- a/src/content/en/tools/lighthouse/v3/scoring.md
+++ b/src/content/en/tools/lighthouse/v3/scoring.md
@@ -33,7 +33,7 @@ score usually indicates an error in Lighthouse. If you see a 0 score repeatedly,
 represents the 98th percentile, a top-performing site. A score of 50 represents the 75th 
 percentile.
 
-[bug]: https://github.com/GoogleChrome/lighthouse/issues/new
+[bug]: https://github.com/GoogleChrome/lighthouse/issues/new/choose
 
 ### Which Performance audits contribute to your score {: #perf-audits }
 

--- a/src/content/ko/tools/lighthouse/index.md
+++ b/src/content/ko/tools/lighthouse/index.md
@@ -58,7 +58,7 @@ Lighthouse에 확인할 URL을 지정하고, 페이지에 대한 테스트를 �
   </a>
   <a class="button button-primary gc-analytics-event"
      data-category="ligthhouse" data-action="bug"
-     href="https://github.com/GoogleChrome/lighthouse/issues/new"
+     href="https://github.com/GoogleChrome/lighthouse/issues/new/choose"
      title="File an issue or feature request" target="_blank">
     <span class="material-icons">bug_report</span>
     이슈 찾기


### PR DESCRIPTION
What's changed, or what was fixed?
- current issue link bypasses Lighthouse's issue templates.
- thanks to @schroef for (https://github.com/GoogleChrome/lighthouse/issues/10426#issuecomment-594913326)[calling this out]

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
