### PR TITLE
devtools.md: Correct 'rbg()' typo

### DIFF
--- a/src/content/en/updates/2020/05/devtools.md
+++ b/src/content/en/updates/2020/05/devtools.md
@@ -137,7 +137,7 @@ Chromium Bug: [#1040019](https://crbug.com/1040019)
 
 [CSS Color Module Level 4](https://drafts.csswg.org/css-color/#changes-from-3)
 specifies that color functions like `rgb()` should support space-separated
-arguments. For example, `rgb(0, 0, 0)` is equivalent to `rbg(0 0 0)`.
+arguments. For example, `rgb(0, 0, 0)` is equivalent to `rgb(0 0 0)`.
 
 When you choose colors with the [Color Picker](/web/tools/chrome-devtools/css/reference#color-picker)
 or alternate between color representations in the Styles pane by holding <kbd>Shift</kbd> and then


### PR DESCRIPTION
What's changed, or what was fixed?
- In section "Color Picker now uses space-separated functional color notation"
  - Typo `rbg(0 0 0)` corrected to `rgb(0 0 0)`

**Fixes:** #8881

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
