### PR TITLE
Add 202002 release to CrUX changelog

### DIFF
--- a/src/content/en/tools/chrome-user-experience-report/changelog.md
+++ b/src/content/en/tools/chrome-user-experience-report/changelog.md
@@ -1,7 +1,7 @@
 project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 
-{# wf_updated_on: 2020-02-11 #}
+{# wf_updated_on: 2020-03-10 #}
 {# wf_published_on: 2019-02-11 #}
 {# wf_blink_components: N/A #}
 
@@ -16,6 +16,19 @@ Tuesday of January 2020 after the data collection period has ended.
 
 In the list below, we've curated some release notes for each monthly dataset. Subscribe to our [CrUX Announce](https://groups.google.com/a/chromium.org/forum/#!forum/chrome-ux-report-announce) mailing list or follow 
 [@ChromeUXReport](https://twitter.com/ChromeUXReport) on Twitter for release announcements.
+
+### 202002
+
+<dl>
+	<dt>Publication date</dt>
+	<dd>March 10, 2020</dd>
+	<dt>Notable stats</dt>
+	<dd>
+		<ul>
+			<li>6,366,736 origins</li>
+		</ul>
+	</dd>
+</dl>
 
 ### 202001
 


### PR DESCRIPTION
What's changed, or what was fixed?
- added 202002 release to CrUX changelog

**Target Live Date:** 2020-03-10

- [x] This has been reviewed and approved by @igrigorik 
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
