### PR TITLE
Update incorrect rendered Lighthouse URL

### DIFF
--- a/src/content/en/updates/2020/06/devtools.md
+++ b/src/content/en/updates/2020/06/devtools.md
@@ -37,10 +37,9 @@ Chromium issue [#946975](https://crbug.com/946975)
 ## Lighthouse 6 in the Lighthouse panel {: #lighthouse }
 
 [changelog]: https://github.com/GoogleChrome/lighthouse/releases/tag/v6.0.0
-[lighthouse]: https://web.dev/lighthouse-whats-new-6.0/
 
 The Lighthouse panel is now running Lighthouse 6.
-Check out [What's New in Lighthouse 6.0](lighthouse) for a summary of all the major
+Check out [What's New in Lighthouse 6.0](https://web.dev/lighthouse-whats-new-6.0/) for a summary of all the major
 changes, or the [v6.0.0 release notes](https://github.com/GoogleChrome/lighthouse/releases/tag/v6.0.0)
 for a full list of all changes.
 


### PR DESCRIPTION
The URL clashes with local id

What's changed, or what was fixed?
- Update incorrect rendered Lighthouse URL

**Target Live Date:** 2020-06-25

- [x] This has been reviewed and approved by (@chybie )
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
