### PR TITLE
Fix translation typo

### DIFF
--- a/src/content/zh-cn/fundamentals/primers/service-workers/registration.md
+++ b/src/content/zh-cn/fundamentals/primers/service-workers/registration.md
@@ -106,7 +106,7 @@ event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onlo
 因此，如果有活动的 Service Worker，那么，何时调用 `navigator.serviceWorker.register()`，或事实上*无论您是否调用它*都无关紧要。
 除非您更改 Service Worker 脚本的网址，否则
 `navigator.serviceWorker.register()` 在后续访问期间实际上是一个 [no-op](https://en.wikipedia.org/wiki/NOP)。
- 因此，何时调用它都无关禁用。
+ 因此，何时调用它都无关紧要。
 
 
 ## 尽早注册的原因

--- a/src/content/zh-tw/fundamentals/primers/service-workers/registration.md
+++ b/src/content/zh-tw/fundamentals/primers/service-workers/registration.md
@@ -88,7 +88,7 @@ description:確定服務工作線程註冊時間的最佳做法。
 
 
 
-因此，如果有活動的服務工作線程，那麼，何時調用 `navigator.serviceWorker.register()`，或事實上*無論您是否調用它*都無關緊要。除非您更改服務工作線程腳本的網址，否則 `navigator.serviceWorker.register()` 在後續訪問期間實際上是一個 [no-op](https://en.wikipedia.org/wiki/NOP)。因此，何時調用它都無關禁用。
+因此，如果有活動的服務工作線程，那麼，何時調用 `navigator.serviceWorker.register()`，或事實上*無論您是否調用它*都無關緊要。除非您更改服務工作線程腳本的網址，否則 `navigator.serviceWorker.register()` 在後續訪問期間實際上是一個 [no-op](https://en.wikipedia.org/wiki/NOP)。因此，何時調用它都無關緊要。
 
 
 ## 儘早註冊的原因


### PR DESCRIPTION
What's changed, or what was fixed?
- service-workers/registration.md zh-cn & zh-tw translation

**Fixes:** #issue

**Target Live Date:** 2020-07-30

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
