### PR TITLE
Fix typo in headless-karma-mocha-chai.md

### DIFF
--- a/src/content/en/updates/2017/06/headless-karma-mocha-chai.md
+++ b/src/content/en/updates/2017/06/headless-karma-mocha-chai.md
@@ -117,7 +117,7 @@ module.exports = function(config) {
 }
 ```
 
-Note: Run `./node_modules/karma/bin/ init karma.conf.js` to generate the Karma configuration file.
+Note: Run `./node_modules/karma/bin/karma init karma.conf.js` to generate the Karma configuration file.
 
 ## Write a test
 


### PR DESCRIPTION
- without this the command fails, with this it succeeds and starts asking initialisation questions to create the config

What's changed, or what was fixed?
- typo in the documentation for initialising karma

**Fixes:** n/a

**Target Live Date:** ?

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
