### PR TITLE
workbox/guides/advanced-recipes: fix snippet typo

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -257,7 +257,7 @@ To help with these sort of use cases, you can use any of the Workbox strategies 
 fashion via the `handle()` method.
 
 ```javascript
-import {StaleWhileRevalidate} from 'workbox-strategies';
+import {NetworkFirst} from 'workbox-strategies';
 
 // Inside your service worker code:
 const strategy = new NetworkFirst({networkTimeoutSeconds: 10});


### PR DESCRIPTION
What was fixed?
- workbox advanced recipes guide

**Fixes:** #9133

**Target Live Date:** 2020-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
