### PR TITLE
8860 | Fix Modern.ie links

### DIFF
--- a/src/content/en/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/en/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description: Your job doesn't end with ensuring your site runs great across Chrome and Android. Even though Device Mode can simulate a range of other devices like iPhones, we encourage you to check out other browsers solutions for emulation.
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -107,7 +107,7 @@ Note: To avoid having to open Xcode every time you want to use the iOS Simulator
   <figcaption>Modern IE VM</figcaption>
 </figure>
 
-Modern.IE Virtual Machines let you access different versions of IE on your computer via VirtualBox (or VMWare). Choose a virtual machine on the <a href="https://modern.ie/en-us/virtualization-tools#downloads">download page here</a>.
+Modern.IE Virtual Machines let you access different versions of IE on your computer via VirtualBox (or VMWare). Choose a virtual machine on the <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">download page here</a>.
 
 
 ## Cloud-based emulators and simulators

--- a/src/content/es/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/es/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description: Tu trabajo no termina al asegurarte de que el sitio funciona perfectamente en Chrome y Android. Aunque Device Mode puede simular otros dispositivos diferentes, como iPhone, te recomendamos ver otras soluciones de navegadores para emulación.
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -107,7 +107,7 @@ Note: Para evitar que debas abrir Xcode cada vez que quieras usar el simulador d
   <figcaption>MV de Modern IE</figcaption>
 </figure>
 
-Las máquinas virtuales de Modern.IE te permiten acceder a versiones diferentes de IE en tu computadora mediante VirtualBox (o VMWare). Elige una máquina virtual en la <a href="https://modern.ie/en-us/virtualization-tools#downloads">página de descarga</a>.
+Las máquinas virtuales de Modern.IE te permiten acceder a versiones diferentes de IE en tu computadora mediante VirtualBox (o VMWare). Elige una máquina virtual en la <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">página de descarga</a>.
 
 
 ## Emuladores y simuladores basados en la nube

--- a/src/content/id/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/id/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description: Tugas Anda belum selesai di tahap memastikan bahwa situs berjalan mulus di Chrome dan Android. Meskipun Device Mode bisa menyimulasikan berbagai perangkat lain seperti iPhone, kami sarankan agar Anda memeriksa solusi browser lain untuk emulasi.
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -107,7 +107,7 @@ Note: Agar tidak perlu membuka Xcode setiap kali Anda ingin menggunakan Simulato
   <figcaption>VM Modern IE</figcaption>
 </figure>
 
-Mesin Virtual Modern.IE memungkinkan Anda mengakses versi IE yang berbeda di komputer Anda melalui VirtualBox (atau VMWare). Pilih mesin virtual di <a href="https://modern.ie/en-us/virtualization-tools#downloads">halaman download di sini</a>.
+Mesin Virtual Modern.IE memungkinkan Anda mengakses versi IE yang berbeda di komputer Anda melalui VirtualBox (atau VMWare). Pilih mesin virtual di <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">halaman download di sini</a>.
 
 
 ## Emulator dan simulator berbasis cloud

--- a/src/content/ja/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/ja/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description:Chrome と Android でサイトがうまく実行できることを確認したら作業完了というわけではありません。 Device Mode では iPhone などの他のさまざまな端末をシミュレートできますが、他のブラウザ ソリューションでエミュレーションを行ってみることをおすすめします。
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -106,7 +106,7 @@ Mac OS X 用の iOS シミュレータは、[App Store からインストール]
   <figcaption>Modern IE VM</figcaption>
 </figure>
 
-Modern.IE 仮想マシンを使用すると、VirtualBox（または VMWare）を使用してコンピュータでさまざまなバージョンの IE にアクセスできます。 <a href="https://modern.ie/en-us/virtualization-tools#downloads">このダウンロード ページ</a>で仮想マシンを選択します。
+Modern.IE 仮想マシンを使用すると、VirtualBox（または VMWare）を使用してコンピュータでさまざまなバージョンの IE にアクセスできます。 <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">このダウンロード ページ</a>で仮想マシンを選択します。
 
 
 ## クラウドベースのエミュレータとシミュレータ

--- a/src/content/ko/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/ko/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description: 사이트가 Chrome과 Android에서 모두 잘 실행되는 것을 확인했다고 해서 할 일이 끝난 것은 아닙니다. Device Mode로 iPhone과 같은 여러 다른 기기를 시뮬레이션할 수 있지만, 그래도 에뮬레이션을 위한 다른 브라우저의 솔루션을 확인해보는 것이 좋습니다.
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -107,7 +107,7 @@ Mac OS X용 iOS 시뮬레이터는 Xcode가 함께 제공되며,
   <figcaption>Modern IE VM</figcaption>
 </figure>
 
