### PR TITLE
Fixes "Full Demo" broken link 

### DIFF
--- a/src/content/en/updates/2011/08/Downloading-resources-in-HTML5-a-download.md
+++ b/src/content/en/updates/2011/08/Downloading-resources-in-HTML5-a-download.md
@@ -1,7 +1,7 @@
 project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 
-{# wf_updated_on: 2019-01-16 #}
+{# wf_updated_on: 2020-06-26 #}
 {# wf_published_on: 2011-08-01 #}
 {# wf_tags: news #}
 {# wf_blink_components: N/A #}
@@ -28,7 +28,7 @@ For example, clicking the following link downloads the .png as "MyGoogleLogo.png
 The real benefit of `a[download]` will be when working with [blob: URLs](//www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-bloburis) and [filesystem: URLs](http://html5-demos.appspot.com/static/filesystem/generatingResourceURIs.html) URLs.
 It'll give users a way to download content created/modified within your app.
 
-[Full Demo](http://html5-demos.appspot.com/static/a.download.html)
+[Full Demo](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_a_download)
 
 Browser support: only the current Chrome dev channel release (14.0.835.15+) supports this attribute.
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Changed "Full Demo" link URL in "Downloading resources in HTML5: a[download]" page

**Fixes:** #8764 

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
