### PR TITLE
Fix link to Trusted Web Activity

### DIFF
--- a/src/content/en/android/custom-tabs/index.md
+++ b/src/content/en/android/custom-tabs/index.md
@@ -109,7 +109,7 @@ For questions, check the [chrome-custom-tabs][5] tag on StackOverflow.
 [5]: https://stackoverflow.com/questions/tagged/chrome-custom-tabs
 [6]: https://research.google/pubs/pub46739/
 [7]: https://android-developers.googleblog.com/2015/09/chrome-custom-tabs-smooth-transition.html
-[8]: /web/android/trusted-web/activity
+[8]: /web/android/trusted-web-activity
 [9]: https://web.dev/progressive-web-apps/
 [10]: https://developers.google.com/digital-asset-links
 [11]: /web/android/custom-tabs/implementation-guide/


### PR DESCRIPTION
What's changed, or what was fixed?
- Link to Trusted Web Activity in the [When should I use Custom Tabs vs Trusted Web Activity](https://developers.google.com/web/android/custom-tabs/#when_should_i_use_custom_tabs_vs_trusted_web_activity) section no longer returns a 404

**Target Live Date:** 2020-07-01

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
