### PR TITLE
Site Kit page: fix search console API was renamed webmasters->searchconsole.

### DIFF
--- a/src/content/en/site-kit/apikey.html
+++ b/src/content/en/site-kit/apikey.html
@@ -39,7 +39,7 @@
                 data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
                 data-henhouse-use-updated-header="true"
                 data-api-id="servicemanagement.googleapis.com"
-                data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
+                data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,searchconsole.googleapis.com"
                 data-henhouse-credential-type="API_KEY"
                 {% dynamic if user.signed_in and setvar.projectName and setvar.productName %}
                   data-henhouse-project-name="{% dynamic print setvar.projectName|escape %}"

--- a/src/content/en/site-kit/index.html
+++ b/src/content/en/site-kit/index.html
@@ -72,7 +72,7 @@
                 data-henhouse-header-logo-url="https://www.gstatic.com/images/branding/product/1x/googleg_64dp.png"
                 data-henhouse-use-updated-header="true"
                 data-api-id="servicemanagement.googleapis.com"
-                data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,webmasters.googleapis.com"
+                data-henhouse-extra-api-ids="adsense.googleapis.com,analytics.googleapis.com,analyticsreporting.googleapis.com,pagespeedonline.googleapis.com,people.googleapis.com,siteverification.googleapis.com,tagmanager.googleapis.com,searchconsole.googleapis.com"
                 data-henhouse-credential-type="OAUTH"
                 data-henhouse-client-type="WEB_SERVER"
                 {% dynamic if user.signed_in and setvar.projectName and setvar.productName and setvar.redirectURI %}


### PR DESCRIPTION
Follow up to https://github.com/google/WebFundamentals/pull/9252, this PR fixes an error shown when clicking the "Get Oauth Credentials" button.

**Couldn't initialize** `Service 'webmasters.googleapis.com' not found or permission denied.`

The error is caused because the Search Console API has been renamed and we can no longer create apps with the service `webmasters.googleapis.com`. Instead, we need to use the service name `searchconsole.googleapis.com`.


**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
