### PR TITLE
Include a full SSRI precaching example

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -357,6 +357,9 @@ const integrityManifestTransform = (originalManifest, compilation) => {
     // If some criteria match:
     if (entry.url.startsWith('...')) {
       // This has to be a synchronous function call, for example:
+      // compilation will be set when using workbox-webpack-plugin.
+      // When using workbox-build directly, you can read the file's
+      // contents from disk using, e.g., the fs module.
       const asset = compilation.getAsset(entry.url);
       entry.integrity = ssri.fromData(asset.source.source()).toString();
 

--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-core.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-08-25 #}
+{# wf_updated_on: 2020-12-09 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Precaching {: .page-title }
@@ -349,13 +349,16 @@ in the appropriate info themselves. The `manifestTransform` option in Workbox's
 build tools configuration can help:
 
 ```javascript
-const integrityManifestTransform = (originalManifest) => {
+const ssri = require('ssri');
+
+const integrityManifestTransform = (originalManifest, compilation) => {
   const warnings = [];
   const manifest = originalManifest.map((entry) => {
     // If some criteria match:
     if (entry.url.startsWith('...')) {
-      // This has to be a synchronous function call:
-      entry.integrity = generateSRIInfo(entry.url);
+      // This has to be a synchronous function call, for example:
+      const asset = compilation.getAsset(entry.url);
+      entry.integrity = ssri.fromData(asset.source.source()).toString();
 
       // Push a message to warnings if needed.
     }


### PR DESCRIPTION
### What's changed, or what was fixed?

This PR adds a complete example of subresource integrity to the precaching docs, using the very standard [SSRI](https://www.npmjs.com/package/ssri) module.

The existing code didn't give you any hints about how to either how to get the content of the asset or actually hash the content. I've just done a bunch of digging to build that myself, and I suspect 99.9% of people reading this example want exactly the same code, so it'd be useful to just include it up front.

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
