### PR TITLE
Fixes #9241 - Remove references to Accept-CH-Lifetime

### DIFF
--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Client hints are a set of HTTP request headers we can use to change how we deliver page resources based on characteristics of a user's device and network connection. In this article, you'll learn all about client hints, how they work, and a few ideas on how you can use them to make your site faster for users.
 
-{# wf_updated_on: 2021-02-03 #}
+{# wf_updated_on: 2021-02-17 #}
 {# wf_published_on: 2018-11-22 #}
 {# wf_blink_components: UI>Browser>Mobile>Settings>DataSaver,Blink>Fonts,Blink>CSS,Blink>JavaScript #}
 

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -81,6 +81,9 @@ client reads this header, it’s being told “this site wants the `Viewport-Wid
 and `Downlink` client hints.” Don’t worry about the specific hints themselves.
 We’ll get to those in a moment.
 
+Note: In order for client hints to work at all, your site must be served over
+HTTPS!
+
 You can set these opt-in headers in any back-end language. For example, [PHP’s
 `header` function](http://php.net/manual/en/function.header.php) could be used.
 You could even set these opt-in headers with [the `http-equiv`
@@ -91,8 +94,10 @@ on a `<meta>` tag:
 <meta http-equiv="Accept-CH" content="Viewport-Width, Downlink">
 ```
 
-Note: In order for client hints to work at all, your site must be served over
-HTTPS!
+Warning: Earlier versions of the spec included the `Accept-CH-Lifetime` which
+has now been removed and sites should also stop sending it. If you were using
+this to enable hints to persist over browser sessions you should instead ensure
+you are sending the necessary `Accept-CH` headers on the relevant responses.
 
 ## All the client hints!
 

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -94,10 +94,11 @@ on a `<meta>` tag:
 <meta http-equiv="Accept-CH" content="Viewport-Width, Downlink">
 ```
 
-Warning: Earlier versions of the spec included the `Accept-CH-Lifetime` which
-has now been removed and sites should also stop sending it. If you were using
-this to enable hints to persist over browser sessions you should instead ensure
-you are sending the necessary `Accept-CH` headers on the relevant responses.
+Warning: Earlier versions of the spec included the `Accept-CH-Lifetime` header
+which has now been removed and sites should also stop sending it. If you were
+using this to enable hints to persist over browser sessions you should instead
+ensure you are sending the necessary `Accept-CH` headers on the relevant
+responses.
 
 ## All the client hints!
 

--- a/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
+++ b/src/content/en/fundamentals/performance/optimizing-content-efficiency/client-hints/index.md
@@ -2,7 +2,7 @@ project_path: /web/fundamentals/_project.yaml
 book_path: /web/fundamentals/_book.yaml
 description: Client hints are a set of HTTP request headers we can use to change how we deliver page resources based on characteristics of a user's device and network connection. In this article, you'll learn all about client hints, how they work, and a few ideas on how you can use them to make your site faster for users.
 
-{# wf_updated_on: 2020-07-24 #}
+{# wf_updated_on: 2021-02-03 #}
 {# wf_published_on: 2018-11-22 #}
 {# wf_blink_components: UI>Browser>Mobile>Settings>DataSaver,Blink>Fonts,Blink>CSS,Blink>JavaScript #}
 
@@ -81,14 +81,6 @@ client reads this header, it’s being told “this site wants the `Viewport-Wid
 and `Downlink` client hints.” Don’t worry about the specific hints themselves.
 We’ll get to those in a moment.
 
-There’s also an optional `Accept-CH-Lifetime` header which specifies the length
-of time, in seconds, the browser should remember the value you set for
-`Accept-CH` for your origin.
-
-Note: Client hints don’t kick in on the navigation request the first time a user
-visits your site. However, if you persist hints with `Accept-CH-Lifetime`, this
-information will be available on the navigation request.
-
 You can set these opt-in headers in any back-end language. For example, [PHP’s
 `header` function](http://php.net/manual/en/function.header.php) could be used.
 You could even set these opt-in headers with [the `http-equiv`
@@ -97,7 +89,6 @@ on a `<meta>` tag:
 
 ```html
 <meta http-equiv="Accept-CH" content="Viewport-Width, Downlink">
-<meta http-equiv="Accept-CH-Lifetime" content="86400">
 ```
 
 Note: In order for client hints to work at all, your site must be served over

--- a/src/content/en/updates/2017/12/device-memory.md
+++ b/src/content/en/updates/2017/12/device-memory.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: The Device Memory API allows developers to serve different resources to users based on their device's memory capabilities.
 
-{# wf_updated_on: 2019-10-13 #}
+{# wf_updated_on: 2021-02-03 #}
 {# wf_published_on: 2017-12-07 #}
 {# wf_tags: performance #}
 {# wf_blink_components: Blink>PerformanceAPIs #}
@@ -107,18 +107,6 @@ app.get('/static/js/:scriptId', (req, res) => {
   res.sendFile(`./path/to/${req.params.scriptId}.${scriptVersion}.js`);
 });
 ```
-
-<aside>
-  <strong>Note:</strong>
-  The <code>Accept-CH</code> header works well for a page's subresource, but it
-  doesn't help if you want to conditionally serve page contents based on device
-  capabilities. To address this, the <a
-  href="http://httpwg.org/http-extensions/client-hints.html#accept-ch-lifetime">
-  <code>Accept-CH-Lifetime</code></a> header (coming soon to Chrome) instructs
-  browsers to include the specified client hints headers in all subsequent
-  requests from this origin for the number of seconds specified by the header
-  value.
-</aside>
 
 ### Using the JavaScript API
 


### PR DESCRIPTION
It's been removed from relevant specs, and we shouldn't encourage its use.

What's changed, or what was fixed?
- I removed references to `Accept-CH-Lifetime`.

**Fixes:** #9241

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
@yoavweiss @rowan-m 
