### PR TITLE
fix: alignment of images of contributors

### DIFF
--- a/src/templates/contributors/include.html
+++ b/src/templates/contributors/include.html
@@ -2,7 +2,7 @@
 
 <style>
 .wf-byline {display: inline-flex; margin: 16px 32px 16px 0;}
-.wf-byline .attempt-left {margin: 0 16px 0 0;}
+.wf-byline .attempt-left {margin: 0 16px 0 0; width: 5rem;}
 .wf-byline img {border-radius: 100%; min-width: 64px; height: 64px;}
 .wf-byline .wf-byline-desc {font-size: smaller; word-break: break-word;}
 .wf-byline .wf-byline-social {font-size: smaller;}


### PR DESCRIPTION
What's changed, or what was fixed?
- The alignment of the images along with the short brief description of the contributors wasn't aligned within the shorter screen width. 

![alignment-contributors-before](https://user-images.githubusercontent.com/44139348/91559181-37730c00-e955-11ea-8cc0-ebd787b3e881.png)

Fixes and aligns the images: 

![alignment-contributors-after](https://user-images.githubusercontent.com/44139348/91559293-6ee1b880-e955-11ea-863e-6bc8ca23eda0.png)


- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
