### PR TITLE
Update Workbox getting started docs

### DIFF
--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -1,5 +1,5 @@
-project_path: /web/tools/workbox/\_project.yaml
-book_path: /web/tools/workbox/\_book.yaml
+project_path: /web/tools/workbox/_project.yaml
+book_path: /web/tools/workbox/_book.yaml
 description:Get Started with Workbox.
 
 {# wf_blink_components: N/A #}

--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -1,231 +1,167 @@
-project_path: /web/tools/workbox/_project.yaml
-book_path: /web/tools/workbox/_book.yaml
-description:Get Started with Workbox.
+project_path: /web/tools/workbox/\_project.yaml book_path: /web/tools/workbox/\_book.yaml description:Get Started with Workbox.
 
-{# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-05-01 #}
-{# wf_published_on: 2017-11-15 #}
+{# wf_blink_components: N/A #} {# wf_updated_on: 2020-11-02 #} {# wf_published_on: 2017-11-15 #}
 
 # Get Started {: .page-title }
 
-This guide will show you how to get up and running with Workbox to route
-common requests for a web page and demonstrate how to cache using a common
-strategy.
+Workbox is a set of libraries to help you write and manage [service workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) and caching with the [`CacheStorage` API](https://web.dev/service-workers-cache-storage/). Service workers and the Cache Storage API, [when used together](https://web.dev/service-workers-cache-storage/), let you control how assets (HTML, CSS, JS, images, etc…) used on your site are requested from the network or cache, even allowing you to return cached content when offline! With Workbox, you can quickly set up and manage both, and more, with production-ready code.
 
-Since most websites contain CSS, JavaScript and images, let’s look at how we
-can cache and serve these files using a service worker and Workbox.
+## Installation
 
-## Create and Register a Service Worker File
+Starting with the [v5 release](https://github.com/GoogleChrome/workbox/releases/tag/v5.0.0), Workbox can be used inside of a service worker source file through [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) by using [npm](https://www.npmjs.com/) to install the [Workbox modules](https://developers.google.com/web/tools/workbox/modules#service-worker-packages) you need and importing what you plan to use.
 
-Before we can use Workbox, we need to create a service worker file and
-register it from our web page.
+Unfortunately, JavaScript modules don’t work inside service workers, so you’ll need a [bundler that supports JavaScript modules](https://bundlers.tooling.report/) to compile your service worker to a single file. Popular choices include [webpack](https://webpack.js.org/), [Rollup](https://rollupjs.org/guide/en/), and [Parcel](https://parceljs.org/). Please consult the documentation for your bundler of choice for setup and configuration.
 
-Start by creating a file called `service-worker.js` at the root of your site and add a
-console message to the file (this is so we can see it load).
+Note: While there are a number of ways you can use Workbox in your project, what is presented in this guide is the current recommended approach.
+
+## Creating a service worker
+
+Before you can use Workbox, you need to create a service worker and [register](https://developers.google.com/web/fundamentals/primers/service-workers/registration) it from a web page. Start by creating a file called `service-worker.js` at the root of your site and add a console message to it to ensure it loads.
 
 ```javascript
 console.log('Hello from service-worker.js');
 ```
 
-In your web page, register your new service worker file like so:
+Next, in your web page, register your new service worker:
 
 {% include "web/tools/workbox/guides/_shared/register-sw.html" %}
 
-This tells the browser this is the service worker to use for the site.
+This tells the browser that this is the service worker to use for the site. If you refresh your page, open up Chrome DevTools, and navigate to the _Console_ tab, you’ll see the log from your service worker.
 
-If you refresh your page, you'll see the log from your service worker file.
+Note: While we are showing Chrome DevTools here, you can use any developer tools you’d like to debug service workers.
 
 ![Console message from sw.js in DevTools](../images/guides/get-started/hello-console.png)
 
-Looking in the “Application” tab in Chrome DevTools, you should see your service
-worker registered.
+Next, switch to the _Application_ tab, you should see your service worker registered.
 
 ![Application Tab displaying a registered service worker.](../images/guides/get-started/application-tab.png)
 
-Note: Click the “Update on reload” checkbox to make it easier to develop with
-your new service worker.
+Note: Trying to debug your service worker? Take advantage of [Incognito Mode](https://support.google.com/chrome/answer/95464) in Chrome when you need to start from a fresh state locally.
 
-Now that we have a service worker registered, let’s look at how we can use
-Workbox.
-
-## Importing Workbox
-
-There two ways to import Workbox into your service worker:
-
-- Using the [workbox-sw](/web/tools/workbox/modules/workbox-sw) loader, which
-  loads Workbox packages at runtime from our CDN.
-- Using a [bundler](/web/tools/workbox/guides/using-bundlers) to include Workbox
-  pages in your service worker at build time.
-
-For quick experimentation and prototyping, loading Workbox from the CDN is
-usually easiest. On the other hand, bundling your service worker is generally
-recommended for more control and better integrations with existing tooling (for
-example, editor integration or writing your service worker in TypeScript).
-
-### From the CDN
-
-To load Workbox from our CDN, update your service worker file to import the
-`workbox-sw.js` file via the `importScripts()` method.
-
-<pre class="prettyprint js">
-importScripts('{% include "web/tools/workbox/_shared/workbox-sw-cdn-url.html" %}');
-
-if (workbox) {
-  console.log(`Yay! Workbox is loaded 🎉`);
-} else {
-  console.log(`Boo! Workbox didn't load 😬`);
-}
-</pre>
-
-With this you should see the “Yay” message, which indicates that Workbox has
-loaded successfully.
-
-![DevTools screenshot of Workbox loading in a service worker.](../images/guides/get-started/yay-loaded.png)
-
-Now we can start using Workbox.
-
-Warning: Importing `workbox-sw.js` will create a [`workbox`
-object](/web/tools/workbox/modules/workbox-sw) inside of your service worker,
-and that instance is responsible for importing all other helper libraries, based
-on the features you use. Due to restrictions in the [service worker
-specification](https://www.chromestatus.com/feature/5748516353736704), these
-imports need to happen either inside of an `install` event handler, or
-synchronously in the top-level code for your service worker. More details, along
-with workarounds, can be found in the [`workbox-sw`
-documentation](/web/tools/workbox/modules/workbox-sw#avoid_async_imports).
-
-### Using a bundler
-
-When loading Workbox from our CDN using the `workbox-sw` loader, a global
-`workbox` object is created, and each of the individual Workbox packages can be
-accessed via a property on the `workbox` global (e.g. `workbox.precaching`,
-`workbox.routing`, or `workbox.backgroundSync`).
-
-When using a bundler to create your service worker, you install the Workbox
-packages you want to use from [npm](https://www.npmjs.com/), and then you use
-`import` statements to directly reference the Workbox modules you want to use.
-In this scenario there is no global `workbox` object. Instead, your bundler will
-inline your imported Workbox modules directly into the service worker file it
-generates. For example:
-
-```javascript
-import {precaching} from 'workbox-precaching';
-import {registerRoute} from 'workbox-routing';
-import {BackgroundSyncPlugin} from 'workbox-background-sync';
-
-// Use the above modules somehow...
-```
-
-For more details see [Using Bundlers (webpack/Rollup) with
-Workbox](/web/tools/workbox/guides/using-bundlers).
-
-Alternatively, if you're using [webpack](https://webpack.js.org/) you can use
-the [workbox-webpack-plugin](/web/tools/workbox/modules/workbox-webpack-plugin)
-which handles bundling your service worker for you.
+Now that you have a registered service worker, we can bring in Workbox.
 
 ## Using Workbox
 
-One of Workbox’s primary features is it’s routing and caching strategy
-modules. It allows you to listen for requests from your web page and determine
-if and how that request should be cached and responded to.
+Workbox is distributed as a number of [npm modules](https://developers.google.com/web/tools/workbox/modules). When you want to use one, first install it from [npm](https://npmjs.com/) then `import` the portions of the modules you need for your service worker. One of Workbox’s primary features is its routing and caching strategy modules, so it’s a good place to start.
 
-Let’s add a cache fallback to our JavaScript files. The easiest way to do this
-is to register a route with Workbox that will match any requests that have a
-[`destination`](https://developer.mozilla.org/en-US/docs/Web/API/RequestDestination) property
-set to `'script'`.
+### Routing and Caching Strategies
 
-Note: the examples in this guide all use `import` syntax to load the various
-Workbox modules. If you prefer to load Workbox from the CDN, see the
-`workbox-sw` documentation for details on how to convert these code examples to
-code that uses the `workbox` global.
+Workbox allows you to manage caching for your web app's HTTP requests using different caching strategies. The first step is to determine whether the request being worked on matches your criteria, and if so, applying a caching strategy to it. Matching happens via a [callback function](https://developers.google.com/web/tools/workbox/modules/workbox-routing#matching_and_handling_in_routes) that returns a truthy value. Caching strategies can either be one of Workbox’s [pre-defined strategies](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#using_strategies), or you can create your own. A basic service worker utilizing routing and caching could look something like this:
 
 ```javascript
-import {registerRoute} from 'workbox-routing';
+import { registerRoute } from 'workbox-routing';
+import {
+  NetworkFirst,
+  StaleWhileRevalidate,
+  CacheFirst,
+} from 'workbox-strategies';
 
+// Used for filtering matches based on status code, header, or both
+import { CacheableResponsePlugin } from 'workbox-cacheable-response';
+// Used to limit entries in cache, remove entries after a certain period of time
+import { ExpirationPlugin } from 'workbox-expiration';
+
+// Cache page navigations (html) with a Network First strategy
 registerRoute(
-  ({request}) => request.destination === 'script',
-  /* ... */
-);
-```
-
-The above code tells Workbox that when a request is made, it should see if the
-function returns a "truthy" value, and if it does, do something with
-that request. For this guide, that “do something” is going to be passing the
-request through one of Workbox’s caching strategies.
-
-If we want our JavaScript files to come from the network whenever possible,
-but fallback to the cached version if the network fails, we can use the
-“network first” strategy to achieve this.
-
-```javascript
-import {registerRoute} from 'workbox-routing';
-import {NetworkFirst} from 'workbox-strategies';
-
-registerRoute(
-  ({request}) => request.destination === 'script',
-  new NetworkFirst()
-);
-```
-
-Add this code to your service worker and refresh the page. If your web page
-has JavaScript files in it, you should see some logs similar to this:
-
-![Example console logs from routing a JavaScript file.](../images/guides/get-started/routing-example.png)
-
-Workbox has routed the request for any script resources and used the network first
-strategy to determine how to respond to the request. You can look in the
-caches of DevTools to check that the request has actually been cached.
-
-![Example of a JavaScript file being cached.](../images/guides/get-started/cached-request.png)
-
-Workbox provides a few caching strategies that you can use. For example, your
-CSS could be served from the cache first and updated in the background or your
-images could be cached and used until they're a week old, after which they’ll need
-updating.
-
-```javascript
-import {registerRoute} from 'workbox-routing';
-import {CacheFirst, StaleWhileRevalidate} from 'workbox-strategies';
-import {ExpirationPlugin} from 'workbox-expiration';
-
-registerRoute(
-  // Cache style resources, i.e. CSS files.
-  ({request}) => request.destination === 'style',
-  // Use cache but update in the background.
-  new StaleWhileRevalidate({
-    // Use a custom cache name.
-    cacheName: 'css-cache',
-  })
-);
-
-registerRoute(
-  // Cache image files.
-  ({request}) => request.destination === 'image',
-  // Use the cache if it's available.
-  new CacheFirst({
-    // Use a custom cache name.
-    cacheName: 'image-cache',
+  // Check to see if the request is a navigation to a new page
+  ({ request }) => request.mode === 'navigate',
+  // Use a Network First caching strategy
+  new NetworkFirst({
+    // Put all cached files in a cache named 'pages'
+    cacheName: 'pages',
     plugins: [
-      new ExpirationPlugin({
-        // Cache only 20 images.
-        maxEntries: 20,
-        // Cache for a maximum of a week.
-        maxAgeSeconds: 7 * 24 * 60 * 60,
-      })
+      // Ensure that only requests that result in a 200 status are cached
+      new CacheableResponsePlugin({
+        statuses: [200],
+      }),
     ],
-  })
+  }),
+);
+
+// Cache CSS, JS, and Web Worker requests with a Stale While Revalidate strategy
+registerRoute(
+  // Check to see if the request's destination is style for stylesheets, script for JavaScript, or worker for web worker
+  ({ request }) =>
+    request.destination === 'style' ||
+    request.destination === 'script' ||
+    request.destination === 'worker',
+  // Use a Stale While Revalidate caching strategy
+  new StaleWhileRevalidate({
+    // Put all cached files in a cache named 'assets'
+    cacheName: 'assets',
+    plugins: [
+      // Ensure that only requests that result in a 200 status are cached
+      new CacheableResponsePlugin({
+        statuses: [200],
+      }),
+    ],
+  }),
+);
+
+// Cache images with a Cache First strategy
+registerRoute(
+  // Check to see if the request's destination is style for an image
+  ({ request }) => request.destination === 'image',
+  // Use a Cache First caching strategy
+  new CacheFirst({
+    // Put all cached files in a cache named 'images'
+    cacheName: 'images',
+    plugins: [
+      // Ensure that only requests that result in a 200 status are cached
+      new CacheableResponsePlugin({
+        statuses: [200],
+      }),
+      // Don't cache more than 50 items, and expire them after 30 days
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 60 * 60 * 24 * 30, // 30 Days
+      }),
+    ],
+  }),
 );
 ```
 
-## What Else Can Workbox Do?
+This service worker caches navigation requests (for new HTML pages) with a [Network First strategy](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache) storing cached pages in a cache named pages, but only if it comes back with a 200 status code. It also caches stylesheets, javascript, and web workers with a [Stale While Revalidate strategy](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#stale-while-revalidate) storing cached assets in a cache named assets, again, only if they come back with a 200 status code. Finally, it caches images with a [Cache First strategy](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#cache_first_cache_falling_back_to_network) storing cached images in a cache named images, only if they come back with a 200 status code, expiring cached items after 30 days and only allowing 50 entries at once.
 
-Routing and caching strategies are performed by the `routing` and
-`strategies` modules, but there are plenty of other modules, each offering
-specific behaviors that you can use in your service worker.
+### Precaching
 
-You'll find a number of guides that cover other features of Workbox as well
-as more information on configuring Workbox. Find a full list on the left, but
-the next natural step is to enable precaching, which is the process of adding
-files to the cache when your service worker loads.
+In addition to caching as requests are made, sometimes called runtime caching, Workbox also supports [precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching), the ability to cache resources when the service worker is installed. There are a number of items that are great candidates for precaching: your web app's [start URL](https://web.dev/add-manifest/#start-url), your [offline fallback](#offline_fallback) page, and key JavaScript and CSS files. By precaching files, you’ll guarantee that they’re available in the cache when the service worker takes control of the page.
 
-<a href="./precache-files" class="button">Learn More About Precaching</a>
+You can use precaching inside your new service worker by using a bundler plugin ([webpack](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#injectmanifest_plugin) or [rollup](https://github.com/chromeos/static-site-scaffold-modules/blob/master/modules/rollup-plugin-workbox-inject/README.md)) that supports precache manifest injection:
+
+```javascript
+import { precacheAndRoute } from 'workbox-precaching';
+
+// Use with precache injection
+precacheAndRoute(self.__WB_MANIFEST);
+```
+
+This service worker will precache files when it installs, replacing `self.__WB_MANIFEST` with a list of entries injected into the service worker at build time.
+
+### Offline Fallback
+
+A common pattern for making websites and apps feel more robust when working offline is to provide a fallback page instead of displaying the browser’s default error page. With Workbox routing and precaching, you can set up this pattern in just a few lines of code:
+
+```javascript
+import { precacheAndRoute, matchPrecache } from 'workbox-precaching';
+import { setCatchHandler } from 'workbox-routing';
+
+// Ensure your build step is configured to include /offline.html as part of your precache manifest.
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Catch routing errors, like if the user is offline
+setCatchHandler(async ({ event }) => {
+  // Return the precached offline page if a document is being requested
+  if (event.request.destination === 'document') {
+    return matchPrecache('/offline.html');
+  }
+
+  return Response.error();
+});
+```
+
+This service worker precaches an offline page and, if a user is offline, returns the contents of the precached offline page instead of producing a browser error.
+
+## Do more with Workbox
+
+There’s lots more you can do with Workbox! Read the [guides](/web/tools/workbox/guides) for a deeper dive into different aspects of Workbox. Check out all of the available [Workbox modules](https://developers.google.com/web/tools/workbox/modules) to see even more things Workbox can do, like managing Google Analytics when offline, retrying form submissions that failed when offline, or broadcast updates when a cache is updated. With Workbox, you can harness the power of service workers to improve performance and give your site a great experience, independent of the network.

--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -1,6 +1,10 @@
-project_path: /web/tools/workbox/\_project.yaml book_path: /web/tools/workbox/\_book.yaml description:Get Started with Workbox.
+project_path: /web/tools/workbox/\_project.yaml
+book_path: /web/tools/workbox/\_book.yaml
+description:Get Started with Workbox.
 
-{# wf_blink_components: N/A #} {# wf_updated_on: 2020-11-02 #} {# wf_published_on: 2017-11-15 #}
+{# wf_blink_components: N/A #}
+{# wf_updated_on: 2020-11-02 #}
+{# wf_published_on: 2017-11-15 #}
 
 # Get Started {: .page-title }
 

--- a/src/content/en/tools/workbox/guides/get-started.md
+++ b/src/content/en/tools/workbox/guides/get-started.md
@@ -8,7 +8,7 @@ Workbox is a set of libraries to help you write and manage [service workers](htt
 
 ## Installation
 
-Starting with the [v5 release](https://github.com/GoogleChrome/workbox/releases/tag/v5.0.0), Workbox can be used inside of a service worker source file through [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) by using [npm](https://www.npmjs.com/) to install the [Workbox modules](https://developers.google.com/web/tools/workbox/modules#service-worker-packages) you need and importing what you plan to use.
+Starting with the [v5 release](https://github.com/GoogleChrome/workbox/releases/tag/v5.0.0), Workbox can be used inside of a service worker source file through [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) by using [npm](https://www.npmjs.com/) to install the [Workbox modules](/web/tools/workbox/modules#service-worker-packages) you need and importing what you plan to use.
 
 Unfortunately, JavaScript modules don’t work inside service workers, so you’ll need a [bundler that supports JavaScript modules](https://bundlers.tooling.report/) to compile your service worker to a single file. Popular choices include [webpack](https://webpack.js.org/), [Rollup](https://rollupjs.org/guide/en/), and [Parcel](https://parceljs.org/). Please consult the documentation for your bundler of choice for setup and configuration.
 
@@ -16,7 +16,7 @@ Note: While there are a number of ways you can use Workbox in your project, what
 
 ## Creating a service worker
 
-Before you can use Workbox, you need to create a service worker and [register](https://developers.google.com/web/fundamentals/primers/service-workers/registration) it from a web page. Start by creating a file called `service-worker.js` at the root of your site and add a console message to it to ensure it loads.
+Before you can use Workbox, you need to create a service worker and [register](/web/fundamentals/primers/service-workers/registration) it from a web page. Start by creating a file called `service-worker.js` at the root of your site and add a console message to it to ensure it loads.
 
 ```javascript
 console.log('Hello from service-worker.js');
@@ -42,11 +42,11 @@ Now that you have a registered service worker, we can bring in Workbox.
 
 ## Using Workbox
 
-Workbox is distributed as a number of [npm modules](https://developers.google.com/web/tools/workbox/modules). When you want to use one, first install it from [npm](https://npmjs.com/) then `import` the portions of the modules you need for your service worker. One of Workbox’s primary features is its routing and caching strategy modules, so it’s a good place to start.
+Workbox is distributed as a number of [npm modules](/web/tools/workbox/modules). When you want to use one, first install it from [npm](https://npmjs.com/) then `import` the portions of the modules you need for your service worker. One of Workbox’s primary features is its routing and caching strategy modules, so it’s a good place to start.
 
 ### Routing and Caching Strategies
 
-Workbox allows you to manage caching for your web app's HTTP requests using different caching strategies. The first step is to determine whether the request being worked on matches your criteria, and if so, applying a caching strategy to it. Matching happens via a [callback function](https://developers.google.com/web/tools/workbox/modules/workbox-routing#matching_and_handling_in_routes) that returns a truthy value. Caching strategies can either be one of Workbox’s [pre-defined strategies](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#using_strategies), or you can create your own. A basic service worker utilizing routing and caching could look something like this:
+Workbox allows you to manage caching for your web app's HTTP requests using different caching strategies. The first step is to determine whether the request being worked on matches your criteria, and if so, applying a caching strategy to it. Matching happens via a [callback function](/web/tools/workbox/modules/workbox-routing#matching_and_handling_in_routes) that returns a truthy value. Caching strategies can either be one of Workbox’s [pre-defined strategies](/web/tools/workbox/modules/workbox-strategies#using_strategies), or you can create your own. A basic service worker utilizing routing and caching could look something like this:
 
 ```javascript
 import { registerRoute } from 'workbox-routing';
@@ -121,13 +121,13 @@ registerRoute(
 );
 ```
 
-This service worker caches navigation requests (for new HTML pages) with a [Network First strategy](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache) storing cached pages in a cache named pages, but only if it comes back with a 200 status code. It also caches stylesheets, javascript, and web workers with a [Stale While Revalidate strategy](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#stale-while-revalidate) storing cached assets in a cache named assets, again, only if they come back with a 200 status code. Finally, it caches images with a [Cache First strategy](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#cache_first_cache_falling_back_to_network) storing cached images in a cache named images, only if they come back with a 200 status code, expiring cached items after 30 days and only allowing 50 entries at once.
+This service worker caches navigation requests (for new HTML pages) with a [Network First strategy](/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache) storing cached pages in a cache named pages, but only if it comes back with a 200 status code. It also caches stylesheets, javascript, and web workers with a [Stale While Revalidate strategy](/web/tools/workbox/modules/workbox-strategies#stale-while-revalidate) storing cached assets in a cache named assets, again, only if they come back with a 200 status code. Finally, it caches images with a [Cache First strategy](/web/tools/workbox/modules/workbox-strategies#cache_first_cache_falling_back_to_network) storing cached images in a cache named images, only if they come back with a 200 status code, expiring cached items after 30 days and only allowing 50 entries at once.
 
 ### Precaching
 
-In addition to caching as requests are made, sometimes called runtime caching, Workbox also supports [precaching](https://developers.google.com/web/tools/workbox/modules/workbox-precaching), the ability to cache resources when the service worker is installed. There are a number of items that are great candidates for precaching: your web app's [start URL](https://web.dev/add-manifest/#start-url), your [offline fallback](#offline_fallback) page, and key JavaScript and CSS files. By precaching files, you’ll guarantee that they’re available in the cache when the service worker takes control of the page.
+In addition to caching as requests are made, sometimes called runtime caching, Workbox also supports [precaching](/web/tools/workbox/modules/workbox-precaching), the ability to cache resources when the service worker is installed. There are a number of items that are great candidates for precaching: your web app's [start URL](https://web.dev/add-manifest/#start-url), your [offline fallback](#offline_fallback) page, and key JavaScript and CSS files. By precaching files, you’ll guarantee that they’re available in the cache when the service worker takes control of the page.
 
-You can use precaching inside your new service worker by using a bundler plugin ([webpack](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#injectmanifest_plugin) or [rollup](https://github.com/chromeos/static-site-scaffold-modules/blob/master/modules/rollup-plugin-workbox-inject/README.md)) that supports precache manifest injection:
+You can use precaching inside your new service worker by using a bundler plugin ([webpack](/web/tools/workbox/modules/workbox-webpack-plugin#injectmanifest_plugin) or [rollup](https://github.com/chromeos/static-site-scaffold-modules/blob/master/modules/rollup-plugin-workbox-inject/README.md)) that supports precache manifest injection:
 
 ```javascript
 import { precacheAndRoute } from 'workbox-precaching';
@@ -164,4 +164,8 @@ This service worker precaches an offline page and, if a user is offline, returns
 
 ## Do more with Workbox
 
-There’s lots more you can do with Workbox! Read the [guides](/web/tools/workbox/guides) for a deeper dive into different aspects of Workbox. Check out all of the available [Workbox modules](https://developers.google.com/web/tools/workbox/modules) to see even more things Workbox can do, like managing Google Analytics when offline, retrying form submissions that failed when offline, or broadcast updates when a cache is updated. With Workbox, you can harness the power of service workers to improve performance and give your site a great experience, independent of the network.
+There’s lots more you can do with Workbox! Read the [guides](/web/tools/workbox/guides) for a deeper dive into different aspects of Workbox. Check out all of the available [Workbox modules](/web/tools/workbox/modules) to see even more things Workbox can do, like managing Google Analytics when offline, retrying form submissions that failed when offline, or broadcast updates when a cache is updated. With Workbox, you can harness the power of service workers to improve performance and give your site a great experience, independent of the network.
+
+## Feedback {: #feedback .hide-from-toc }
+
+{% include "web/_shared/helpful.html" %}


### PR DESCRIPTION
What's changed, or what was fixed?
- Updates Workbox's getting started documentation

**Target Live Date:** 2020-11-03

- [x] This has been reviewed and approved by @jeffposnick 
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label. (don't have the ability to add a label)
- [ ] I've staged the site and manually verified that my content displays correctly. (unable to get local server working, don't know how to stage the site otherwise)

**CC:** @petele
