### PR TITLE
Fix Device Orientation sample code axis inversions.

### DIFF
--- a/src/content/en/fundamentals/native-hardware/device-orientation/_code/dev-orientation.html
+++ b/src/content/en/fundamentals/native-hardware/device-orientation/_code/dev-orientation.html
@@ -20,7 +20,6 @@
         margin-left: auto;
         margin-right: auto;
       }
-
     </style>
   </head>
   <body>
@@ -69,7 +68,6 @@
       var beta = document.getElementById("beta");
       var gamma = document.getElementById("gamma");
 
-
       /* // [START devori] */
       if (window.DeviceOrientationEvent) {
         window.addEventListener('deviceorientation', deviceOrientationHandler, false);
@@ -90,14 +88,19 @@
           // Account for difference in coordinate systems between Device
           // Orientation and CSS by inverting some signs, and apply the
           // rotations in the order specified by the Device Orientation spec.
+          // Alpha and beta have their signs inverted because of the different
+          // rotation orientations; gamma is not inverted because the Y axis
+          // has opposite directions in the two coordinate systems, which also
+          // makes them both have the same rotation orientation.
+          // Also apply a perspective() transformation to make it easier to see
+          // the rotations around the X and Y axes.
           const rotation =
-              `rotateZ(${-evt.alpha}deg) rotateX(${evt.beta}deg) rotateY(${-evt.gamma}deg)`;
+              `perspective(50rem) rotateZ(${-evt.alpha}deg) rotateX(${-evt.beta}deg) rotateY(${evt.gamma}deg)`;
           h5logo.style.transform = rotation;
         } catch (ex) {
           document.getElementById("doeSupported").innerText = "NOT";
         }
       }
-
 
     </script>
   </body>


### PR DESCRIPTION
Follow-up to #9157, and another indication of how confusing it can get when
the CSS and Device Orientation coordinate systems get mixed.

Adjust which axes need to be inverted, this time with an explanation, and
add a perspective() transformation that makes it easier to see the rotations
around X and Y.

---

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
