### PR TITLE
fixes close #8956 for hyperlink correction which was going to 404 page.

### DIFF
--- a/src/content/en/fundamentals/_index.yaml
+++ b/src/content/en/fundamentals/_index.yaml
@@ -105,7 +105,7 @@ landing_page:
       description: >
         Web Components are a new set of standards which let you create your own HTML elements.
         You can use them to build anything, from simple UI elements, to entire applications.
-      path: web-components/
+      path: web/fundamentals/web-components/
       buttons:
       - label: Learn more
         path: /web/fundamentals/web-components/


### PR DESCRIPTION
What's changed, or what was fixed?
- hyperlink correction which was going to 404 page.

To check this:
Go to :  https://developers.google.com/web/fundamentals try to navigate to first anchor of the 'What's hot?' section at the bottom of the page, its a broken link. 

**Fixes:** #8956

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
