### PR TITLE
Fix Site Kit name in footer link

### DIFF
--- a/src/content/en/_footer.yaml
+++ b/src/content/en/_footer.yaml
@@ -27,7 +27,7 @@ footer:
       path: http://developers.google.com/docs/android/
     - label: Chrome Extension Docs
       path: https://developer.chrome.com/
-    - label: Site-Kit Plugin for WordPress
+    - label: Site Kit plugin for WordPress
       path: https://sitekit.withgoogle.com/
     - label: How to file a good browser bug
       path: https://web.dev/how-to-file-a-good-bug/


### PR DESCRIPTION
What's changed, or what was fixed?
- The correct name is "Site Kit", not "Site-Kit". This fixes the footer link where it is incorrectly hyphenated.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [x] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
