### PR TITLE
fix: update GitHub URL of Puppeteer

### DIFF
--- a/gulp-tasks/puppeteer/build_docs.js
+++ b/gulp-tasks/puppeteer/build_docs.js
@@ -21,7 +21,7 @@ const readFile = promisify(fs.readFile);
 const ensureDir = promisify(fs.ensureDir);
 const writeFile = promisify(fs.writeFile);
 
-const ORG = 'GoogleChrome';
+const ORG = 'puppeteer';
 const USER = 'puppeteer';
 const GITHUB_PROJECT_URL = `https://github.com/${ORG}/${USER}`;
 const GIT_URL = `${GITHUB_PROJECT_URL}.git`;

--- a/src/content/en/tools/puppeteer/_toc.yaml
+++ b/src/content/en/tools/puppeteer/_toc.yaml
@@ -43,16 +43,16 @@ toc:
     path: 'https://www.npmjs.com/package/puppeteer'
     status: external
   - title: Github
-    path: 'https://github.com/GoogleChrome/puppeteer'
+    path: 'https://github.com/puppeteer/puppeteer'
     status: external
   - title: Report an issue
-    path: 'https://github.com/GoogleChrome/puppeteer/issues/new'
+    path: 'https://github.com/puppeteer/puppeteer/issues/new'
     status: external
   - title: Releases
-    path: 'https://github.com/GoogleChrome/puppeteer/releases'
+    path: 'https://github.com/puppeteer/puppeteer/releases'
     status: external
   - title: How to Contribute
-    path: 'https://github.com/GoogleChrome/puppeteer/blob/main/CONTRIBUTING.md'
+    path: 'https://github.com/puppeteer/puppeteer/blob/main/CONTRIBUTING.md'
     status: external
   - title: FAQ
     path: /web/tools/puppeteer/faq


### PR DESCRIPTION
What's changed, or what was fixed?
- changed https://github.com/GoogleChrome/puppeteer links to https://github.com/puppeteer/puppeteer

**Fixes:** #9320

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
