### PR TITLE
Fix messageSkipWaiting in example code

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -20,7 +20,7 @@ To do this you'll need to add some code to your page and to your service worker.
 ```html
 <script type="module">
 // This code sample uses features introduced in Workbox v6.
-import {Workbox, messageSkipWaiting} from 'https://storage.googleapis.com/workbox-cdn/releases/{% include "web/tools/workbox/_shared/workbox-latest-version.html" %}/workbox-window.prod.mjs';
+import {Workbox} from 'https://storage.googleapis.com/workbox-cdn/releases/{% include "web/tools/workbox/_shared/workbox-latest-version.html" %}/workbox-window.prod.mjs';
 
 if ('serviceWorker' in navigator) {
   const wb = new Workbox('/sw.js');
@@ -44,7 +44,7 @@ if ('serviceWorker' in navigator) {
           window.location.reload();
         });
 
-        messageSkipWaiting();
+        wb.messageSkipWaiting();
       },
 
       onReject: () => {


### PR DESCRIPTION
What's changed, or what was fixed?
- Fixes error in the example code. messageSkipWaiting is a method of the Workbox class, not an export of the workbox-window module.

**Fixes:** Didn't create an issue, since it's such a minor change

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
