### PR TITLE
Fixes broken link on Updates 2019/02 Model Viewer page 

### DIFF
--- a/src/content/en/updates/2019/02/model-viewer.md
+++ b/src/content/en/updates/2019/02/model-viewer.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Adding 3D models to a website can be tricky for a variety of reasons including the hosting issues and the high bar of 3D programming. That's why we're introducing the &lt;model-viewer&gt; web component to let you use 3D models declaratively.
 
-{# wf_updated_on: 2019-05-02 #}
+{# wf_updated_on: 2020-06-15 #}
 {# wf_published_on: 2019-02-06 #}
 {# wf_tags: 3d,model-viewer #}
 {# wf_featured_image: /web/updates/images/2019/02/space-suit.png #}
@@ -12,7 +12,7 @@ description: Adding 3D models to a website can be tricky for a variety of reason
 # The model-viewer web component {: .page-title}
 
 Note: We're always [updating and improving](https://github.com/GoogleWebComponents/model-viewer/releases)
-`<model-viewer>`. Check out the [`<model-viewer>` homepage](https://googlewebcomponents.github.io/model-viewer/)
+`<model-viewer>`. Check out the [`<model-viewer>` homepage](https://modelviewer.dev/)
 to explore what it can do.
 
 {% include "web/_shared/contributors/josephmedley.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes broken link on Updates 2019/02 Model Viewer page 

**Fixes:** #8737

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
