### PR TITLE
Use matchCallbacks instead of RegExps in Workbox docs

### DIFF
--- a/src/content/en/tools/workbox/_index.yaml
+++ b/src/content/en/tools/workbox/_index.yaml
@@ -136,32 +136,19 @@ landing_page:
       cache.</p>
 
       <pre class="prettyprint lang-javascript">
-        import {registerRoute} from 'workbox-routing';
-        import {CacheFirst, StaleWhileRevalidate} from 'workbox-strategies';
-        import {CacheableResponsePlugin} from 'workbox-cacheable-response';
         import {ExpirationPlugin} from 'workbox-expiration';
+        import {registerRoute} from 'workbox-routing';
+        import {StaleWhileRevalidate} from 'workbox-strategies';
 
-        // Cache the Google Fonts stylesheets with a stale while revalidate strategy.
+        // Cache Google Fonts with a stale-while-revalidate strategy, with
+        // a maximum number of entries.
         registerRoute(
-          /^https:\/\/fonts\.googleapis\.com/,
+          ({url}) => url.origin === 'https://fonts.googleapis.com' ||
+                     url.origin === 'https://fonts.gstatic.com',
           new StaleWhileRevalidate({
-            cacheName: 'google-fonts-stylesheets',
-          }),
-        );
-
-
-        // Cache the Google Fonts webfont files with a cache first strategy for 1 year.
-        registerRoute(
-          /^https:\/\/fonts\.gstatic\.com/,
-          new CacheFirst({
-            cacheName: 'google-fonts-webfonts',
+            cacheName: 'google-fonts',
             plugins: [
-              new CacheableResponsePlugin({
-                statuses: [0, 200],
-              }),
-              new ExpirationPlugin({
-                maxAgeSeconds: 60 * 60 * 24 * 365,
-              }),
+              new ExpirationPlugin({maxEntries: 20}),
             ],
           }),
         );
@@ -175,7 +162,11 @@ landing_page:
         import {registerRoute} from 'workbox-routing';
         import {StaleWhileRevalidate} from 'workbox-strategies';
 
-        registerRoute(/\.(?:js|css)$/, new StaleWhileRevalidate());
+        registerRoute(
+          ({request}) => request.destination === 'script' ||
+                         request.destination === 'style',
+          new StaleWhileRevalidate()
+        );
       </pre>
 
       <h3>Cache Images</h3>
@@ -184,15 +175,19 @@ landing_page:
       them indefinitely, consuming your users' storage.</p>
 
       <pre class="prettyprint lang-javascript">
-        import {registerRoute} from 'workbox-routing';
+        import {CacheableResponsePlugin} from 'workbox-cacheable-response';
         import {CacheFirst} from 'workbox-strategies';
         import {ExpirationPlugin} from 'workbox-expiration';
