### PR TITLE
fix duplicated entry for "HAR Analyzer"

### DIFF
--- a/src/content/en/tools/chrome-devtools/network/reference.md
+++ b/src/content/en/tools/chrome-devtools/network/reference.md
@@ -798,10 +798,7 @@ To save all network requests to a HAR file:
    request.
 
 Once you've got a HAR file, you can import it back into DevTools for analysis. Just
-drag-and-drop the HAR file into the Requests table. See also [HAR Analyzer][HAR
-Analyzer]{: .external }.
-
-[HAR Analyzer]: https://toolbox.googleapps.com/apps/har_analyzer/
+drag-and-drop the HAR file into the Requests table. See also [HAR Analyzer](https://toolbox.googleapps.com/apps/har_analyzer/){: .external }.
 
 <figure>
   <img src="imgs/save-as-har.png"


### PR DESCRIPTION
doc displays:
[HAR Analyzer]HAR Analyzer.

instead of 
HAR Analyzer.

What's changed, or what was fixed?
- the hyperlink for HAR analyzer was de-duplicated

**Fixes:** #issue
Visual issue on UI
<img width="887" alt="Screen Shot 2020-10-26 at 20 17 20" src="https://user-images.githubusercontent.com/14802981/97224051-80660600-17c8-11eb-83e2-eb1401745cf3.png">


**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
