### PR TITLE
Update Workbox "Using Plugins" documentation 

### DIFF
--- a/src/content/en/tools/workbox/guides/using-plugins.md
+++ b/src/content/en/tools/workbox/guides/using-plugins.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: A guide to using plugins with Workbox.
 
-{# wf_updated_on: 2020-05-01 #}
+{# wf_updated_on: 2020-09-22 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: n/a #}
 
@@ -103,40 +103,40 @@ A plugin using all of these callbacks would look like this:
 
 ```javascript
 const myPlugin = {
-  cacheWillUpdate: async ({request, response, event}) => {
+  cacheWillUpdate: async ({request, response, event, state}) => {
     // Return `response`, a different `Response` object, or `null`.
     return response;
   },
-  cacheDidUpdate: async ({cacheName, request, oldResponse, newResponse, event}) => {
+  cacheDidUpdate: async ({cacheName, request, oldResponse, newResponse, event, state}) => {
     // No return expected
     // Note: `newResponse.bodyUsed` is `true` when this is called,
     // meaning the body has already been read. If you need access to
     // the body of the fresh response, use a technique like:
     // const freshResponse = await caches.match(request, {cacheName});
   },
-  cacheKeyWillBeUsed: async ({request, mode}) => {
+  cacheKeyWillBeUsed: async ({request, mode, params, event, state}) => {
     // `request` is the `Request` object that would otherwise be used as the cache key.
     // `mode` is either 'read' or 'write'.
     // Return either a string, or a `Request` whose `url` property will be used as the cache key.
     // Returning the original `request` will make this a no-op.
     return request;
   },
-  cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse, event}) => {
+  cachedResponseWillBeUsed: async ({cacheName, request, matchOptions, cachedResponse, event, state}) => {
     // Return `cachedResponse`, a different `Response` object, or null.
     return cachedResponse;
   },
-  requestWillFetch: async ({request}) => {
+  requestWillFetch: async ({request, event, state}) => {
     // Return `request` or a different `Request` object.
     return request;
   },
-  fetchDidFail: async ({originalRequest, request, error, event}) => {
+  fetchDidFail: async ({originalRequest, request, error, event, state}) => {
     // No return expected.
     // NOTE: `originalRequest` is the browser's request, `request` is the
     // request after being passed through plugins with
     // `requestWillFetch` callbacks, and `error` is the exception that caused
     // the underlying `fetch()` to fail.
   },
-  fetchDidSucceed: async ({request, response}) => {
+  fetchDidSucceed: async ({request, response, event, state}) => {
     // Return `response` to use the network response as-is,
     // or alternatively create and return a new `Response` object.
     return response;
@@ -144,13 +144,71 @@ const myPlugin = {
 };
 ```
 
-Note: the `event` object passed to each plugin callback above represents the
-original event that triggered the fetch or cache action. In some cases there
-will **not** be an original event, so your code should check for its existence
-before referencing it. Also, when invoking the
-[`handle()`](/web/tools/workbox/guides/advanced-recipes#handle)
-method of a strategy, the `event` you pass to `handle()` will be the event
-passed to the plugin callbacks.
+The `event` object passed to each plugin callback above represents the original event that triggered
+the fetch or cache action. In some cases there will **not** be an original event, so your code
+should check for its existence before referencing it. Also, when invoking the
+[`handle()`](/web/tools/workbox/guides/advanced-recipes#handle) method of a strategy, the `event`
+you pass to `handle()` will be the event passed to the plugin callbacks.
+
+All plugin callbacks are also passed a `state` object which is unique to the particular plugin
+object and strategy invocation (i.e. the call to `handle()`). This makes it possible to write
+plugins where one callback can conditionally do something based on what another callback in the same
+plugin did (e.g. compute the time delta between running `requestWillFetch()` and `fetchDidSucceed()`
+or `fetchDidFail()`).
+
+## Lifecycle Callbacks
+
+Any of the following callbacks can be used to handle different points of the plugin lifecycle state: 
+
+* `handlerWillStart`: Called before any handler logic starts running. This callback can be used to
+  set the initial handler state (e.g. record the start time).
+
+* `handlerWillRespond`: Called before the strategies `handle()` method returns a response. This
+  callback can be used to modify that response before returning it to a route handler or other
+  custom logic.
+
+* `handlerDidRespond`: Called after the strategy's `handle()` method returns a response. This
+  callback can be used to record any final response details, e.g. after changes made by other
+  plugins.
+
+* `handlerDidComplete`: Called after all [extend lifetime
+  promises](https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises) added to
+  the event from the invocation of this strategy have settled. This callback can be used to report
+  on any data that needs to wait until the handler is done in order to calculate (e.g. cache hit
+  status, cache latency, network latency).
+
+* `handlerDidError`: Called if the handler was unable to provide a valid response from any source.
+  This callback can be used to provide "fallback" content as an alternative to a network error.
+
+A plugin using all of these callbacks would look like this:
+
+```javascript
+const myPlugin = {
+  handlerWillStart: async ({request, event, state}) => {
+    // No return expected. 
+    // Can set initial handler state here.
+  },
+  handlerWillRespond: async ({request, response, event, state}) => {
+    // Return `response` or a different `Response` object.
+    return response;
+  },
+  handlerDidRespond: async ({request, response, event, state}) => {
+    // No return expected. 
+    // Can record final response details here.
+  },
+  handlerDidComplete: async ({request, response, error, event, state}) => {
+    // No return expected. 
+    // Can report any data here.
+  },
+  handlerDidError: async ({request, event, error, state}) => {
+    // Return `response`, a different `Response` object as a fallback, or `null`.
+    return response;
+  },
+};
+```
+
+Note: If you're implementing your own custom strategy, you do not have to worry about invoking any
+of these callbacks yourself. This is all handled by the `Strategy` base class.
 
 ## Third-party Plugins
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Updates the "Using Plugins" documentation for Workbox to include new plugin capabilities:
  - Lifecycle state
  - New lifecycle callbacks

**Target Live Date:** TBD

- [ ] This has been reviewed and approved by (NAME)
- [X] I have run `npm test` locally and all tests pass.
- [X] I have added the appropriate `type-something` label.
- [X] I've staged the site and manually verified that my content displays correctly.

**CC:** @jeffposnick @philipwalton 
