### PR TITLE
Fix the Workbox guides table of contents

### DIFF
--- a/src/content/en/tools/workbox/guides/_toc.yaml
+++ b/src/content/en/tools/workbox/guides/_toc.yaml
@@ -1,7 +1,7 @@
 toc:
 - title: "Get Started"
   path: /web/tools/workbox/guides/get-started
-- title: "Using bundlers with Workbox"
+- title: "Using Bundlers with Workbox"
   path: /web/tools/workbox/guides/using-bundlers
 - title: "Precache Files"
   path: /web/tools/workbox/guides/precache-files
@@ -21,8 +21,6 @@ toc:
   path: /web/tools/workbox/guides/handle-third-party-requests
 - title: "Using Plugins"
   path: /web/tools/workbox/guides/using-plugins
-- title: "Using Bundlers (webpack/Rollup) with Workbox"
-  path: /web/tools/workbox/guides/using-bundlers
 - title: "Troubleshoot and Debug"
   path: /web/tools/workbox/guides/troubleshoot-and-debug
 - title: "Understanding Storage Quota"


### PR DESCRIPTION
R: @petele @philipwalton 

The duplicated item was removed in https://github.com/google/WebFundamentals/pull/8872/files#diff-074fff077c827468fd565ec0d9025089 but somehow was re-added via a PR in the meantime.

This removes it again.