### PR TITLE
Fix markup error in devtools network page (#8674)

### DIFF
--- a/src/content/en/tools/chrome-devtools/network/index.md
+++ b/src/content/en/tools/chrome-devtools/network/index.md
@@ -522,7 +522,7 @@ to find out:
        <img src="/web/tools/chrome-devtools/network-performance/imgs/tutorial/addblock.png"
             alt="Blocking main.css"/>
        <figcaption>
-         <b>Figure 32</b>. Blocking <code>main.css</code></main>
+         <b>Figure 32</b>. Blocking <code>main.css</code>
        </figcaption>
      </figure>
 


### PR DESCRIPTION
What's changed, or what was fixed?
- removed a wayward closing tag for the <main> element which fixes a markup bug on the end of the article

**Fixes:** #8674 
**Target Live Date:** whenever works :shrug: 

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
