### PR TITLE
docs: Fix typo, link to package visibility page

### DIFF
--- a/src/content/en/android/custom-tabs/best-practices/index.md
+++ b/src/content/en/android/custom-tabs/best-practices/index.md
@@ -132,7 +132,7 @@ public static ArrayList<ResolveInfo> getCustomTabsPackages(Context context) {
 
 ### Applications targeting Android 11 (API level 30) or above
 
-Android 11 has introduced [package visiblity changes][31]. If your Android app is targeting API
+Android 11 has introduced [package visibility changes][7]. If your Android app is targeting API
 level 30 or above, adding a `queries` section to `AndroidManifest.xml` is needed, otherwise the
 code snippet above won't return results:
 
@@ -347,3 +347,4 @@ clicks multiple times on the same link and does not open a Custom Tab multiple t
 [4]: https://developer.android.com/reference/android/webkit/WebView.html
 [5]: https://developer.android.com/reference/android/widget/TextView.html#attr_android:autoLink
 [6]: https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_REQUIRE_NON_BROWSER
+[7]: https://developer.android.com/preview/privacy/package-visibility


### PR DESCRIPTION
What's changed, or what was fixed?
- On the [Custom Tabs Best Practices page](https://developers.google.com/web/android/custom-tabs/best-practices), the link to the page about package visibility changes in Android 11 is now valid and spelled correctly.

**Target Live Date:** 2020-07-20

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
