### PR TITLE
Invalid aria in Introduction to ARIA page 

### DIFF
--- a/src/content/en/fundamentals/accessibility/semantics-aria/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/index.md
@@ -4,7 +4,7 @@ description: Introduction to ARIA and non-native HTML semantics
 
 
 {# wf_blink_components: Blink>Accessibility #}
-{# wf_updated_on: 2018-09-20 #}
+{# wf_updated_on: 2020-06-15 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Introduction to ARIA {: .page-title }
@@ -119,7 +119,7 @@ with plain HTML.
 
 <div class="clearfix"></div>
 
-    <div aria-live="true">
+    <div aria-live="polite">
       <span>GOOG: $400</span>
     </div>
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Fix invalid aria in Introduction to ARIA page

**Fixes:** #8642

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
