### PR TITLE
[Fixed] Typos on documentation for Chrome: strict-origin-when-cross-origin #9380Ananya07105 patch 2

### DIFF
--- a/src/content/en/updates/2016/06/2-cookie-handoff.md
+++ b/src/content/en/updates/2016/06/2-cookie-handoff.md
@@ -48,7 +48,7 @@ industry on documenting best practices for using 2CH.
 
 Service workers are a new technology supported by multiple browsers such as
 Chrome, Firefox, Opera and coming soon to 
-[Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/serviceworker).
+[Edge](https://developer.microsoft.com/en-us/microsoft-edge/status/serviceworker/).
 They allow you to intercept all network requests from your site through a
 common point of code on the client, without modifying the existing pages. This
 allows you to set up a "2CH worker" for logged in users that can intercept

--- a/src/content/en/updates/2020/07/referrer-policy-new-chrome-default.md
+++ b/src/content/en/updates/2020/07/referrer-policy-new-chrome-default.md
@@ -197,7 +197,7 @@ like `strict-origin-when-cross-origin` or stricter right now.
 This protects your users and makes your website behave more predictably across browsers. Mostly, it
 gives you control —rather than having your site depend on browser defaults.
 
-Check [Referer and Referrer-Policy: best practices](https://web.dev/referrer-best-practices) for
+Check [Referrer and Referrer-Policy: best practices](https://web.dev/referrer-best-practices) for
 details on setting a policy.
 
 ### About Chrome enterprise


### PR DESCRIPTION
What's changed, or what was fixed?
- item 1
- item 2

**Fixes:** #issue

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
