### PR TITLE
Update /nic to nic84

### DIFF
--- a/src/content/en/updates/_redirects.yaml
+++ b/src/content/en/updates/_redirects.yaml
@@ -5,7 +5,7 @@
 redirects:
 
 - from: /web/updates/nic
-  to: /web/updates/2020/04/nic81
+  to: /web/updates/2020/07/nic84
 
 # Redirects for TWA content
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Update /nic redirect to latest nic article

**CC:** @petele
