### PR TITLE
Fix Missing ')' after the 'timeupdate' addEventListener call

### DIFF
--- a/src/content/en/fundamentals/media/mobile-web-video-playback.md
+++ b/src/content/en/fundamentals/media/mobile-web-video-playback.md
@@ -140,7 +140,7 @@ visible.
         videoCurrentTime.textContent = secondsToTimeCode(video.currentTime);
         videoProgressBar.style.transform = `scaleX(${video.currentTime / video.duration})`;
       }
-    }
+    });
 
 When the video ends, we simply change button state to "play", set video
 `currentTime` back to 0 and show video controls for now. Note that we could


### PR DESCRIPTION
What's changed, or what was fixed?

- added `);` after `video.addEventListener('timeupdate', function() {...}` in the code sample provided.

**Fixes:** #8543

**CC:** @petele
