### PR TITLE
Fixes navigationPreload import

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -140,7 +140,7 @@ else, this is a baseline recipe to follow. It takes advantage of
 browsers) to help mitigate the startup cost of a service worker.
 
 ```javascript
-import {* as navigationPreload} from 'workbox-navigation-preload';
+import * as navigationPreload from 'workbox-navigation-preload';
 import {registerRoute, NavigationRoute} from 'workbox-routing';
 import {NetworkOnly} from 'workbox-strategies';
 


### PR DESCRIPTION
Fixes `navigationPreload` import in [Advanced Recipes](https://developers.google.com/web/tools/workbox/guides/advanced-recipes) documentation.

What's changed, or what was fixed?
- Removed curly brackets from the `navigationPreload` import in the example

```javascript
import {* as navigationPreload} from 'workbox-navigation-preload';
```

**CC:** @petele
