### PR TITLE
fix: correct link to 2021/01/devtools

### DIFF
--- a/src/content/en/updates/_shared/discover-devtools-blog.md
+++ b/src/content/en/updates/_shared/discover-devtools-blog.md
@@ -2,7 +2,7 @@
 
 Below is a list of everything that's been covered in the *Chrome DevTools Engineering Blog* series.
 
-* [Improving DevTools startup time](/web/updates/2021/01/faster-devtools-startup)
+* [Improving DevTools startup time](/web/updates/2021/01/devtools)
 * [Migrating Puppeteer to TypeScript](/web/updates/2021/01/puppeteer-typescript)
 * [Debugging WebAssembly with modern tools](/web/updates/2020/12/webassembly)
 * [DevTools architecture refresh: migrating to Web Components](/web/updates/2020/12/migrating-to-web-components)


### PR DESCRIPTION
A broken link in discover-devtools-blog.md was fixed: replaced `...updates/2021/01/faster-devtools-startup` by `...updates/2021/01/devtools`  (did a cross-check, in other usages also the 2nd one was placed, e.g.: in [_shared/discover.md](https://github.com/google/WebFundamentals/blob/main/src/content/en/updates/_shared/discover.md))

**Fixes:** #9256

**Target Live Date:** not applicable

_Note:_ I haven't done the following checklist but for me it seems they are not mandatory for the current fix, I did testing locally of this small change:  
- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
