### PR TITLE
Fixes Fibonacci example

### DIFF
--- a/src/content/en/updates/2018/03/emscripting-a-c-library.md
+++ b/src/content/en/updates/2018/03/emscripting-a-c-library.md
@@ -138,7 +138,7 @@ arguments, in that order:
 
 If you [run this
 code](https://googlechrome.github.io/samples/webassembly/index.html), you should
-see the "233" in the console, which is the 12th Fibonacci number.
+see the "144" in the console, which is the 12th Fibonacci number.
 
 Note: Emscripten offers a couple of options to handle loading multiple modules.
 More about that in their

--- a/src/content/en/updates/2018/03/emscripting-a-c-library.md
+++ b/src/content/en/updates/2018/03/emscripting-a-c-library.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Emscripting a C library to Wasm
 
-{# wf_updated_on: 2019-09-15 #}
+{# wf_updated_on: 2020-06-27 #}
 {# wf_published_on: 2018-03-05 #}
 {# wf_tags: webassembly #}
 {# wf_featured_image: /web/updates/images/2018/03/emscripting-a-c-library/wasmcode.png #}
@@ -69,8 +69,11 @@ calculates the n<sup>th</sup> fibonacci number:
 
     EMSCRIPTEN_KEEPALIVE
     int fib(int n) {
+      if(n <= 0){
+        return 0;
+      }
       int i, t, a = 0, b = 1;
-      for (i = 0; i < n; i++) {
+      for (i = 1; i < n; i++) {
         t = a + b;
         a = b;
         b = t;


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes Fibonacci example in Emscripting a C library to Wasm page

**Fixes:** #7634

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