+        import {registerRoute} from 'workbox-routing';
 
         registerRoute(
-          /\.(?:png|gif|jpg|jpeg|svg)$/,
+          ({request}) => request.destination === 'image',
           new CacheFirst({
             cacheName: 'images',
             plugins: [
+              new CacheableResponsePlugin({
+                statuses: [0, 200],
+              }),
               new ExpirationPlugin({
                 maxEntries: 60,
                 maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days

--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Advanced recipes to use with Workbox.
 
-{# wf_updated_on: 2020-03-23 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: N/A #}
 
@@ -193,7 +193,7 @@ precacheAndRoute(self.__WB_MANIFEST);
 
 // Use an explicit cache-first strategy and a dedicated cache for images.
 registerRoute(
-  new RegExp('/images/'),
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'images',
     plugins: [...],
@@ -354,7 +354,7 @@ import {RangeRequestsPlugin} from 'workbox-range-requests';
 // but it won't populate the cache at runtime.
 // If there is a cache match, then it will properly serve partial responses.
 registerRoute(
-  /.*\.mp4/,
+  ({url}) => url.pathname.endsWith('.mp4'),
   new CacheFirst({
     cacheName: 'your-cache-name-here',
     plugins: [

--- a/src/content/en/tools/workbox/guides/codelabs/_shared/create.md
+++ b/src/content/en/tools/workbox/guides/codelabs/_shared/create.md
@@ -46,7 +46,7 @@ the service worker at build-time.
     workbox.core.clientsClaim();
 
     workbox.routing.registerRoute(
-      new RegExp('https://hacker-news.firebaseio.com'),
+      ({url}) => url.origin === 'https://hacker-news.firebaseio.com',
       new workbox.strategies.StaleWhileRevalidate()
     );
 

--- a/src/content/en/tools/workbox/guides/codelabs/webpack.md
+++ b/src/content/en/tools/workbox/guides/codelabs/webpack.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Learn how to make a webpack-based app work offline by adding Workbox to it.
 
-{# wf_updated_on: 2019-02-01 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-10-31 #}
 {# wf_blink_components: N/A #}
 
@@ -205,7 +205,7 @@ the service worker at build-time.
     workbox.core.clientsClaim();
 
     workbox.routing.registerRoute(
-      new RegExp('https://hacker-news.firebaseio.com'),
+      ({url}) => url.origin === 'https://hacker-news.firebaseio.com',
       new workbox.strategies.StaleWhileRevalidate()
     );
 

--- a/src/content/en/tools/workbox/guides/common-recipes.md
+++ b/src/content/en/tools/workbox/guides/common-recipes.md
@@ -106,7 +106,7 @@ registerRoute(
 
 You can create regular expressions to cache similar requests from multiple
 origins in a single route by combining multiple checks into a single
-[`matchCallback` function](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback).
+[`matchCallback` function](/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback).
 
 ```javascript
 import {registerRoute} from 'workbox-routing';
@@ -182,7 +182,7 @@ registerRoute(
 You can route requests to files in a specific directory on your local web app by checking the
 `origin` and `pathname` properties of the
 [URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL) passed to the
-[`matchCallback` function](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback):
+[`matchCallback` function](/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback):
 
 ```javascript
 import {registerRoute} from 'workbox-routing';

--- a/src/content/en/tools/workbox/guides/configure-workbox.md
+++ b/src/content/en/tools/workbox/guides/configure-workbox.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to configure Workbox.
 
-{# wf_updated_on: 2020-01-28 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -83,7 +83,7 @@ import {registerRoute} from 'workbox-routing';
 import {CacheFirst} from 'workbox-strategies';
 
 registerRoute(
-  /\.(?:png|jpg|jpeg|svg|gif)$/,
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'my-image-cache',
   })
@@ -114,7 +114,7 @@ import {registerRoute} from 'workbox-routing';
 import {NetworkFirst} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('https://third-party\\.example\\.com/'),
+  ({url}) => url.origin === 'https://third-party.example.com',
   new NetworkFirst({
     fetchOptions: {
       credentials: 'include',

--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description:Get Started with Workbox.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-15 #}
 
 # Get Started {: .page-title }
@@ -130,8 +130,9 @@ modules. It allows you to listen for requests from your web page and determine
 if and how that request should be cached and responded to.
 
 Let’s add a cache fallback to our JavaScript files. The easiest way to do this
-is to register a route with Workbox that will match any `.js` files that are
-requested, which we can do with a regular expression:
+is to register a route with Workbox that will match any requests that have a
+[`destination`](https://developer.mozilla.org/en-US/docs/Web/API/RequestDestination) property
+set to `'script'`.
 
 Note: the examples in this guide all use `import` syntax to load the various
 Workbox modules. If you prefer to load Workbox from the CDN, see the
@@ -142,13 +143,13 @@ code that uses the `workbox` global.
 import {registerRoute} from 'workbox-routing';
 
 registerRoute(
-  /\.js$/,
+  ({request}) => request.destination === 'script',
   /* ... */
 );
 ```
 
 The above code tells Workbox that when a request is made, it should see if the
-regular expression matches part of the URL, and if it does, do something with
+function returns a "truthy" value, and if it does, do something with
 that request. For this guide, that “do something” is going to be passing the
 request through one of Workbox’s caching strategies.
 
@@ -161,7 +162,7 @@ import {registerRoute} from 'workbox-routing';
 import {NetworkFirst} from 'workbox-strategies';
 
 registerRoute(
-  /\.js$/,
+  ({request}) => request.destination === 'script',
   new NetworkFirst()
 );
 ```
@@ -171,7 +172,7 @@ has JavaScript files in it, you should see some logs similar to this:
 
 ![Example console logs from routing a JavaScript file.](../images/guides/get-started/routing-example.png)
 
-Workbox has routed the request for any `.js` files and used the network first
+Workbox has routed the request for any script resources and used the network first
 strategy to determine how to respond to the request. You can look in the
 caches of DevTools to check that the request has actually been cached.
 
@@ -188,8 +189,8 @@ import {CacheFirst, StaleWhileRevalidate} from 'workbox-strategies';
 import {ExpirationPlugin} from 'workbox-expiration';
 
 registerRoute(
-  // Cache CSS files.
-  /\.css$/,
+  // Cache style resources, i.e. CSS files.
+  ({request}) => request.destination === 'style',
   // Use cache but update in the background.
   new StaleWhileRevalidate({
     // Use a custom cache name.
@@ -199,7 +200,7 @@ registerRoute(
 
 registerRoute(
   // Cache image files.
-  /\.(?:png|jpg|jpeg|svg|gif)$/,
+  ({request}) => request.destination === 'image',
   // Use the cache if it's available.
   new CacheFirst({
     // Use a custom cache name.

--- a/src/content/en/tools/workbox/guides/route-requests.md
+++ b/src/content/en/tools/workbox/guides/route-requests.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on how to route requests with Workbox.
 
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-15 #}
 {# wf_blink_components: N/A #}
 
@@ -128,18 +128,22 @@ registerRoute(
 ## Matching a Route with a Callback Function
 
 To allow developers to do anything they want to match a request, you can also
-provide a function that can determine whether a request should match a route on
-any criteria it wishes.
+provide a [`matchCallback` function](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback)
+that can determine whether a request should match a route on any criteria it wishes.
 
-The callback will receive an object with the request's URL and the `FetchEvent`
-received in the service worker.
+The function is passed an
+[`ExtendableEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent),
+[`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request), and a
+[`URL` object](https://developer.mozilla.org/en-US/docs/Web/API/URL).
+You indicate a match by returning a truthy value.
+
+For a simple example, you could match against a specific URL like so:
 
 ```javascript
 import {registerRoute} from 'workbox-routing';
 
-const matchFunction = ({url, event}) => {
-  // Return true if the route should match
-  return false;
+const matchFunction = ({url, request, event}) => {
+  return url.href === 'https://example.com/app.js';
 };
 
 registerRoute(
@@ -162,26 +166,26 @@ There are two ways you can  handle a request:
 Most routes can be handled with one of the built in caching strategies.
 
 - Stale While Revalidate
-    - This strategy will use a cached response for a request if it is
-    available and update the cache in the background with a response form
-    the network. (If it’s not cached it will wait for the network response
-    and use that.) This is a fairly safe strategy as it means users are
-    regularly updating their cache. The downside of this strategy is that
-    it’s always requesting an asset from the network, using up the user’s
-    bandwidth.
+  - This strategy will use a cached response for a request if it is
+  available and update the cache in the background with a response form
+  the network. (If it’s not cached it will wait for the network response
+  and use that.) This is a fairly safe strategy as it means users are
+  regularly updating their cache. The downside of this strategy is that
+  it’s always requesting an asset from the network, using up the user’s
+  bandwidth.
 - Network First
-    - This will try to get a response from the network first. If it receives
-    a response, it’ll pass that to the browser and also save it to a cache.
-    If the network request fails, the last cached response will be used.
+  - This will try to get a response from the network first. If it receives
+  a response, it’ll pass that to the browser and also save it to a cache.
+  If the network request fails, the last cached response will be used.
 - Cache First
-    - This strategy will check the cache for a response first and use that
-    if one is available. If the request isn’t in the cache, the network will
-    be used and any valid response will be added to the cache before being
-    passed to the browser.
+  - This strategy will check the cache for a response first and use that
+  if one is available. If the request isn’t in the cache, the network will
+  be used and any valid response will be added to the cache before being
+  passed to the browser.
 - Network Only
-    - Force the response to come from the network.
+  - Force the response to come from the network.
 - Cache Only
-    - Force the response to come from the cache.
+  - Force the response to come from the cache.
 
 Using these as your `handler` can be done like so:
 
@@ -261,10 +265,12 @@ it’ll be passed into the `handler` callback as a `params` argument.
 import {registerRoute} from 'workbox-routing';
 
 const match = ({url, event}) => {
-  return {
-    name: 'Workbox',
-    type: 'guide',
-  };
+  if (url.pathname === '/example') {
+    return {
+      name: 'Workbox',
+      type: 'guide',
+    };
+  }
 };
 
 const handler = async ({url, event, params}) => {

--- a/src/content/en/tools/workbox/guides/route-requests.md
+++ b/src/content/en/tools/workbox/guides/route-requests.md
@@ -128,7 +128,7 @@ registerRoute(
 ## Matching a Route with a Callback Function
 
 To allow developers to do anything they want to match a request, you can also
-provide a [`matchCallback` function](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback)
+provide a [`matchCallback` function](/web/tools/workbox/reference-docs/latest/module-workbox-routing#~matchCallback)
 that can determine whether a request should match a route on any criteria it wishes.
 
 The function is passed an

--- a/src/content/en/tools/workbox/guides/storage-quota.md
+++ b/src/content/en/tools/workbox/guides/storage-quota.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide on configuring Workbox to avoid storage quota issues.
 
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2018-06-26 #}
 {# wf_blink_components: N/A #}
 
@@ -30,8 +30,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {ExpirationPlugin} from 'workbox-expiration';
 
 registerRoute(
-  // Match common image extensions.
-  new RegExp('\\.(?:png|gif|jpg|jpeg|svg)$'),
+  ({request}) => request.destination === 'image',
   // Use a cache-first strategy with the following config:
   new CacheFirst({
     // You need to provide a cache name when using expiration.

--- a/src/content/en/tools/workbox/guides/using-bundlers.md
+++ b/src/content/en/tools/workbox/guides/using-bundlers.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: Advanced recipes to use with Workbox.
 
 {# wf_published_on: 2019-02-24 #}
-{# wf_updated_on: 2020-04-23 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_blink_components: N/A #}
 
 # Using Bundlers (webpack/Rollup) with Workbox {: .page-title }
@@ -108,7 +108,7 @@ import {CacheFirst} from 'workbox-strategies/CacheFirst.mjs';
 import {ExpirationPlugin} from 'workbox-expiration/ExpirationPlugin.mjs';
 
 registerRoute(
-  /\.(?:png|gif|jpg|jpeg|svg)$/,
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'images',
     plugins: [

--- a/src/content/en/tools/workbox/guides/using-plugins.md
+++ b/src/content/en/tools/workbox/guides/using-plugins.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to using plugins with Workbox.
 
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: n/a #}
 
@@ -50,7 +50,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {ExpirationPlugin} from 'workbox-expiration';
 
 registerRoute(
-  /\.(?:png|gif|jpg|jpeg|svg)$/,
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'images',
     plugins: [

--- a/src/content/en/tools/workbox/modules/workbox-broadcast-update.md
+++ b/src/content/en/tools/workbox/modules/workbox-broadcast-update.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-background-sync.
 
-{# wf_updated_on: 2020-02-12 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-29 #}
 {# wf_blink_components: N/A #}
 
@@ -62,7 +62,7 @@ import {StaleWhileRevalidate} from 'workbox-strategies';
 import {BroadcastUpdatePlugin} from 'workbox-broadcast-update';
 
 registerRoute(
-  new RegExp('/api/'),
+  ({url}) => url.pathname.startsWith('/api/'),
   new StaleWhileRevalidate({
     plugins: [
       new BroadcastUpdatePlugin(),
@@ -127,7 +127,7 @@ import {StaleWhileRevalidate} from 'workbox-strategies';
 import {BroadcastUpdatePlugin} from 'workbox-broadcast-update';
 
 registerRoute(
-  new RegExp('/api/'),
+  ({url}) => url.pathname.startsWith('/api/'),
   new StaleWhileRevalidate({
     plugins: [
       new BroadcastUpdatePlugin({

--- a/src/content/en/tools/workbox/modules/workbox-cacheable-response.md
+++ b/src/content/en/tools/workbox/modules/workbox-cacheable-response.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-cacheable-response.
 
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-27 #}
 {# wf_blink_components: N/A #}
 
@@ -33,7 +33,8 @@ import {CacheFirst} from 'workbox-strategies';
 import {CacheableResponsePlugin} from 'workbox-cacheable-response';
 
 registerRoute(
-  new RegExp('^https://third-party\\.example\\.com/images/'),
+  ({url}) => url.origin === 'https://third-party.example.com' &&
+             url.pathname.startsWith('/images/'),
   new CacheFirst({
     cacheName: 'image-cache',
     plugins: [
@@ -64,7 +65,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {CacheableResponsePlugin} from 'workbox-cacheable-response';
 
 registerRoute(
-  new RegExp('/path/to/api/'),
+  ({url}) => url.pathname.startsWith('/path/to/api/'),
   new StaleWhileRevalidate({
     cacheName: 'api-cache',
     plugins: [
@@ -99,7 +100,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {CacheableResponsePlugin} from 'workbox-cacheable-response';
 
 registerRoute(
-  new RegExp('/path/to/api/'),
+  ({url}) => url.pathname.startsWith('/path/to/api/'),
   new StaleWhileRevalidate({
     cacheName: 'api-cache',
     plugins: [

--- a/src/content/en/tools/workbox/modules/workbox-expiration.md
+++ b/src/content/en/tools/workbox/modules/workbox-expiration.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-expiration.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-30 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Expiration {: .page-title }
@@ -28,7 +28,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {ExpirationPlugin} from 'workbox-expiration';
 
 registerRoute(
-  new RegExp('/images/'),
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'image-cache',
     plugins: [
@@ -58,7 +58,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {ExpirationPlugin} from 'workbox-expiration';
 
 registerRoute(
-  /\/images\//,
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'image-cache',
     plugins: [

--- a/src/content/en/tools/workbox/modules/workbox-range-requests.md
+++ b/src/content/en/tools/workbox/modules/workbox-range-requests.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-range-requests.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Range Requests {: .page-title }
@@ -35,7 +35,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {RangeRequestsPlugin} from 'workbox-range-requests';
 
 registerRoute(
-  /\.mp4$/,
+  ({url}) => url.pathname.endsWith('.mp4'),
   new CacheFirst({
     plugins: [
       new RangeRequestsPlugin(),

--- a/src/content/en/tools/workbox/modules/workbox-strategies.md
+++ b/src/content/en/tools/workbox/modules/workbox-strategies.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-routing.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-04-06 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Strategies {: .page-title }
@@ -47,7 +47,7 @@ import {registerRoute} from 'workbox-routing';
 import {StaleWhileRevalidate} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('/images/avatars/'),
+  ({url}) => url.pathname.startsWith('/images/avatars/'),
   new StaleWhileRevalidate()
 );
 ```
@@ -71,7 +71,7 @@ import {registerRoute} from 'workbox-routing';
 import {CacheFirst} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('/styles/'),
+  ({request}) => request.destination === 'style',
   new CacheFirst()
 );
 ```
@@ -92,7 +92,7 @@ import {registerRoute} from 'workbox-routing';
 import {NetworkFirst} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('/social-timeline/'),
+  ({url}) => url.pathname.startsWith('/social-timeline/'),
   new NetworkFirst()
 );
 ```
@@ -110,7 +110,7 @@ import {registerRoute} from 'workbox-routing';
 import {NetworkOnly} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('/admin/'),
+  ({url}) => url.pathname.startsWith('/admin/'),
   new NetworkOnly()
 );
 ```
@@ -128,7 +128,7 @@ import {registerRoute} from 'workbox-routing';
 import {CacheOnly} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('/app/v2/'),
+  ({url}) => url.pathname.startsWith('/app/v2/'),
   new CacheOnly()
 );
 ```
@@ -151,7 +151,7 @@ import {registerRoute} from 'workbox-routing';
 import {CacheFirst} from 'workbox-strategies';
 
 registerRoute(
-  new RegExp('/images/'),
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'image-cache',
   })
@@ -177,7 +177,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {ExpirationPlugin} from 'workbox-expiration';
 
 registerRoute(
-  new RegExp('/images/'),
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     cacheName: 'image-cache',
     plugins: [

--- a/src/content/en/tools/workbox/modules/workbox-sw.md
+++ b/src/content/en/tools/workbox/modules/workbox-sw.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-sw.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2020-05-01 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox {: .page-title }
@@ -87,7 +87,7 @@ importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}
 
 // This will work!
 workbox.routing.registerRoute(
-  new RegExp('\\.png$'),
+  ({request}) => request.destination === 'image',
   new workbox.strategies.CacheFirst()
 );
 </pre>
@@ -195,7 +195,7 @@ import {CacheFirst} from 'workbox-strategies';
 import {CacheableResponse} from 'workbox-cacheable-response';
 
 registerRoute(
-  /\.(?:png|jpg|jpeg|svg|gif)$/,
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     plugins: [
       new CacheableResponsePlugin({statuses: [0, 200]})
@@ -215,7 +215,7 @@ const {CacheFirst} = workbox.strategies;
 const {CacheableResponse} = workbox.cacheableResponse;
 
 registerRoute(
-  /\.(?:png|jpg|jpeg|svg|gif)$/,
+  ({request}) => request.destination === 'image',
   new CacheFirst({
     plugins: [
       new CacheableResponsePlugin({statuses: [0, 200]})


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/workbox/issues/2486 by using `matchCallback` functions with appropriate predicates instead of `RegExp` objects in most places in our docs. (`RegExp` objects are still fully supported, but an explicit `matchCallback` can be cleaner.)

R: @petele @philipwalton 
CC: @tomayac because I think he suggested we do this a while ago 😄 
