### PR TITLE
Workbox  docs typo and  dead link fixes

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-google-analytics.md
+++ b/src/content/en/tools/workbox/modules/workbox-google-analytics.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-google-analytics.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2020-01-15 #}
+{# wf_updated_on: 2021-04-23 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Google Analytics  {: .page-title }

--- a/src/content/en/tools/workbox/modules/workbox-google-analytics.md
+++ b/src/content/en/tools/workbox/modules/workbox-google-analytics.md
@@ -30,7 +30,7 @@ failed requests sent to the Measurement Protocol. It can store these
 requests in IndexedDB and then retry them later once connectivity is
 restored.
 
-Workbox Google Analytics does exactly this. It also also adds fetch
+Workbox Google Analytics does exactly this. It also adds fetch
 handlers to cache the
 [analytics.js](/analytics/devguides/collection/analyticsjs/) and
 [gtag.js](/analytics/devguides/collection/gtagjs/)

--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -120,9 +120,8 @@ Workbox comes with tools to help with generating this list:
 - `workbox-webpack-plugin`: webpack users can use this plugin.
 - `workbox-cli`: Our CLI can also be used to generate the list of assets and add
   them to your service worker.
+Warning: It's strongly recommended that you use one of Workbox's [build tools](/web/tools/workbox/modules#node-modules) to generate this precache manifest.
 
-Warning: It's strongly recommended that you use one of Workbox's build tools to [generate this
-precache manifest](/web/tools/workbox/guides/precache-files/#generating_a_precache_manifest).
 **Never hardcode revision info into a "hand written" manifest, as precached URLs will not be kept up
 to date unless the revision info reflects the URL's contents!**
 

--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -120,7 +120,9 @@ Workbox comes with tools to help with generating this list:
 - `workbox-webpack-plugin`: webpack users can use this plugin.
 - `workbox-cli`: Our CLI can also be used to generate the list of assets and add
   them to your service worker.
-Warning: It's strongly recommended that you use one of Workbox's [build tools](/web/tools/workbox/modules#node-modules) to generate this precache manifest.
+Warning: It's strongly recommended that you use one of Workbox's 
+[build tools](/web/tools/workbox/modules#node-modules) to generate this precache 
+manifest.
 
 **Never hardcode revision info into a "hand written" manifest, as precached URLs will not be kept up
 to date unless the revision info reflects the URL's contents!**

--- a/src/content/en/tools/workbox/modules/workbox-precaching.md
+++ b/src/content/en/tools/workbox/modules/workbox-precaching.md
@@ -3,7 +3,7 @@ book_path: /web/tools/workbox/_book.yaml
 description: The module guide for workbox-core.
 
 {# wf_blink_components: N/A #}
-{# wf_updated_on: 2021-03-11 #}
+{# wf_updated_on: 2021-04-23 #}
 {# wf_published_on: 2017-11-27 #}
 
 # Workbox Precaching {: .page-title }
@@ -122,10 +122,8 @@ Workbox comes with tools to help with generating this list:
   them to your service worker.
 Warning: It's strongly recommended that you use one of Workbox's 
 [build tools](/web/tools/workbox/modules#node-modules) to generate this precache 
-manifest.
-
-**Never hardcode revision info into a "hand written" manifest, as precached URLs will not be kept up
-to date unless the revision info reflects the URL's contents!**
+manifest. **Never hardcode revision info into a "hand written" manifest, as precached URLs will not
+be kept up to date unless the revision info reflects the URL's contents!**
 
 ## Incoming Requests for Precached Files
 


### PR DESCRIPTION
What's changed, or what was fixed?
- typo in workbox-google-analytics module docs
- dead link in workbox-precaching module docs 


- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.


