### PR TITLE
Rename computeStage to compute

### DIFF
--- a/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
+++ b/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: This article is about me playing with the experimental WebGPU API and sharing my journey with web developers interested in performing data-parallel computations using the GPU.
 
 
-{# wf_updated_on: 2021-04-16 #}
+{# wf_updated_on: 2021-04-20 #}
 {# wf_published_on: 2019-08-28 #}
 {# wf_tags: news,gpu,canvas,graphics #}
 {# wf_blink_components: Blink>WebGPU #}
@@ -419,7 +419,7 @@ const computePipeline = device.createComputePipeline({
   layout: device.createPipelineLayout({
     bindGroupLayouts: [bindGroupLayout]
   }),
-  computeStage: {
+  compute: {
     module: shaderModule,
     entryPoint: "main"
   }
@@ -545,7 +545,7 @@ An illustration of `getBindGroupLayout` for the previous sample is [available].
 -  layout: device.createPipelineLayout({
 -    bindGroupLayouts: [bindGroupLayout]
 -  }),
-   computeStage: {
+   compute: {
 ```
 
 ```


### PR DESCRIPTION
This PR is about replacing the deprecated `computeStage` attribute with `compute` in the GPU Compute article. See https://chromium-review.googlesource.com/c/chromium/src/+/2830460

Samples have already been updated.

Live preview: https://pr-9335-dot-web-central.appspot.com/web/updates/2019/08/get-started-with-gpu-compute-on-the-web

@Kangz Can you review?

@petele Can you merge once it's approved by @Kangz?