### PR TITLE
Update install criteria URL

### DIFF
--- a/src/content/en/updates/2018/06/a2hs-updates.md
+++ b/src/content/en/updates/2018/06/a2hs-updates.md
@@ -29,7 +29,7 @@ current behavior.
 
 Starting in Chrome 68 on Android (Stable in July 2018), Chrome will no longer
 show the add to home screen banner. If the site meets the
-[add to home screen criteria](/web/fundamentals/app-install-banners/#criteria),
+[add to home screen criteria](https://web.dev/install-criteria/),
 Chrome will show the mini-infobar. Then, if the user clicks on the
 mini-infobar, or you call `prompt()` on the `beforeinstallprompt` event from
 within a user gesture, Chrome will show a modal add to home screen dialog.
@@ -122,7 +122,7 @@ The mini-infobar is a Chrome UI component and is not controllable by the site,
 but can be easily dismissed by the user. Once dismissed by the user, it will
 not appear again until a sufficient amount of time has passed
 (currently 3 months). The mini-infobar will appear when the site meets the
-[add to home screen criteria](/web/fundamentals/app-install-banners/#criteria),
+[add to home screen criteria](https://web.dev/install-criteria/),
 regardless of whether you `preventDefault()` on the `beforeinstallprompt` event
 or not.
 
@@ -169,7 +169,7 @@ tomorrow, or whenever they’re ready to install.
 
 ### Listening for the `beforeinstallprompt` event {: #listening }
 If your site meets the
-[add to home screen criteria](/web/fundamentals/app-install-banners/#criteria),
+[add to home screen criteria](https://web.dev/install-criteria/),
 Chrome will fire a `beforeinstallprompt` event, save a reference to the event,
 and update your user interface to indicate that the user can add your app to
 their home screen.
@@ -188,12 +188,12 @@ window.addEventListener('beforeinstallprompt', (event) => {
 ```
 
 Note: Your site must meet the
-[add to home screen criteria](/web/fundamentals/app-install-banners/#criteria)
+[add to home screen criteria](https://web.dev/install-criteria/)
 in order for the `beforeinstallprompt` event to be fired and your app installed.
 
 The `beforeinstallprompt` event will not be fired if the app is already
 installed (see the
-[add to home screen criteria](/web/fundamentals/app-install-banners/#criteria)).
+[add to home screen criteria](https://web.dev/install-criteria/)).
 But if the user later uninstalls the app, the `beforeinstallprompt` event will
 again be fired on each page navigation.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- https://developers.google.com/web/fundamentals/app-install-banners#criteria points to https://web.dev/customize-install/#criteria, but the `criteria` anchor doesn’t exist there. Instead, the link should point to https://web.dev/install-criteria/.

**Fixes:** —

**Target Live Date:** —

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
