### PR TITLE
Fix bug in MutationObserver doc

### DIFF
--- a/src/content/en/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers.md
+++ b/src/content/en/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers.md
@@ -44,7 +44,7 @@ And here’s how it looks with Mutation Observers:
          insertedNodes.push(mutation.addedNodes[i]);
      })
     });
-    observer.observe(document, { childList: true });
+    observer.observe(document.documentElement, { childList: true });
     console.log(insertedNodes);
 
 


### PR DESCRIPTION
What's changed, or what was fixed?
- The example doesn't work on document, but does work on document.documentElement.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @PaulKinlan 