### PR TITLE
Update guidance to use the pagehide event over unload

### DIFF
--- a/src/content/en/updates/2020/05/heavy-ad-interventions.md
+++ b/src/content/en/updates/2020/05/heavy-ad-interventions.md
@@ -188,8 +188,8 @@ window.addEventListener('pagehide', (event) => {
 });
 ```
 
-Remember the `pagehide` event restricts the amount of work that can happen
-within it to protect the user experience. For example, trying to send a
+Remember that, to protect the user experience, the `pagehide` event restricts 
+the amount of work that can happen within it. For example, trying to send a
 `fetch()` request with the reports will result in that request being canceled.
 You should use `navigator.sendBeacon()` to send that report and even then, this
 is only best-effort by the browser not a guarantee.

--- a/src/content/en/updates/2020/05/heavy-ad-interventions.md
+++ b/src/content/en/updates/2020/05/heavy-ad-interventions.md
@@ -189,7 +189,7 @@ window.addEventListener('pagehide', (event) => {
 ```
 
 Remember the `pagehide` event restricts the amount of work that can happen
-within them to protect the user experience. For example, trying to send a
+within it to protect the user experience. For example, trying to send a
 `fetch()` request with the reports will result in that request being canceled.
 You should use `navigator.sendBeacon()` to send that report and even then, this
 is only best-effort by the browser not a guarantee.

--- a/src/content/en/updates/2020/05/heavy-ad-interventions.md
+++ b/src/content/en/updates/2020/05/heavy-ad-interventions.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: Handling Heavy Ad Interventions
 
 {# wf_published_on: 2020-05-14 #}
-{# wf_updated_on: 2020-05-14 #}
+{# wf_updated_on: 2021-01-13 #}
 {# wf_featured_image: /web/updates/images/generic/security.png #}
 {# wf_tags: devtools,performance #}
 {# wf_featured_snippet: Chrome’s Heavy Ad Intervention will unload ads that exceed their allowance for CPU or network usage. Learn how to monitor these with the Reporting API and update your ads to avoid issues. #}

--- a/src/content/en/updates/2020/05/heavy-ad-interventions.md
+++ b/src/content/en/updates/2020/05/heavy-ad-interventions.md
@@ -188,13 +188,13 @@ window.addEventListener('pagehide', (event) => {
 });
 ```
 
-Caution: The `pagehide` event restricts the amount of work that can happen
+Remember the `pagehide` event restricts the amount of work that can happen
 within them to protect the user experience. For example, trying to send a
 `fetch()` request with the reports will result in that request being canceled.
 You should use `navigator.sendBeacon()` to send that report and even then, this
 is only best-effort by the browser not a guarantee.
 
-[**Do not use** the `unload` and `beforeunload`
+Caution: [**Do not use** the `unload` and `beforeunload`
 events](https://web.dev/bfcache/#never-use-the-unload-event) here. This will
 actively hurt your page caching and performance across multiple browsers.
 

--- a/src/content/en/updates/2020/05/heavy-ad-interventions.md
+++ b/src/content/en/updates/2020/05/heavy-ad-interventions.md
@@ -178,21 +178,25 @@ observer.observe();
 However, because the intervention will literally remove the page from the
 iframe, you should add a failsafe to ensure that the report is definitely
 captured before the page is gone completely, for example, an ad within an
-iframe. For this, you can hook your same callback into the `unload` event.
+iframe. For this, you can hook your same callback into the `pagehide` event.
 
 ```js
-window.addEventListener('unload', (event) => {
+window.addEventListener('pagehide', (event) => {
   // pull all pending reports from the queue
   let reports = observer.takeRecords();
   sendReports(reports);
 });
 ```
 
-Caution: The `unload` and `beforeunload` events both restrict the amount of work
-that can happen within them to protect the user experience. For example, trying
-to send a `fetch()` request with the reports will result in that request being
-canceled. You should use `navigator.sendBeacon()` to send that report and even
-then, this is only best-effort by the browser not a guarantee.
+Caution: The `pagehide` event restricts the amount of work that can happen
+within them to protect the user experience. For example, trying to send a
+`fetch()` request with the reports will result in that request being canceled.
+You should use `navigator.sendBeacon()` to send that report and even then, this
+is only best-effort by the browser not a guarantee.
+
+[**Do not use** the `unload` and `beforeunload`
+events](https://web.dev/bfcache/#never-use-the-unload-event) here. This will
+actively hurt your page caching and performance across multiple browsers.
 
 The resulting JSON from the JavaScript is similar to that sent on the `POST`
 request:


### PR DESCRIPTION
https://developers.google.com/web/updates/2020/05/heavy-ad-interventions suggests using the `unload` and `beforeunload` events to report on interventions. This conflicts with the advice to never use `unload` and use `pagehide` instead in https://web.dev/bfcache/#never-use-the-unload-event

The article demo has been updated to make use of the `pagehide` event and warn against `unload` and `beforeunload`.

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
