### PR TITLE
docs: correct typo in WorkboxBroadcastUpdate docs (`updatedUrl` to `updatedURL`)

### DIFF
--- a/src/content/en/tools/workbox/modules/workbox-broadcast-update.md
+++ b/src/content/en/tools/workbox/modules/workbox-broadcast-update.md
@@ -77,13 +77,13 @@ In your web app, you can listen for these events like so:
 navigator.serviceWorker.addEventListener('message', async (event) => {
   // Optional: ensure the message came from workbox-broadcast-update
   if (event.data.meta === 'workbox-broadcast-update') {
-    const {cacheName, updatedUrl} = event.data.payload;
+    const {cacheName, updatedURL} = event.data.payload;
 
-    // Do something with cacheName and updatedUrl.
+    // Do something with cacheName and updatedURL.
     // For example, get the cached content and update
     // the content on the page.
     const cache = await caches.open(cacheName);
-    const updatedResponse = await cache.match(updatedUrl);
+    const updatedResponse = await cache.match(updatedURL);
     const updatedText = await updatedResponse.text();
   }
 });


### PR DESCRIPTION
See https://github.com/GoogleChrome/workbox/blob/v6/packages/workbox-broadcast-update/src/BroadcastCacheUpdate.ts#L34-L46 for source.

What's changed, or what was fixed?
- there was a typo in the case of `updatedURL` for the BroadcastUpdated documentation

<!-- **Fixes:** #issue -->

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
