### PR TITLE
Update instructions for DevTools feature request

### DIFF
--- a/src/content/en/tools/chrome-devtools/index.md
+++ b/src/content/en/tools/chrome-devtools/index.md
@@ -188,17 +188,9 @@ Debug mixed content issues, certificate problems, and more.
   }
 </style>
 
-The best place to file feature requests for Chrome DevTools is the mailing list.
-The team needs to understand use cases, gauge community interest, and discuss
-feasibility before implementing any new features.
+File bug reports and feature requests in Crbug, which is the engineering team's bug tracker.
 
-<a class="button button-primary gc-analytics-event cdt-but"
-   href="https://groups.google.com/forum/#!forum/google-chrome-developer-tools"
-   data-category="DevTools" data-label="Home / Mailing List">Mailing List</a>
-
-File bug reports in Crbug, which is the engineering team's bug tracker.
-
-<a class="button button-primary gc-analytics-event" href="https://crbug.com"
+<a class="button button-primary gc-analytics-event" href="https://crbug.com/new"
    data-category="DevTools" data-label="Home / Crbug">Crbug</a>
 
 If you want to alert us to a bug or feature request but don't have much time,


### PR DESCRIPTION
Update instructions for DevTools feature request.

https://groups.google.com/forum/#!forum/google-chrome-developer-tools

The [mailing list](https://groups.google.com/forum/#!forum/google-chrome-developer-tools) explicitly asks feature requests go in to crbug

<img width="778" alt="Screenshot 2020-05-28 at 14 49 01" src="https://user-images.githubusercontent.com/1027024/83149859-88732a00-a0f2-11ea-9692-28d41c478efd.png">


- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
