### PR TITLE
Update polymer twitter handle

### DIFF
--- a/src/content/en/updates/2019/02/lit-element-and-lit-html.md
+++ b/src/content/en/updates/2019/02/lit-element-and-lit-html.md
@@ -132,7 +132,7 @@ project, see the lit-html docs:
 * [lit-html docs](https://lit-html.polymer-project.org/)
 
 As always, let us know what you think. You can reach us on [Slack](https://join.slack.com/t/polymer/shared_invite/enQtNTAzNzg3NjU4ODM4LTkzZGVlOGIxMmNiMjMzZDM1YzYyMzdiYTk0YjQyOWZhZTMwN2RlNjM5ZDFmZjMxZWRjMWViMDA1MjNiYWFhZWM)
-or [Twitter](https://twitter.com/polymer). Our projects are open source (of course!) and you can
+or [Twitter](https://twitter.com/buildWithLit). Our projects are open source (of course!) and you can
 report bugs, file feature requests or suggest improvements on GitHub:
 
 * [lit-html on GitHub](https://github.com/Polymer/lit-html)


### PR DESCRIPTION
`@polymer` was snagged by a bot when we renamed it to `@buildWithLit`!

**CC:** @petele
