### PR TITLE
Send CA to CSR -> Send CSR to CA

### DIFF
--- a/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
+++ b/src/content/en/fundamentals/security/encrypt-in-transit/enable-https.md
@@ -113,7 +113,7 @@ CSR by email, or something else. Some CAs (or their resellers) may even automate
 some or all of the process (including, in some cases, key pair and CSR
 generation).
 
-Send the CA to your CSR, and follow their instructions to receive your final
+Send the CSR to your CA, and follow their instructions to receive your final
 certificate or certificate chain.
 
 Different CAs charge different amounts of money for the service of vouching


### PR DESCRIPTION
The previous version stated: Send the CA to your CSR, which is incorrect since the user must send the Certificate Signing Request to the Certificate Authority for them to validate the certificate.

What's changed, or what was fixed?
- Line 116(Semantics issue before described above)

**Fixes:** #issue

**Target Live Date:** 2020-12-16

I believe the steps below are unnecessary given how small the change is, and its scope.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
