### PR TITLE
fix broken links that accidentally start with http://localhost:8080/

### DIFF
--- a/src/content/en/fundamentals/performance/audit/next.md
+++ b/src/content/en/fundamentals/performance/audit/next.md
@@ -15,8 +15,8 @@ Having completed a site audit, you will have accurate review data in a form that
 developers and other stakeholders to prioritize and justify changes.
 
 Next, you may want to revisit the sections on this site that provide in-depth advice on how to
-improve [load performance](http://localhost:8080/web/fundamentals/performance/get-started/) and
-[rendering performance](http://localhost:8080/web/fundamentals/performance/rendering/).
+improve [load performance](/web/fundamentals/performance/get-started/) and
+[rendering performance](/web/fundamentals/performance/rendering/).
 
 ## Find out more
 

--- a/src/content/en/updates/2020/01/devtools.md
+++ b/src/content/en/updates/2020/01/devtools.md
@@ -36,7 +36,7 @@ Related features:
 * Open the [Command Menu](/web/tools/chrome-devtools/command-menu/) and run the `Capture screenshot`
   command to take a screenshot of the viewport that includes the Moto G4 hardware (after enabling
   **Show Device Frame**).
-* [Throttle the network and CPU](http://localhost:8080/web/tools/chrome-devtools/device-mode/#throttle)
+* [Throttle the network and CPU](/web/tools/chrome-devtools/device-mode/#throttle)
   to more accurately simulate a mobile user's web browsing conditions.
 
 {# https://chromium.googlesource.com/devtools/devtools-frontend/+/49e4673403214c99cc9d358fb5f311727dcf47e8 #}


### PR DESCRIPTION
I'm guessing the URL was copied from a development server, and it accidentally included the domain instead of just the path.

**Fixes:** I didn't file an issue for this trivial bug.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label. (I don't know what this means?)
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
