### PR TITLE
Fix typo in nic87.md

### DIFF
--- a/src/content/en/updates/2020/11/nic87.md
+++ b/src/content/en/updates/2020/11/nic87.md
@@ -61,7 +61,7 @@ Starting in Chrome 87, once a user has granted permission you can now control
 the PTZ features on a camera.
 
 Feature detection is a little different from what you're probably used to.
-You’ll need to call `navigator.mediaDevices.getSupportedContraints()` to see
+You’ll need to call `navigator.mediaDevices.getSupportedConstraints()` to see
 if the _browser_ supports PTZ.
 
 ```js


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixed typo in the name of the method `getSupportedConstraints` in nic87.md

**CC:** @petele
