### PR TITLE
Update advanced-recipes.md

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -48,7 +48,7 @@ if ('serviceWorker' in navigator) {
           // instructing it to activate.  
           // Note: for this to work, you have to add a message
           // listener in your service worker. See below.
-          messageSW(registration.waiting, {type: 'SKIP_WAITING'});
+          await messageSW(registration.waiting, {type: 'SKIP_WAITING'});
         }
       },
 


### PR DESCRIPTION
Add `await` in the `messageSW` call. `messageSW` returns a promise https://github.com/GoogleChrome/workbox/blob/v6/packages/workbox-window/src/messageSW.ts, I assume that the onAccept handler is async because of this await.

What's changed, or what was fixed?
- adds an await

Just changes docs so omittting the rest of the template.

**CC:** @petele
