### PR TITLE
Remove 404 demo link from PaymentRequest article

### DIFF
--- a/src/content/en/ilt/pwa/introduction-to-the-payment-request-api.md
+++ b/src/content/en/ilt/pwa/introduction-to-the-payment-request-api.md
@@ -88,7 +88,6 @@ Best of all, the browser acts as an intermediary, storing all the information ne
 
 Payment Request demos are available at these URLs:
 
-* Demo:  [https://emerald-eon.appspot.com/](https://emerald-eon.appspot.com/)
 * Polymer Shop demo:  [https://polykart-credential-payment.appspot.com/](https://polykart-credential-payment.appspot.com/)
 * Simple demos and sample code:  [https://googlechrome.github.io/samples/paymentrequest/](https://googlechrome.github.io/samples/paymentrequest/)
 * Deep dive documentation:  [https://developers.google.com/web/fundamentals/discovery-and-monetization/payment-request/deep-dive-into-payment-request](/web/fundamentals/discovery-and-monetization/payment-request/deep-dive-into-payment-request)


### PR DESCRIPTION
https://emerald-eon.appspot.com/ is no longer available

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
