### PR TITLE
Workbox docs tweaks

### DIFF
--- a/src/content/en/tools/workbox/_index.yaml
+++ b/src/content/en/tools/workbox/_index.yaml
@@ -31,7 +31,7 @@ landing_page:
         Welcome! Workbox is a set of libraries that can power a production-ready
         <a href="https://web.dev/service-workers-cache-storage/">service worker</a>
         for your
-        <a href="https://web.dev/progressive-web-apps/">progressive web app</a>.
+        <a href="https://web.dev/progressive-web-apps/">Progressive Web App</a>.
 
   - custom_html: >
       <style>

--- a/src/content/en/tools/workbox/_index.yaml
+++ b/src/content/en/tools/workbox/_index.yaml
@@ -22,19 +22,16 @@ landing_page:
       </style>
       <div class="workbox-heading">
       <p><img class="workbox-heading__logo" src="./images/Workbox-Logo-Grey.svg" alt="Workbox Logo" /></p>
-
-      <p class="devsite-landing-row-description">JavaScript Libraries for adding offline support to web apps</p>
-
       <p><a class="button button-primary" href="/web/tools/workbox/guides/get-started">Get started</a></p>
       </div>
 
   - background: grey
     items:
     - description: >
-        Welcome, Workbox is a set of libraries and Node modules that make it
-        easy to cache assets and take full advantage of features used to
-        build
-        <a href="https://web.dev/progressive-web-apps/">Progressive Web Apps</a>.
+        Welcome! Workbox is a set of libraries that can power a production-ready
+        <a href="https://web.dev/service-workers-cache-storage/">service worker</a>
+        for your
+        <a href="https://web.dev/progressive-web-apps/">progressive web app</a>.
 
   - custom_html: >
       <style>
@@ -267,6 +264,9 @@ landing_page:
           </li>
           <li>
             <a href="https://web.dev/opensooq-case-study/">How OpenSooq increased engagement by investing in the web</a>
+          </li>
+          <li>
+            <a href="https://web.dev/rakuten-24/">Rakuten 24’s investment in PWA increases user retention by 450%</a>
           </li>
         </ul>
 

--- a/src/content/en/tools/workbox/_reference-docs.yaml
+++ b/src/content/en/tools/workbox/_reference-docs.yaml
@@ -20,8 +20,10 @@ toc:
   path: /web/tools/workbox/reference-docs/latest/module-workbox-navigation-preload
 - title: "workbox-precaching"
   path: /web/tools/workbox/reference-docs/latest/module-workbox-precaching
-- title: "workbox-rangeRequests"
+- title: "workbox-range-requests"
   path: /web/tools/workbox/reference-docs/latest/module-workbox-range-requests
+- title: "workbox-recipes"
+  path: /web/tools/workbox/reference-docs/latest/module-workbox-recipes
 - title: "workbox-routing"
   path: /web/tools/workbox/reference-docs/latest/module-workbox-routing
 - title: "workbox-strategies"

--- a/src/content/en/tools/workbox/modules/_index.yaml
+++ b/src/content/en/tools/workbox/modules/_index.yaml
@@ -165,6 +165,11 @@ landing_page:
         - label: Demo
           path: https://glitch.com/edit/#!/workbox-streams
 
+      # Force Devsite 4-up layout
+      - heading: ""
+      - heading: ""
+      - heading: ""
+
     - heading: Window Packages
       description: >
         Workbox provides modules that run in the window context and complement

--- a/src/content/en/tools/workbox/modules/_toc.yaml
+++ b/src/content/en/tools/workbox/modules/_toc.yaml
@@ -24,6 +24,7 @@ toc:
   path: /web/tools/workbox/modules/workbox-range-requests
 - title: workbox-recipes
   path: /web/tools/workbox/modules/workbox-recipes
+  status: new
 - title: workbox-routing
   path: /web/tools/workbox/modules/workbox-routing
 - title: workbox-strategies
@@ -32,7 +33,6 @@ toc:
 - heading: Window Packages
 - title: Workbox Window
   path: /web/tools/workbox/modules/workbox-window
-  status: new
 
 - heading: Node Packages
 - title: Workbox CLI

--- a/src/content/en/tools/workbox/modules/workbox-recipes.md
+++ b/src/content/en/tools/workbox/modules/workbox-recipes.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-recipes.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-11-16 #}
+{# wf_updated_on: 2020-12-01 #}
 {# wf_published_on: 2020-11-13 #}
 
 # Workbox Recipes {: .page-title }
@@ -152,7 +152,7 @@ registerRoute(
 
 ### Image cache
 
-The image cache recipe allows your service worker to respond to a request for images with a [stale-while-revalidate](/web/tools/workbox/modules/workbox-strategies#cache_first_cache_falling_back_to_network) caching strategy so that once they're available in cache a user doesn't need to make another request for them.
+The image cache recipe allows your service worker to respond to a request for images with a [cache-first](/web/tools/workbox/modules/workbox-strategies#cache_first_cache_falling_back_to_network) caching strategy so that once they're available in cache a user doesn't need to make another request for them.
 
 This recipe, by default, caches a maximum of 60 images, each for 30 days. See the [image cache options](/web/tools/workbox/reference-docs/latest/module-workbox-recipes#~imageCache) for a list of all configuration options.
 


### PR DESCRIPTION
R: @philipwalton @Snugug 

Some minor issues that we've noticed over the past day:
- Fixed some of the wording on the homepage, and added a link to a new production case study.
- Fixed the "new" tag on the modules TOC, so that it flags `workbox-recipes`, and adds `workbox-recipes` to another TOC.
- Fixed the description of the caching strategy in one of the recipes.
- Fixed the layout on the modules page to ensure that each module takes up the same horizontal space, even on an incomplete row.

**CC:** @petele
