### PR TITLE
Bring Site Kit page up to date with styles and correct redirect URI.

### DIFF
--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -31,8 +31,8 @@
     </style>
   </head>
   <body>
-    <section class="devsite-landing-row devsite-landing-row-1-up devsite-landing-row-50">
-      <div class="devsite-landing-row-group">
+    <section class="devsite-landing-row devsite-landing-row-2-up">
+      <div class="devsite-landing-row-inner">
         <div class="devsite-landing-row-item">
           <div id="site-kit-setup">
             {% dynamic if request.query_string.sitename %}
@@ -40,7 +40,7 @@
             {% dynamic endif %}
             {% dynamic if request.query_string.siteurl %}
               {% dynamic setvar productName %}Site Kit on {% dynamic print request.query_string.siteurl|escape %}{% dynamic endsetvar %}
-              {% dynamic setvar redirectURI %}{% dynamic print request.query_string.siteurl|escape %}?oauth2callback=1{% dynamic endsetvar %}
+              {% dynamic setvar redirectURI %}{% dynamic print request.query_string.siteurl|escape %}/wp-admin/index.php?oauth2callback=1{% dynamic endsetvar %}
             {% dynamic endif %}
             {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}
             <p>


### PR DESCRIPTION
What's changed, or what was fixed?
- Update classes used for container divs to match current styles.
- Adjust the redirect URI to match the new default value (includes WordPress wp-admin root).

**Fixes:** 

Site Kit developer plugin not working.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
