### PR TITLE
clientsClaim and skipWaiting updates for v6

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -2,7 +2,7 @@ project_path: /web/tools/workbox/_project.yaml
 book_path: /web/tools/workbox/_book.yaml
 description: Advanced recipes to use with Workbox.
 
-{# wf_updated_on: 2020-08-25 #}
+{# wf_updated_on: 2021-03-19 #}
 {# wf_published_on: 2017-12-17 #}
 {# wf_blink_components: N/A #}
 
@@ -19,7 +19,8 @@ To do this you'll need to add some code to your page and to your service worker.
 
 ```html
 <script type="module">
-import {Workbox, messageSW} from 'https://storage.googleapis.com/workbox-cdn/releases/{% include "web/tools/workbox/_shared/workbox-latest-version.html" %}/workbox-window.prod.mjs';
+// This code sample uses features introduced in Workbox v6.
+import {Workbox, messageSkipWaiting} from 'https://storage.googleapis.com/workbox-cdn/releases/{% include "web/tools/workbox/_shared/workbox-latest-version.html" %}/workbox-window.prod.mjs';
 
 if ('serviceWorker' in navigator) {
   const wb = new Workbox('/sw.js');
@@ -43,13 +44,7 @@ if ('serviceWorker' in navigator) {
           window.location.reload();
         });
 
-        if (registration && registration.waiting) {
-          // Send a message to the waiting service worker,
-          // instructing it to activate.  
-          // Note: for this to work, you have to add a message
-          // listener in your service worker. See below.
-          messageSW(registration.waiting, {type: 'SKIP_WAITING'});
-        }
+        messageSkipWaiting();
       },
 
       onReject: () => {
@@ -61,9 +56,8 @@ if ('serviceWorker' in navigator) {
   // Add an event listener to detect when the registered
   // service worker has installed but is waiting to activate.
   wb.addEventListener('waiting', showSkipWaitingPrompt);
-  wb.addEventListener('externalwaiting', showSkipWaitingPrompt);
 
-  wb.register().then((r) => registration = r);
+  wb.register();
 }
 </script>
 ```
@@ -74,7 +68,7 @@ phase.
 
 When a waiting service worker is found we inform the user that an updated
 version of the site is available and prompt them to reload. If they accept the
-prompt, we `postMessage()` the new service worker telling it to run
+prompt, we use `messageSkipWaiting()` to the waiting service worker telling it to run
 `skipWaiting()`, meaning it'll start to activate. Once the new service worker
 has activated and taken control, we reload the current page, causing the latest
 version of all the precached assets to be displayed.
@@ -97,13 +91,13 @@ service worker file yourself:
 ```javascript
 addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') {
-    skipWaiting();
+    self.skipWaiting();
   }
 });
 ```
 
-This will listen for messages of `type: 'SKIP_WAITING'` and run the `skipWaiting()`
-method, forcing the service worker to activate right away.
+This will listen for messages of `type: 'SKIP_WAITING'` and run the
+`self.skipWaiting()` method, forcing the service worker to activate right away.
 
 ## "Warm" the runtime cache
 

--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -68,8 +68,8 @@ phase.
 
 When a waiting service worker is found we inform the user that an updated
 version of the site is available and prompt them to reload. If they accept the
-prompt, we use `messageSkipWaiting()` to the waiting service worker telling it to run
-`skipWaiting()`, meaning it'll start to activate. Once the new service worker
+prompt, we use `messageSkipWaiting()` to tell the waiting service worker to run
+`self.skipWaiting()`, meaning it'll start to activate. Once the new service worker
 has activated and taken control, we reload the current page, causing the latest
 version of all the precached assets to be displayed.
 

--- a/src/content/en/tools/workbox/modules/workbox-core.md
+++ b/src/content/en/tools/workbox/modules/workbox-core.md
@@ -90,7 +90,7 @@ The `clientsClaim()` method in `workbox-core` automatically adds an `activate`
 event listener to your service worker, and inside of it, calls
 `self.clients.claim()`. Calling `self.clients.claim()` before the current service
 worker activates will lead to a
-[runtime exception](https://w3c.github.io/ServiceWorker/#:~:text=If%20the%20service%20worker%20is%20not%20an%20active%20worker%2C%20return%20a%20promise%20rejected%20with%20an%20%22InvalidStateError%22%20DOMException.),
+[runtime exception](https://w3c.github.io/ServiceWorker/#dom-clients-claim),
 and `workbox-core`'s wrapper helps ensure that you call it at the right time.
 
 ### The skipWaiting wrapper is deprecated

--- a/src/content/en/tools/workbox/modules/workbox-core.md
+++ b/src/content/en/tools/workbox/modules/workbox-core.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-core.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2021-03-19 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Core {: .page-title }
@@ -69,21 +69,45 @@ multiple projects and use the same localhost port for each project, setting a
 custom prefix for each module will prevent the caches from conflicting
 with each other.
 
-## Skip Waiting and Clients Claim
+## Clients Claim
 
 Some developers want to be able to publish a new service worker and have it
-update and control a web page as soon as possible, skipping the default
-[service worker lifecycle](/web/fundamentals/primers/service-workers/lifecycle).
+control already-open web pages as soon as soon as it activates, which will not
+happen [by default](/web/fundamentals/primers/service-workers/lifecycle#clientsclaim).
 
-If you find yourself wanting this behavior, `workbox-core` provides some helper
-methods to make this easy:
+If you find yourself wanting this behavior, `workbox-core` provides a helper method:
 
 <pre class="prettyprint js">
-import {skipWaiting, clientsClaim} from 'workbox-core';
+import {clientsClaim} from 'workbox-core';
 
-skipWaiting();
+// This clientsClaim() should be at the top level
+// of your service worker, not inside of, e.g.,
+// an event handler.
 clientsClaim();
 </pre>
+
+The `clientsClaim()` method in `workbox-core` automatically adds an `activate`
+event listener to your service worker, and inside of it, calls
+`self.clients.claim()`. Calling `self.clients.claim()` before the current service
+worker activates will lead to a
+[runtime exception](https://w3c.github.io/ServiceWorker/#:~:text=If%20the%20service%20worker%20is%20not%20an%20active%20worker%2C%20return%20a%20promise%20rejected%20with%20an%20%22InvalidStateError%22%20DOMException.),
+and `workbox-core`'s wrapper helps ensure that you call it at the right time.
+
+### The skipWaiting wrapper is deprecated
+
+Previous to Workbox v6, developers were also encouraged to use the `skipWaiting()`
+method from `workbox-core`. However, this method offered little value beyond what
+developers would get if they called `self.skipWaiting()` explicitly.
+
+Because the legacy `workbox-core` wrapper also registered an `install` event handler
+in which `self.skipWaiting()` was called, the wrapper would not behave as expected
+if it were called inside of another event handler, like `message`, after installation
+had already completed.
+
+For these reasons, `workbox-core`'s `skipWaiting()` is deprecated, and developers
+should switch to calling `self.skipWaiting()` directly. Unlike with
+`self.clients.claim()`, `self.skipWaiting()` will not throw an exception if called
+at the "wrong" time, so there is no need to wrap it in an event handler.
 
 Note: If your web app lazy-loads resources that are uniquely versioned with, e.g., hashes in their
 URLs, it's recommended that you avoid using skip waiting. Enabling it could

--- a/src/content/en/tools/workbox/modules/workbox-window.md
+++ b/src/content/en/tools/workbox/modules/workbox-window.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-routing.
 
 {# wf_published_on: 2019-02-24 #}
-{# wf_updated_on: 2021-02-10 #}
+{# wf_updated_on: 2021-03-19 #}
 {# wf_blink_components: N/A #}
 
 # Workbox Window {: .page-title }
@@ -599,7 +599,6 @@ optional):
   </tr>
 </table>
 
-
 Messages sent via the `messageSW()` method use `MessageChannel` so the receiver
 can respond to them. To respond to a message you can call
 `event.ports[0].postMessage(response)` in your message event listener. The
@@ -684,3 +683,18 @@ allows you to differentiate between breaking updates and non-breaking updates,
 and in the case of a breaking update you'd know it's not safe to message the
 service worker. Instead you'd want to warn the user that they're running an old
 version of the page, and suggest they reload to get the update.
+
+### Skip waiting helper
+
+A common use convention for window to service worker messaging is send a
+`{type: 'SKIP_WAITING'}` message to instruct a service worker that's installed to
+[skip the waiting phase](/web/fundamentals/primers/service-workers/lifecycle#skip_the_waiting_phase)
+and activate.
+
+Starting with Workbox v6, the `messageSkipWaiting()` method can be used to send a
+`{type: 'SKIP_WAITING'}` message to the waiting service worker associated with the
+current service worker registration. It will silently do nothing if there isn't a
+waiting service worker.
+
+For guidance on using `messageSkipWaiting()`, see the
+"[Offer a page reload for users](/web/tools/workbox/guides/advanced-recipes#offer_a_page_reload_for_users)" recipe.


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/workbox/issues/2070

CC: @petele @philipwalton @tropicadri

This is a potpourri of updates to document a few things that changed related to `skipWaiting` and `clientsClaim` in Workbox v6 that we overlooked the first time around.

One of the changes is that the "Offer a page reload for users" recipe now requires Workbox v6+, but I think that's a reasonable tradeoff, in that the updated recipe is even more straightforward.