### PR TITLE
Fix incorrect usage of `messageSkipWaiting`

### DIFF
--- a/src/content/en/tools/workbox/guides/advanced-recipes.md
+++ b/src/content/en/tools/workbox/guides/advanced-recipes.md
@@ -20,7 +20,7 @@ To do this you'll need to add some code to your page and to your service worker.
 ```html
 <script type="module">
 // This code sample uses features introduced in Workbox v6.
-import {Workbox, messageSkipWaiting} from 'https://storage.googleapis.com/workbox-cdn/releases/{% include "web/tools/workbox/_shared/workbox-latest-version.html" %}/workbox-window.prod.mjs';
+import {Workbox} from 'https://storage.googleapis.com/workbox-cdn/releases/{% include "web/tools/workbox/_shared/workbox-latest-version.html" %}/workbox-window.prod.mjs';
 
 if ('serviceWorker' in navigator) {
   const wb = new Workbox('/sw.js');
@@ -44,7 +44,7 @@ if ('serviceWorker' in navigator) {
           window.location.reload();
         });
 
-        messageSkipWaiting();
+        wb.messageSkipWaiting();
       },
 
       onReject: () => {


### PR DESCRIPTION
What's changed, or what was fixed?
- In **Workbox > Tools > Guides > Advanced Recipe > Offer a page reload for users**, the `messageSkipWaiting` is used incorrectly. [`messageSkipWaiting` is not exported from the module](https://github.com/GoogleChrome/workbox/blob/79a415ceeac7fb8840762333f11c903152b74ac4/packages/workbox-window/src/index.ts) but is [exposed as a method on `Workbox` instances](https://github.com/GoogleChrome/workbox/blob/79a415ceeac7fb8840762333f11c903152b74ac4/packages/workbox-window/src/Workbox.ts#L290).

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
