### PR TITLE
Fix broken link IndexedDB Chrome Devtools

### DIFF
--- a/src/content/en/tools/chrome-devtools/storage/indexeddb.md
+++ b/src/content/en/tools/chrome-devtools/storage/indexeddb.md
@@ -2,7 +2,7 @@ project_path: /web/tools/_project.yaml
 book_path: /web/tools/_book.yaml
 description: How to view and change IndexedDB data with the Application panel and Snippets.
 
-{# wf_updated_on: 2019-03-19 #}
+{# wf_updated_on: 2020-06-19 #}
 {# wf_published_on: 2019-03-18 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -72,7 +72,7 @@ IndexedDB. If not, see [Using IndexedDB][IDB]{: .external }.
 1. Click an object store to see its key-value pairs.
 
      <aside class="caution">
-       IndexedDB data does not update in real-time. See <a href="refresh">Refresh
+       IndexedDB data does not update in real-time. See <a href="#refresh">Refresh
        IndexedDB data</a>.
      </aside>
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Changed `href` of link on IndexedDB Chrome Devtools page.

**Fixes:** #8759

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