-Modern.IE 가상 머신을 사용하면 VirtualBox(또는 VMWare)를 통해 사용자의 컴퓨터에서 여러 가지 버전의 IE에 액세스할 수 있습니다. <a href="https://modern.ie/en-us/virtualization-tools#downloads">여기의 다운로드 페이지</a>에서 가상 머신을 선택하세요.
+Modern.IE 가상 머신을 사용하면 VirtualBox(또는 VMWare)를 통해 사용자의 컴퓨터에서 여러 가지 버전의 IE에 액세스할 수 있습니다. <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">여기의 다운로드 페이지</a>에서 가상 머신을 선택하세요.
 
 
 ## 클라우드 기반 에뮬레이터 및 시뮬레이터

--- a/src/content/pt-br/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/pt-br/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description: Seu trabalho não acaba depois de garantir que o site funcione perfeitamente no Chrome e no Android. Embora o Device Mode possa simular diversos outros dispositivos, como iPhones, recomendamos que você confira soluções de emulação para outros navegadores.
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -107,7 +107,7 @@ Note: Para evitar a necessidade de abrir o Xcode sempre que quiser usar o iOS Si
   <figcaption>VM do Modern IE</figcaption>
 </figure>
 
-As máquinas virtuais do Modern.IE permitem acessar diferentes versões do IE no computador pelo VirtualBox (ou VMWare). Escolha uma máquina virtual na página de <a href="https://modern.ie/en-us/virtualization-tools#downloads">download aqui</a>.
+As máquinas virtuais do Modern.IE permitem acessar diferentes versões do IE no computador pelo VirtualBox (ou VMWare). Escolha uma máquina virtual na página de <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">download aqui</a>.
 
 
 ## Emuladores e simuladores baseados na nuvem

--- a/src/content/zh-cn/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/zh-cn/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description: 您的任务不只局限于确保网站在 Chrome 和 Android 上出色运行。 即使 Device Mode 可以模拟 iPhone 等多种其他设备，我们仍鼓励您查看其他浏览器模拟解决方案。
 
-{# wf_updated_on: 2020-07-10 #}
+{# wf_updated_on: 2020-07-21 #}
 {# wf_published_on: 2015-04-13 #}
 {# wf_blink_components: Platform>DevTools #}
 
@@ -106,7 +106,7 @@ Chromium Content Shell for Android，请保持模拟器运行并在命令提示�
   <figcaption>Modern IE VM</figcaption>
 </figure>
 
-利用 Modern.IE 虚拟机，您可以在自己的计算机上通过 VirtualBox（或 VMWare）访问不同版本的 IE。 在<a href="https://modern.ie/en-us/virtualization-tools#downloads">此处的下载页面</a>上选择一款虚拟机。
+利用 Modern.IE 虚拟机，您可以在自己的计算机上通过 VirtualBox（或 VMWare）访问不同版本的 IE。 在<a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">此处的下载页面</a>上选择一款虚拟机。
 
 
 ## 基于云的模拟器

--- a/src/content/zh-tw/tools/chrome-devtools/device-mode/testing-other-browsers.md
+++ b/src/content/zh-tw/tools/chrome-devtools/device-mode/testing-other-browsers.md
@@ -2,7 +2,7 @@ project_path: /web/tools/chrome-devtools/_project.yaml
 book_path: /web/tools/chrome-devtools/_book.yaml
 description:您的任務不只侷限於確保網站在 Chrome 和 Android 上出色運行。即使 Device Mode 可以模擬 iPhone 等多種其他設備，我們仍鼓勵您查看其他瀏覽器模擬解決方案。
 
-{# wf_updated_on:2020-07-10 #}
+{# wf_updated_on:2020-07-21 #}
 {# wf_published_on:2015-04-13 #}
 
 # 模擬和測試其他瀏覽器 {: .page-title }
@@ -104,7 +104,7 @@ Note: 爲了避免在每次想要使用 iOS 模擬器時都要打開 Xcode，請
   <figcaption>Modern IE VM</figcaption>
 </figure>
 
-利用 Modern.IE 虛擬機，您可以在自己的計算機上通過 VirtualBox（或 VMWare）訪問不同版本的 IE。在<a href="https://modern.ie/en-us/virtualization-tools#downloads">此處的下載頁面</a>上選擇一款虛擬機。
+利用 Modern.IE 虛擬機，您可以在自己的計算機上通過 VirtualBox（或 VMWare）訪問不同版本的 IE。在<a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/">此處的下載頁面</a>上選擇一款虛擬機。
 
 
 ## 基於雲的模擬器


### PR DESCRIPTION
What's changed, or what was fixed?
- fixing all instances of bad Modern IE VM links

**Fixes:** #8860

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
