### PR TITLE
Updates TWA docs with latest libraries

### DIFF
--- a/src/content/en/android/custom-tabs/implementation-guide/index.md
+++ b/src/content/en/android/custom-tabs/implementation-guide/index.md
@@ -3,7 +3,7 @@ book_path: /web/android/_book.yaml
 description: Implementation Guide for Custom Tabs.
 
 {# wf_published_on: 2020-02-04 #}
-{# wf_updated_on: 2020-07-25 #}
+{# wf_updated_on: 2020-12-08 #}
 {# wf_blink_components: N/A #}
 
 # Custom Tabs Implementation guide {: .page-title }
@@ -20,7 +20,7 @@ project. Open the `app/build.gradle` file and add the browser library to the dep
 ```gradle
 dependencies {
     ...
-    implementation "androidx.browser:browser:1.2.0"
+    implementation "androidx.browser:browser:1.3.0"
 }
 ```
 

--- a/src/content/en/android/trusted-web-activity/android-browser-helper-migration/index.md
+++ b/src/content/en/android/trusted-web-activity/android-browser-helper-migration/index.md
@@ -3,7 +3,7 @@ book_path: /web/android/_book.yaml
 description: Introduces android-browser-helper, a new library to build Trusted Web Activities.
 
 {# wf_published_on: 2020-01-10 #}
-{# wf_updated_on: 2020-11-25 #}
+{# wf_updated_on: 2020-12-08 #}
 {# wf_tags: trusted-web-activity #}
 {# wf_featured_image: /web/updates/images/generic/devices.png #}
 {# wf_blink_components: N/A #}
@@ -42,7 +42,7 @@ appllication `build.gradle`:
 ```gradle
 dependencies {
     //...
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.1'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
 }
 ```
 

--- a/src/content/en/android/trusted-web-activity/integration-guide/index.md
+++ b/src/content/en/android/trusted-web-activity/integration-guide/index.md
@@ -3,7 +3,7 @@ book_path: /web/android/_book.yaml
 description: Trusted Web Activity
 
 {# wf_published_on: 2020-02-04 #}
-{# wf_updated_on: 2020-11-10 #}
+{# wf_updated_on: 2020-12-08 #}
 {# wf_blink_components: N/A #}
 
 # Trusted Web Activity Integration Guide {: .page-title }
@@ -81,7 +81,7 @@ dependency to the `dependencies` section:
 
 ```
 dependencies {
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.1'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
 }
 ```
 
@@ -258,6 +258,12 @@ command line. Go to _Android Settings > Apps & notifications > Chrome_,
 and click on _Force stop_.
 
 ## Establish an association from the website to the app {: #link-site-to-app }
+
+<div class="video-wrapper">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="3bAQPnxLd4c"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
 There are 2 pieces of information that the developer needs to collect from the
 app in order to create the association:

--- a/src/content/en/android/trusted-web-activity/play-billing/index.md
+++ b/src/content/en/android/trusted-web-activity/play-billing/index.md
@@ -3,7 +3,7 @@ book_path: /web/android/_book.yaml
 description: Learn how to integrate Google Play Billing into your Trusted Web Activity project.
 
 {# wf_published_on: 2020-11-25 #}
-{# wf_updated_on: 2020-11-25 #}
+{# wf_updated_on: 2020-12-08 #}
 {# wf_tags: trusted-web-activity #}
 {# wf_featured_image: /web/updates/images/generic/devices.png #}
 {# wf_blink_components: N/A #}
@@ -41,8 +41,8 @@ You will also need to add an implementation declaration for the billing extensio
 ```groovy
 dependencies {
     ...
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0-alpha02'
-    implementation 'com.google.androidbrowserhelper:billing:1.0.0-alpha04'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
+    implementation 'com.google.androidbrowserhelper:billing:1.0.0-alpha05'
 }
 ```
 

--- a/src/content/en/android/trusted-web-activity/quick-start/index.md
+++ b/src/content/en/android/trusted-web-activity/quick-start/index.md
@@ -3,7 +3,7 @@ book_path: /web/android/_book.yaml
 description: A guide to get started building a basic, bare-bones Trusted Web Activity.
 
 {# wf_published_on: 2019-08-28 #}
-{# wf_updated_on: 2020-07-31 #}
+{# wf_updated_on: 2020-12-08 #}
 {# wf_tags: trusted-web-activity #}
 {# wf_featured_image: /web/updates/images/generic/devices.png #}
 {# wf_blink_components: N/A #}
@@ -64,26 +64,10 @@ npm i -g @bubblewrap/cli
 
 ### Setting up the Environment
 
-#### Get the Java Development Kit (JDK) 8.
-The Android Command line tools requires the correct version of the JDK to run. To prevent version
-conflicts with a JDK version that is already installed, Bubblewrap uses a JDK that can unzipped in
-a separate folder.
-
-Warning: Using a version lower than 8 will make it impossible to compile the project and higher
-versions are incompatible with the Android command line tools.
-
-Download a version of JDK 8 that is compatible with your OS from
-[AdoptOpenJDK](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=hotspot)
-and extract it in its own folder.
-
-#### Get the Android command line tools
-Download a version of Android command line tools that is compatible with your OS from
-[https://developer.android.com/studio#command-tools](https://developer.android.com/studio#command-tools).
-Create a folder and extract the downloaded file into it. The tool will further install its
-dependencies, without the need to install the whole Android IDE.
-
-When running `bubblewrap` for the first time, it will ask where it can find the JDK and Android
-command line tools. So, take note of the location where both were decompressed.
+When running Bubblewrap for the first time, it will offer to automatically download and install the
+required external dependencies. We recommend allowing the tool do do this, as it guarantees that
+the dependencies are configured correctly. Check the [Bubblewrap documentation][1] to use an
+existing Java Development Kit (JDK) or Android command line tools installation.
 
 ## Initialize and build project {: initialize-and-build}
 
@@ -144,6 +128,12 @@ When Bubblewrap builds the application, an APK will be created with a key setup 
 step.
 
 ## Setting up your asset link file {: #creating-your-asset-link-file }
+
+<div class="video-wrapper">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="3bAQPnxLd4c"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
 Besides the APK file, Bubblewrap output an `assetlinks.json` file that matches the key used to sign
 the APK.
@@ -283,3 +273,5 @@ With that done, you can consider deploying your app to the Play Store.
 {% include "web/_shared/helpful.html" %}
 
 {% include "web/_shared/rss-widget-updates.html" %}
+
+[1]: https://github.com/GoogleChromeLabs/bubblewrap/blob/master/packages/cli/README.md

--- a/src/content/en/android/trusted-web-activity/web-share-target/index.md
+++ b/src/content/en/android/trusted-web-activity/web-share-target/index.md
@@ -3,7 +3,7 @@ book_path: /web/android/_book.yaml
 description: Learn how to enable Web Share Target in a project using Trusted Web Activity.
 
 {# wf_published_on: 2020-11-10 #}
-{# wf_updated_on: 2020-11-25 #}
+{# wf_updated_on: 2020-12-08 #}
 {# wf_tags: trusted-web-activity #}
 {# wf_featured_image: /web/updates/images/generic/devices.png #}
 {# wf_blink_components: N/A #}
@@ -43,7 +43,7 @@ first step, update the application to use a version that is higher or equal to 2
 ```gradle
 dependencies {
     ...
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.0.1'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.1.0'
 }
 ```
 


### PR DESCRIPTION
Changes:
- Updates docs to latest version of android-browser-helper
  and androidx.
- Update quick-start guide and removed areas covering manual
  installation of the JDK and Android CLI tools.
- Linked to the Asset Links videos where possible.

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
