### PR TITLE
Add workgroup_size to WGSL code sample

### DIFF
--- a/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
+++ b/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
@@ -462,7 +462,8 @@ The size of the workgroup grid for our compute shader is `(8, 8)` in our WGSL
 code. Because of that, “x” and “y” that are respectively the number of rows of
 the first matrix and the number of columns of the second matrix will be divided
 by 8. With that, we can now dispatch a compute call with
-`passEncoder.dispatch(firstMatrix[0] / 8, secondMatrix[1] / 8)`.
+`passEncoder.dispatch(firstMatrix[0] / 8, secondMatrix[1] / 8)`. The number of
+workgroup grids to run are the `dispatch()` arguments.
 
 As seen in the drawing above, each shader will have access to a unique
 `builtin(global_invocation_id)` object that will be used to know which result

--- a/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
+++ b/src/content/en/updates/2019/08/get-started-with-gpu-compute-on-the-web.md
@@ -3,7 +3,7 @@ book_path: /web/updates/_book.yaml
 description: This article is about me playing with the experimental WebGPU API and sharing my journey with web developers interested in performing data-parallel computations using the GPU.
 
 
-{# wf_updated_on: 2021-06-09 #}
+{# wf_updated_on: 2021-07-05 #}
 {# wf_published_on: 2019-08-28 #}
 {# wf_tags: news,gpu,canvas,graphics #}
 {# wf_blink_components: Blink>WebGPU #}
@@ -388,7 +388,8 @@ const shaderModule = device.createShaderModule({
     [[group(0), binding(1)]] var<storage, read> secondMatrix : Matrix;
     [[group(0), binding(2)]] var<storage, write> resultMatrix : Matrix;
 
-    [[stage(compute)]] fn main([[builtin(global_invocation_id)]] global_id : vec3<u32>) {
+    [[stage(compute), workgroup_size(64)]]
+    fn main([[builtin(global_invocation_id)]] global_id : vec3<u32>) {
       resultMatrix.size = vec2<f32>(firstMatrix.size.x, secondMatrix.size.y);
 
       let resultCell : vec2<u32> = vec2<u32>(global_id.x, global_id.y);


### PR DESCRIPTION
This CL adds new and required `workgroup_size` decoration to WGSL code sample.

I've updated samples as well.

@Kangz PTAL