### PR TITLE
Remove CrUX from _book.yaml

### DIFF
--- a/src/content/en/tools/_book.yaml
+++ b/src/content/en/tools/_book.yaml
@@ -28,6 +28,7 @@ upper_tabs:
           path: /web/tools/workbox/
       - name: Chrome User Experience Report
         contents:
-        - include: /web/tools/chrome-user-experience-report/_toc.yaml
+        - title: Chrome User Experience Report
+          path: /web/tools/chrome-user-experience-report/
   - include: /web/_upper_tabs-Updates.yaml
   - include: /web/_upper_tabs-Showcase.yaml


### PR DESCRIPTION
What's changed, or what was fixed?
- Removes the CrUX `_toc.yaml` from the tools `_book.yaml` so it can live on its own

**CC:** @rviscomi
