### PR TITLE
Parameter in precacheAndRoute code sample changed to reflect v5

### DIFF
--- a/src/content/en/tools/workbox/guides/precache-files/workbox-build.md
+++ b/src/content/en/tools/workbox/guides/precache-files/workbox-build.md
@@ -23,7 +23,7 @@ Before the files can be "injected" into your service worker, you need to add
 this line of code to your service worker file:
 
 ```javascript
-workbox.precaching.precacheAndRoute([]);
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST);
 ```
 
 This piece of code will be replaced by `workbox-build` with the list of files. (See


### PR DESCRIPTION
Changed `[]` to `self.__WB_MANIFEST` like stated in the migration to v5 guide

What's changed, or what was fixed?
- Doc page for Workbox v5 precaching: https://developers.google.com/web/tools/workbox/guides/precache-files/workbox-build

**CC:** @jeffposnick 
