### PR TITLE
Updated "downloading resources in HTML5" article

### DIFF
--- a/src/content/en/updates/2011/08/Downloading-resources-in-HTML5-a-download.md
+++ b/src/content/en/updates/2011/08/Downloading-resources-in-HTML5-a-download.md
@@ -19,16 +19,18 @@ From [Downloading Resources](https://html.spec.whatwg.org/dev/links.html#downloa
 
 >The attribute can furthermore be given a value, to specify the filename that user agents are to use when storing the resource in a file system. This value can be overridden by the `Content-Disposition` HTTP header's `filename` parameter.
 
-For example, clicking the following link downloads the .png as "MyGoogleLogo.png" instead of navigating to its `href` value: <a href="http://www.google.com/intl/en_com/images/srpr/logo2w.png" download="MyGoogleLogo">download me</a>. The markup is simple:
+For example, clicking the following link downloads the .png as "MyGoogleLogo.png" instead of navigating to its `href` value: <a href="https://web-central.appspot.com/web/images/web-fundamentals-icon192x192.png" download="WebfundamentalsLogo">download me</a>. The markup is simple:
 
 
-    <a href="http://www.google.com/.../logo2w.png" download="MyGoogleLogo">download me</a>
+    <a href="http://web-central.appspot.com/.../web-fundamentals-icon192x192.png" download="WebfundamentalsLogo">download me</a>
 
 
 The real benefit of `a[download]` will be when working with [blob: URLs](//www.html5rocks.com/en/tutorials/workers/basics/#toc-inlineworkers-bloburis) and [filesystem: URLs](http://html5-demos.appspot.com/static/filesystem/generatingResourceURIs.html) URLs.
 It'll give users a way to download content created/modified within your app.
 
 [Full Demo](http://html5-demos.appspot.com/static/a.download.html)
+
+One thing to note is that in the above example, the image has same origin with respect to website. If you try to use a link of image from different origin the link may not work as a navigating link rather than a downloading link. This is because many versions of browser does not support the download policy on cross-origin files. For example Chrome versions prior to 65 did allow downloading cross origin files and it was deprecated in later versions. Read <a href="https://developers.google.com/web/updates/2018/02/chrome-65-deprecations">this</a> for more detail. You can use `Content-Disposition` header to force a download from other origin.
 
 Browser support: only the current Chrome dev channel release (14.0.835.15+) supports this attribute.
 


### PR DESCRIPTION
Updated the article according to latest cross origin download policy

What's changed, or what was fixed?

-The link of image is replaced by a link to image in same origin
-The paragraph is added to tell readers about the new cross origin download policy and deprecatation of download attribute for cross origin download in Chrome 65

**Fixes:** #9438

**Target Live Date:** N/A

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
