### PR TITLE
Fix broken link in command menu

### DIFF
--- a/src/content/en/tools/chrome-devtools/css/reference.md
+++ b/src/content/en/tools/chrome-devtools/css/reference.md
@@ -183,7 +183,7 @@ tutorial.
 
 To view a page in print mode:
 
-1. Open the [Command Menu](/web/tools/chrome-devtools/ui#command-menu).
+1. Open the [Command Menu](/web/tools/chrome-devtools/command-menu).
 1. Start typing `Rendering` and select `Show Rendering`.
 1. For the **Emulate CSS Media** dropdown, select **print**.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Fix broken link in command menu

**Fixes:** https://github.com/google/WebFundamentals/issues/8767


**CC:** @petele
