### PR TITLE
Add YouTube video to WebAssembly post

### DIFF
--- a/src/content/en/updates/2020/12/webassembly.md
+++ b/src/content/en/updates/2020/12/webassembly.md
@@ -7,10 +7,17 @@ description: Step-by-step overview of the new debugging experience for WebAssemb
 {# wf_tags: devtools-blog #}
 {# wf_featured_image: /web/updates/images/2020/12/webassembly/image5.png #}
 {# wf_blink_components: Platform>DevTools>WebAssembly #}
+{# wf_youtube_id: VBMHswhun-s #}
 
 # Debugging WebAssembly with modern tools {: .page-title }
 
 {% include "web/_shared/contributors/ingvarstepanyan.html" %}
+
+<div class="video-wrapper">
+  <iframe class="devsite-embedded-youtube-video" data-video-id="VBMHswhun-s"
+          data-autohide="1" data-showinfo="0" frameborder="0" allowfullscreen>
+  </iframe>
+</div>
 
 ## The road so far {: #past }
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Added YouTube embed for the related CDS talk.

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
