### PR TITLE
Replace defaultQueue with queue

### DIFF
--- a/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
+++ b/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: This article is about me playing with the experimental WebGPU API and sharing my journey with web developers interested in performing data-parallel computations using the GPU.
 
 
-{# wf_updated_on: 2021-01-13 #}
+{# wf_updated_on: 2021-01-28 #}
 {# wf_published_on: 2019-08-28 #}
 {# wf_tags: news,gpu,canvas,graphics #}
 {# wf_blink_components: Blink>WebGPU #}
@@ -155,9 +155,8 @@ Once you have the GPU command encoder, call `copyEncoder.copyBufferToBuffer()`
 as shown below to add this command to the command queue for later execution.
 Finally, finish encoding commands by calling `copyEncoder.finish()` and submit
 those to the GPU device command queue. The queue is responsible for handling
-submissions done via `device.defaultQueue.submit()` with the GPU commands as
-arguments. This will atomically execute all the commands stored in the array in
-order.
+submissions done via `device.queue.submit()` with the GPU commands as arguments.
+This will atomically execute all the commands stored in the array in order.
 
 ```js
 // Encode commands for copying buffer to buffer.
@@ -172,7 +171,7 @@ copyEncoder.copyBufferToBuffer(
 
 // Submit copy commands.
 const copyCommands = copyEncoder.finish();
-device.defaultQueue.submit([copyCommands]);
+device.queue.submit([copyCommands]);
 ```
 
 At this point, GPU queue commands have been sent, but not necessarily executed.
@@ -503,7 +502,7 @@ To end the compute pass encoder, call `passEncoder.endPass()`. Then, create a
 GPU buffer to use as a destination to copy the result matrix buffer with
 `copyBufferToBuffer`. Finally, finish encoding commands with
 `copyEncoder.finish()` and submit those to the GPU device queue by calling
-`device.defaultQueue.submit()` with the GPU commands.
+`device.queue.submit()` with the GPU commands.
 
 ```js
 // Get a GPU buffer for reading in an unmapped state.
@@ -523,7 +522,7 @@ commandEncoder.copyBufferToBuffer(
 
 // Submit GPU commands.
 const gpuCommands = commandEncoder.finish();
-device.defaultQueue.submit([gpuCommands]);
+device.queue.submit([gpuCommands]);
 ```
 
 ### Read result matrix


### PR DESCRIPTION
This PR is about replacing the soon to be deprecated `defaultQueue` attribute with `queue` in the GPU Compute article.
See https://chromium-review.googlesource.com/c/chromium/src/+/2651406

I'll update samples as well.

@kangz Can you review?

@petele Can you merge once it's approved by @Kangz?