### PR TITLE
Small update to the Payment Handler article

### DIFF
--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Web Payments allows any websites to act as a payment handler for the Payment Request API. Learn how to do it.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2020-04-06 #}
+{# wf_updated_on: 2020-04-07 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Web based payment apps developer guide {: .page-title }
@@ -419,13 +419,12 @@ payment method your app supports.
 
 Following are the conditions to enable skip-the-sheet:
 
-1. Only one payment method identifier is specified in the `PaymentRequest`
-   constructor. The payment method identifier must be URL-based.
-2. There is only a single payment handler (installed or JIT installable) with
+1. There is only a single payment handler (installed or JIT installable) with
    full delegation support (i.e. only a single available payment handler can
    provide all merchant requested information including shipping address and/or
-   contact information whenever needed) that matches the payment method
-   identifier.
+   contact information whenever needed).
+2. The available payment handler with full delegation should support the
+   requested URL-based payment method.
 3. `show()` is triggered with a user gesture.
 
 See a skip-the-sheet example here:

--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
@@ -423,8 +423,8 @@ Following are the conditions to enable skip-the-sheet:
    full delegation support (i.e. only a single available payment handler can
    provide all merchant requested information including shipping address and/or
    contact information whenever needed).
-2. The available payment handler with full delegation should support the
-   requested URL-based payment method.
+2. The available payment handler with full delegation should support a requested
+   URL-based payment method.
 3. `show()` is triggered with a user gesture.
 
 See a skip-the-sheet example here:

--- a/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
+++ b/src/content/en/fundamentals/payments/payment-apps-developer-guide/web-payment-apps.md
@@ -3,7 +3,7 @@ book_path: /web/fundamentals/_book.yaml
 description: Web Payments allows any websites to act as a payment handler for the Payment Request API. Learn how to do it.
 
 {# wf_published_on: 2018-09-10 #}
-{# wf_updated_on: 2019-10-04 #}
+{# wf_updated_on: 2020-04-06 #}
 {# wf_blink_components: Blink>Payments #}
 
 # Web based payment apps developer guide {: .page-title }
@@ -421,9 +421,12 @@ Following are the conditions to enable skip-the-sheet:
 
 1. Only one payment method identifier is specified in the `PaymentRequest`
    constructor. The payment method identifier must be URL-based.
-2. No shipping address or contact info are requested in the `PaymentRequest`
-   constructor.
-3. `show()` is called with a user gesture.
+2. There is only a single payment handler (installed or JIT installable) with
+   full delegation support (i.e. only a single available payment handler can
+   provide all merchant requested information including shipping address and/or
+   contact information whenever needed) that matches the payment method
+   identifier.
+3. `show()` is triggered with a user gesture.
 
 See a skip-the-sheet example here:
 [https://rsolomakhin.github.io/pr/skip-ui/](https://rsolomakhin.github.io/pr/skip-ui/)


### PR DESCRIPTION
What's changed, or what was fixed?
- An update to https://developers.google.com/web/fundamentals/payments/payment-apps-developer-guide/web-payment-apps#optional_let_chrome_skip-the-sheet
- Updated conditions to skip the Payment Handler sheet

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @sahel-sh
