### PR TITLE
Workbox: Updates to using bundlers guide

### DIFF
--- a/src/content/en/tools/workbox/guides/_toc.yaml
+++ b/src/content/en/tools/workbox/guides/_toc.yaml
@@ -1,6 +1,8 @@
 toc:
 - title: "Get Started"
   path: /web/tools/workbox/guides/get-started
+- title: "Using bundlers with Workbox"
+  path: /web/tools/workbox/guides/using-bundlers
 - title: "Precache Files"
   path: /web/tools/workbox/guides/precache-files
   style: accordion
@@ -21,8 +23,6 @@ toc:
   path: /web/tools/workbox/guides/using-plugins
 - title: "Enable Offline Google Analytics"
   path: /web/tools/workbox/guides/enable-offline-analytics
-- title: "Using Bundlers (webpack/Rollup) with Workbox"
-  path: /web/tools/workbox/guides/using-bundlers
 - title: "Troubleshoot and Debug"
   path: /web/tools/workbox/guides/troubleshoot-and-debug
 - title: "Understanding Storage Quota"

--- a/src/content/en/tools/workbox/guides/using-bundlers.md
+++ b/src/content/en/tools/workbox/guides/using-bundlers.md
@@ -73,7 +73,7 @@ The [`InjectManifest` plugin](/web/tools/workbox/modules/workbox-webpack-plugin#
 
 ### CLI setup
 
-Instead of using a bundler plugin, you can run [`workbox-cli`](https://developers.google.com/web/tools/workbox/modules/workbox-cli) in [`injectManifest` mode](https://developers.google.com/web/tools/workbox/modules/workbox-cli#injectmanifest).
+Instead of using a bundler plugin, you can run [`workbox-cli`](/web/tools/workbox/modules/workbox-cli) in [`injectManifest` mode](/web/tools/workbox/modules/workbox-cli#injectmanifest).
 
 If you take this approach, you should run the `injectManifest` step immediately following each successful build, passing in your freshly bundled service worker file as the `swSrc` option
 
@@ -91,4 +91,4 @@ These examples feature build processes that use bundling, and in some cases also
 
 ## Using the CDN is an alternative to bundling
 
-While we expect that most developers will eventually migrate to a bundler approach, using the Workbox runtime code from the official CDN, loaded via `workbox-sw`, remains a supported alternative. For more information, please see the [`workbox-sw` documentation](https://developers.google.com/web/tools/workbox/modules/workbox-sw).
+While we expect that most developers will eventually migrate to a bundler approach, using the Workbox runtime code from the official CDN, loaded via `workbox-sw`, remains a supported alternative. For more information, please see the [`workbox-sw` documentation](/web/tools/workbox/modules/workbox-sw).

--- a/src/content/en/tools/workbox/guides/using-bundlers.md
+++ b/src/content/en/tools/workbox/guides/using-bundlers.md
@@ -1,302 +1,94 @@
 project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
-description: Advanced recipes to use with Workbox.
+description: Using build tools to bundle the Workbox runtime into a custom service worker.
 
 {# wf_published_on: 2019-02-24 #}
-{# wf_updated_on: 2020-05-01 #}
+{# wf_updated_on: 2020-07-16 #}
 {# wf_blink_components: N/A #}
 
-# Using Bundlers (webpack/Rollup) with Workbox {: .page-title }
+# Using bundlers with Workbox {: .page-title }
 
-One of the core principles we have for Workbox is to make it as small and
-light-weight as possible. We want Workbox to have lots of features, but we don't
-want your users to have to download code for features they don't use.
+Starting with the [v5 release](https://github.com/GoogleChrome/workbox/releases/tag/v5.0.0), Workbox can be used inside of a service worker source file via [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 
-This is why the version of Workbox we release on our CDN is configured to
-[automatically only load the packages you're
-using](/web/tools/workbox/guides/get-started#importing_workbox)
-(via `workbox-sw`) when they're referenced. For example, if your code never
-references `workbox.backgroundSync`, then the `workbox-background-sync` package
-will not be downloaded.
+Using Workbox in this fashion allows you to pull in precisely the bits of Workbox that you plan on using, and leads to a smaller overall service worker file. Creating your own bundles of the Workbox runtime libraries also means that you don't need to load the Workbox runtime from third-party web servers.
 
-While only loading the _packages_ being used is a good first step in reducing
-your total service worker file size, you can often reduce the total size even
-more by only loading the specific modules your code imports.
+## Creating a service worker bundle
 
-You can do this using JavaScript bundling tools like
-[webpack](https://webpack.js.org/) or [Rollup](https://rollupjs.org) to build
-your own custom service worker file. This guide will outline the recommended way
-to use bundlers with Workbox.
+### Choose a bundler
 
-## Importing workbox code into your bundle
+Any [bundler that supports JavaScript modules](https://bundlers.tooling.report/) will work when bundling the Workbox runtime libraries. Some popular choices include:
 
-When using Workbox without a bundler, you import Workbox into your service
-worker file using
-[`importScripts()`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts):
+- [webpack](https://webpack.js.org/)
+- [Rollup](https://rollupjs.org/guide/en/)
+- [Parcel](https://parceljs.org/)
 
-<pre class="prettyprint js">
-// Import workbox-sw, which defines the global `workbox` object.
-importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
+If you're already using a bundler for other parts of your web app, the using the same one for your service worker as part of your existing build process should work fine.
 
-// Then reference the workbox packages you need, which will dynamically
-// call `importScripts()` to load the individual packages.
-workbox.precaching.precacheAndRoute([...]);
-</pre>
+Please consult the documentation for each bundler to learn more about general configuration. There are a few Workbox-specific build options that are explained in the following sections.
 
-When using a JavaScript bundler, you don't need (and actually shouldn't use) the
-`workbox` global or the `workbox-sw` module, as you can import the individual
-package files directly.
+### Write your service worker source code
 
-Here's how you'd import and run the above code using a bundler:
+The following example is a hypothetical service worker source file that imports a few different Workbox libraries. This source file needs to be processed by a bundler before it could be run in a browser.
 
 ```javascript
-// Import just the `workbox-precaching` package.
+// These JavaScript module imports that need to be bundled:
 import {precacheAndRoute} from 'workbox-precaching';
+import {registerRoute} from 'workbox-routing';
+import {CacheFirst} from 'workbox-strategies';
 
-precacheAndRoute([...]);
-```
-
-### Determining import file paths
-
-The definitive way to know what file to import is to look at the [package source
-code](https://github.com/GoogleChrome/workbox/tree/master/packages), but to make
-it so you don't necessarily have to do that, we follow a few conventions that
-make it easy to know the path of the file:
-
-* Every [workbox package](/web/tools/workbox/modules/) is released as a
-  separate `npm` package with the name converted to
-  [kebab-case](https://en.wikipedia.org/wiki/Letter_case#Special_case_styles)
-  (e.g. the `workbox.backgroundSync` object maps to the
-  `workbox-background-sync` npm package).
-* Every property of each package object maps to a module file in the top-level
-  package directly with the same name, plus the `.mjs` extension (e.g.
-  `workbox.backgroundSync.Queue` is defined in
-  `workbox-background-sync/Queue.mjs`).
-* Any `.mjs` file in the top-level directory of a workbox package is considered
-  part of the public API and can be imported. Files in sub-directories should be
-  considered implementation details and should not be relied upon.
-
-### Moving from importScripts to module imports
-
-Here's a more complete example of taking code that uses `importScripts()` versus
-the same logic written for a bundler using `import` statements:
-
-<h4 class="hide-from-toc">Using <code>importScripts</code>:</h4>
-
-<pre class="prettyprint js">
-importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
-
-workbox.routing.registerRoute(
-  /\.(?:png|gif|jpg|jpeg|svg)$/,
-  new workbox.strategies.CacheFirst({
-    cacheName: 'images',
-    plugins: [
-      new workbox.expiration.ExpirationPlugin({
-        maxEntries: 60,
-        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
-      }),
-    ],
-  }),
-);
-</pre>
-
-<h4 class="hide-from-toc">Using <code>import</code> via a bundler:</h4>
-
-```javascript
-import {registerRoute} from 'workbox-routing/registerRoute.mjs';
-import {CacheFirst} from 'workbox-strategies/CacheFirst.mjs';
-import {ExpirationPlugin} from 'workbox-expiration/ExpirationPlugin.mjs';
-
+// Use the imported Workbox libraries to implement caching,
+// routing, and other logic:
+precacheAndRoute([self.__WB_MANIFEST]);
 registerRoute(
   ({request}) => request.destination === 'image',
-  new CacheFirst({
-    cacheName: 'images',
-    plugins: [
-      new ExpirationPlugin({
-        maxEntries: 60,
-        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
-      }),
-    ],
-  }),
+  new CacheFirst({cacheName: 'images'}),
 );
+
+// Etc.
 ```
 
-<aside class="caution">
-  <strong>Important!</strong>
-  When using a bundler to build your service worker, you don't need to import
-  the <code>workbox-sw</code> package. The <code>workbox-sw</code> package code
-  defines the global <code>workbox</code> object that loads the other workbox
-  packages (via <code>importScripts()</code>) when referenced, but if you're
-  using a bundler to build your service worker, this is unnecessary (and will
-  likely result in loading code twice).
-</aside>
+### Configure your bundler for a development or production build
 
-## Keeping dev-only code out of the bundle
+Workbox supports additional logging intended for development environments, and a quieter logging mode (with minifiable code that leads to a smaller runtime size) for production environments. Workbox does this by including references to `process.env.NODE_ENV` inside of its source code, and disables logging when that variable is set to `'production'`.
 
-One of the key developer features that  Workbox offers is its logging, but when
-deploying Workbox code to production, you don't want users to pay the price of
-downloading that developer-focused code.
+Your bundler is responsible for replacing `process.env.NODE_ENV` inside of Workbox's runtime code with either `'development'` or `'production'`. Here are details on how different bundlers handle this replacement:
 
-In the production builds of Workbox we release on our CDN, we've removed this
-code for you. But if you're making your own bundle, you'll need to do this
-yourself.
+- [webpack](https://webpack.js.org/guides/production/#specify-the-mode)
+- [Rollup](https://github.com/rollup/plugins/tree/master/packages/replace#readme)
+- [Parcel](https://parceljs.org/env.html)
 
-There are two things you should do to ensure dev-only code doesn't end up in a
-production bundle:
+## Optional: inject a precache manifest
 
-* Replace instances of `process.env.NODE_ENV` in the source with the string
-  `'production'`.
-* Using a minifier that will remove falsy conditionals.
+Many developers use Workbox for [precaching](/web/tools/workbox/modules/workbox-precaching) URLs that are generated as part of a build process. The convention is to use `self.__WB_MANIFEST` as a placeholder for these URLs in your service worker source code.
 
-To understand how this works, consider this simplified example of what most of
-the dev-only code looks like in Workbox:
+Replacing `self.__WB_MANIFEST` with a the actual URLs to precache isn't technically part of bundling, but bundling often happens as part of a larger build process. It's common to want to both bundle your service worker and perform the precache manifest injection using the same build tools.
 
-```javascript
-if (process.env.NODE_ENV !== 'production') {
-  console.log('This is a dev-only log message!');
-}
-```
+### webpack setup
 
-Using something like webpack's
-[DefinePlugin](https://webpack.js.org/plugins/define-plugin/) or
-[rollup-plugin-replace](https://github.com/rollup/rollup-plugin-replace), you
-can replace all occurrences of `process.env.NODE_ENV` with the string
-'production'. That means the above conditional will turn into the following
-block, and a minifier can safely discard the entire block (because it will never
-be true that `'production' !=== 'production'`).
+The [`InjectManifest` plugin](/web/tools/workbox/modules/workbox-webpack-plugin#injectmanifest_plugin) handles both bundling and also injecting the precache manifest for you. When using this plugin, you don't have to configure your service worker source code as a [separate entry](https://webpack.js.org/concepts/entry-points/).
 
-```javascript
-if ('production' !== 'production') {
-  console.log('This is a dev-only log message!');
-}
-```
+### Rollup setup
 
-The following examples show how you can set up minification and dev-only code
-removal in both webpack and Rollup:
+[`rollup-plugin-workbox-inject`](https://github.com/chromeos/static-site-scaffold-modules/blob/master/modules/rollup-plugin-workbox-inject/README.md) handles the precache manifest injection step for you, and assumes that you've already configured Rollup to bundle your service worker source file.
 
-### Webpack
+### CLI setup
 
-```javascript
-const webpack = require('webpack');
-const Terser = require('terser-webpack-plugin');
+Instead of using a bundler plugin, you can run [`workbox-cli`](https://developers.google.com/web/tools/workbox/modules/workbox-cli) in [`injectManifest` mode](https://developers.google.com/web/tools/workbox/modules/workbox-cli#injectmanifest).
 
-module.exports = {
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production'),
-    }),
-  ],
-  optimization: {
-    // Use terser instead of the default Uglify since service
-    // worker code does not need to be transpiled to ES5.
-    minimizer: [new Terser({
-      // Ensure .mjs files get included.
-      test: /\.m?js$/,
-    })],
-    // ...
-  },
-  // ...
-};
-```
+If you take this approach, you should run the `injectManifest` step immediately following each successful build, passing in your freshly bundled service worker file as the `swSrc` option
 
-### Rollup
+## GenerateSW handles bundling for you
 
-```javascript
-import replace from 'rollup-plugin-replace';
-import {terser} from 'rollup-plugin-terser';
+If you're using `generateSW` mode in either `workbox-build` or `workbox-cli`, or `GenerateSW` in `workbox-webpack-plugin`, then you don't need to configure bundling. Those tools will automatically generate a browser-ready service worker for you. Under the hood, Rollup is automatically used to produce the final bundle, based on the declarative configuration you provide.
 
-export default {
-  plugins: [
-    replace({
-      'process.env.NODE_ENV': JSON.stringify('production'),
-    }),
-    terser(),
-  ],
-  // ...
-}
-```
+## Examples
 
-## Using bundlers with Workbox's existing build tools
+These examples feature build processes that use bundling, and in some cases also inject a precache manifest into the built service worker file.
 
-### `workbox-build`
+- [https://github.com/GoogleChromeLabs/so-pwa](https://github.com/GoogleChromeLabs/so-pwa) (Rollup)
+- [https://github.com/jeffposnick/jeffposnick.github.io](https://github.com/jeffposnick/jeffposnick.github.io) (Rollup)
+- [https://gist.github.com/jeffposnick/fc761c06856fa10dbf93e62ce7c4bd57](https://gist.github.com/jeffposnick/fc761c06856fa10dbf93e62ce7c4bd57) (webpack)
 
-The `workbox-build` package has a mode known as `injectManifest`, which replaces
-the string `precacheAndRoute([])` in a file with a reference to the generated
-manifest.
+## Using the CDN is an alternative to bundling
 
-The main thing to consider when using a bundler is that if you import the
-`precacheAndRoute()` method as a different name, the manifest injection will not
-work, and you'd have to manually set your own replace regular expression.
-
-### `workbox-webpack-plugin`
-
-The primary purpose of `workbox-webpack-plugin` is to help developers create a
-precache manifest based on the files generated from their webpack build process.
-
-If you also want to use webpack to generate your service worker file (as
-described in this article), beware that the `workbox-webpack-plugin`'s
-[injectManifest config](/web/tools/workbox/modules/workbox-build#full_injectmanifest_config)
-accepts a `swSrc` option that it will update with your precache manifest.
-
-This can be problematic if you're using the same webpack configuration to
-generate your service worker file, since it may not exist by the time the
-`workbox-webpack-plugin` code runs.
-
-## Code splitting and dynamic imports
-
-Many bundlers today have some form of automatic [code
-splitting](/web/fundamentals/performance/optimizing-javascript/code-splitting/)
-based on [dynamic imports](/web/updates/2017/11/dynamic-import), where the
-bundler automatically determines how to best split up your final JavaScript code
-so logic that might not be needed by the user right away can be loaded at a
-later time.
-
-If you're using this feature with your bundler and you're also building a
-service worker, there are a few important gotchas to consider:
-
-* Most bundlers polyfill a version of the browsers native
-  [`import()`](/web/updates/2017/11/dynamic-import) feature, and these polyfills
-  are usually based on creating a `<script>` element, which will fail when run
-  in a service worker.
-* Along the same lines, bundlers today (as of the most recent Workbox version)
-  do not support sharing the same modules between the window and a service
-  worker. This will not be possible until service worker supports [dynamic
-  imports](/web/updates/2017/11/dynamic-import).
-
-Because of this, you should not use the dynamic import syntax in your service
-worker's JavaScript.
-
-## ES2015 syntax
-
-One of the main reasons people use bundlers today is to also use transpilers to
-convert their modern JavaScript syntax to
-[ES5](https://en.wikipedia.org/wiki/ECMAScript#5th_Edition) so it can be run in
-older browsers.
-
-Keep in mind that every browser that supports service workers also supports most
-[ES2015](https://en.wikipedia.org/wiki/ECMAScript#6th_Edition_-_ECMAScript_2015)
-features (the primary exception being `import` statements), so there's usually
-no need to transpile your code.
-
-This means you can freely use features like classes and syntax like
-`async`/`await` when writing service worker code, which is fantastic as most
-service worker APIs are promise-based.
-
-<aside>
-  <strong>Note:</strong>
-  an exception to this is the <code>workbox-window</code> package, because
-  its code will run in the window context, and not in the service worker. For
-  specific advice on using <code>workbox-window</code> with JavaScript bundlers,
-  see the
-  <a href="/web/tools/workbox/modules/workbox-window#loading_workbox_with_javascript_bundlers">
-  <code>workbox-window</code> usage guide</a>.
-</aside>
-
-## Third-party bundler plugins
-
-The following is a list of bundler plugins that integrate with Workbox. Note:
-these plugins are not maintained by the Workbox core team, so they might not be
-up-to-date with the most recent Workbox version:
-
-- [rollup-plugin-workbox](https://www.npmjs.com/package/rollup-plugin-workbox)
-- [rollup-plugin-workbox-inject](https://www.npmjs.com/package/rollup-plugin-workbox-inject)
+While we expect that most developers will eventually migrate to a bundler approach, using the Workbox runtime code from the official CDN, loaded via `workbox-sw`, remains a supported alternative. For more information, please see the [`workbox-sw` documentation](https://developers.google.com/web/tools/workbox/modules/workbox-sw).

--- a/src/content/en/tools/workbox/guides/using-bundlers.md
+++ b/src/content/en/tools/workbox/guides/using-bundlers.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: Using build tools to bundle the Workbox runtime into a custom service worker.
 
 {# wf_published_on: 2019-02-24 #}
-{# wf_updated_on: 2020-07-16 #}
+{# wf_updated_on: 2020-07-22 #}
 {# wf_blink_components: N/A #}
 
 # Using bundlers with Workbox {: .page-title }
@@ -22,16 +22,16 @@ Any [bundler that supports JavaScript modules](https://bundlers.tooling.report/)
 - [Rollup](https://rollupjs.org/guide/en/)
 - [Parcel](https://parceljs.org/)
 
-If you're already using a bundler for other parts of your web app, the using the same one for your service worker as part of your existing build process should work fine.
+If you're already using a bundler for other parts of your web app, then using the same one for your service worker as part of your existing build process should work fine.
 
 Please consult the documentation for each bundler to learn more about general configuration. There are a few Workbox-specific build options that are explained in the following sections.
 
 ### Write your service worker source code
 
-The following example is a hypothetical service worker source file that imports a few different Workbox libraries. This source file needs to be processed by a bundler before it could be run in a browser.
+The following example is a hypothetical service worker source file that imports a few different Workbox libraries. This source file needs to be processed by a bundler before it can be run in a browser.
 
 ```javascript
-// These JavaScript module imports that need to be bundled:
+// These JavaScript module imports need to be bundled:
 import {precacheAndRoute} from 'workbox-precaching';
 import {registerRoute} from 'workbox-routing';
 import {CacheFirst} from 'workbox-strategies';


### PR DESCRIPTION
R: @philipwalton 

In addition to

- fixes https://github.com/GoogleChrome/workbox/issues/2379
- fixes https://github.com/GoogleChrome/workbox/issues/2553

this hopefully also takes recent feedback from @surma and others into account, by simplifying the "Using bundlers with Workbox" guide to focus on positive examples instead of contrasting it with `workbox-sw`.

There is a decent amount of material that I just cut in the interest of giving developers step-by-step instructions on usage for a specific set of bundlers and use cases, with fewer digressions. Instead of including inline examples in some cases, I chose to link to the relevant documentation.

I feel like we might need to do some additional cleanup of this doc, but that's what I came up with for a first attempt.

**CC:** @petele
