### PR TITLE
Fixes grammar error in Introduction to Aria page

### DIFF
--- a/src/content/en/fundamentals/accessibility/semantics-aria/index.md
+++ b/src/content/en/fundamentals/accessibility/semantics-aria/index.md
@@ -4,7 +4,7 @@ description: Introduction to ARIA and non-native HTML semantics
 
 
 {# wf_blink_components: Blink>Accessibility #}
-{# wf_updated_on: 2020-06-15 #}
+{# wf_updated_on: 2020-06-27 #}
 {# wf_published_on: 2016-10-04 #}
 
 # Introduction to ARIA {: .page-title }
@@ -114,7 +114,7 @@ with plain HTML.
 
     
 
- - And ARIA can make parts of the page "live", so they immediately inform
+ - And ARIA can make parts of the page "live," so they immediately inform
    assistive technology when they change.
 
 <div class="clearfix"></div>


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes grammar error in Introduction to Aria page;

**Fixes:** #7925

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
