### PR TITLE
Update Device Orientation sample code.

### DIFF
--- a/src/content/en/fundamentals/native-hardware/device-orientation/_code/dev-orientation.html
+++ b/src/content/en/fundamentals/native-hardware/device-orientation/_code/dev-orientation.html
@@ -86,8 +86,12 @@
           alpha.innerText = evt.alpha.toFixed(fixed);
           beta.innerText = evt.beta.toFixed(fixed);
           gamma.innerText = evt.gamma.toFixed(fixed);
-          var rotation = "rotate("+ evt.alpha +"deg) rotate3d(1,0,0, "+ (evt.gamma * -1)+"deg)";
-          h5logo.style.webkitTransform = rotation;
+
+          // Account for difference in coordinate systems between Device
+          // Orientation and CSS by inverting some signs, and apply the
+          // rotations in the order specified by the Device Orientation spec.
+          const rotation =
+              `rotateZ(${-evt.alpha}deg) rotateX(${evt.beta}deg) rotateY(${-evt.gamma}deg)`;
           h5logo.style.transform = rotation;
         } catch (ex) {
           document.getElementById("doeSupported").innerText = "NOT";


### PR DESCRIPTION
Although this sample is not linked by any pages since #6714, Googling for
"device orientation demo" still shows the googlesamples.github.io version of
this code as one of the first results. As such, fix the "deviceorientation"
event handler so that it applies rotations in a more correct and natural
way:
* Invert across the 3 axes rather than just 2, and do so in the order
  mandated by the Device Orientation spec.
* Invert the signs of the alpha and gamma rotations to account for
  differences between the CSS and Device Orientation coordinate systems.

Starting with Chrome 89, some of the presets in the DevTools Sensors tab
will cause the HTML5 logo not to show up because of the angles
involved (this is also the case even without this commit), but slight
changes in the rotations will cause it to be shown again.

This change was triggered by https://crbug.com/1137281 and the behavior of
the sample while I tried to investigate the DevTools behavior.

---

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
