### PR TITLE
Figure X replaced respectively by Figure 8 and Figure 9

### DIFF
--- a/src/content/en/tools/chrome-devtools/console/reference.md
+++ b/src/content/en/tools/chrome-devtools/console/reference.md
@@ -151,7 +151,7 @@ default message grouping behavior. See [Log XHR and Fetch requests](#xhr) for an
   </figcaption>
 </figure>
 
-The top message in **Figure X** shows the Console's default grouping behavior. **Figure X** shows
+The top message in **Figure 8** shows the Console's default grouping behavior. **Figure 9** shows
 how the same log looks after [disabling message grouping](#group).
 
 <figure>


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixing typos in reference.md

**Fixes:** https://github.com/google/WebFundamentals/issues/8475

**CC:** @petele
