### PR TITLE
Remove all references to Google Surveys

### DIFF
--- a/gulp-tasks/tests/projectYaml.js
+++ b/gulp-tasks/tests/projectYaml.js
@@ -58,7 +58,6 @@ const SCHEMA_PROJECT = {
       additionalProperties: false,
     },
     footer_path: {type: 'string', required: true},
-    gcs_id: {type: 'string'},
     google_analytics_ids: {
       type: 'array',
       items: {type: 'string', format: 'wfUAString'},

--- a/src/content/en/_project.yaml
+++ b/src/content/en/_project.yaml
@@ -15,7 +15,6 @@ social_media:
     path: /web/images/social-webfu-16x9.png
     width: 1200
     height: 675
-gcs_id: ylj5ifxusvvmr4pp6ae5lwrctq
 announcement:
   description: |
     <style>

--- a/src/content/en/fundamentals/_project.yaml
+++ b/src/content/en/fundamentals/_project.yaml
@@ -15,7 +15,6 @@ social_media:
     path: /web/images/social-webfu-16x9.png
     width: 1200
     height: 675
-gcs_id: ylj5ifxusvvmr4pp6ae5lwrctq
 announcement:
   description: |
     <style>

--- a/src/content/en/tools/_project.yaml
+++ b/src/content/en/tools/_project.yaml
@@ -15,7 +15,6 @@ social_media:
     path: /web/images/social-webfu-16x9.png
     width: 1200
     height: 675
-gcs_id: ylj5ifxusvvmr4pp6ae5lwrctq
 announcement:
   description: |
     <style>

--- a/src/content/en/tools/workbox/_project.yaml
+++ b/src/content/en/tools/workbox/_project.yaml
@@ -14,7 +14,6 @@ social_media:
     path: /web/tools/workbox/images/workbox-social.png
     width: 1200
     height: 675
-gcs_id: ylj5ifxusvvmr4pp6ae5lwrctq
 announcement:
   description: |
     <style>


### PR DESCRIPTION
DevSite is trying to move away from Google Surveys (f.k.a Google Consumer Surveys a.k.a `gcs`) and instead move all surveys onto HaTS.

Right now we don't detect any active surveys on these IDs so this removal is safe. For information on using HaTS surveys see internal docs:
https://developers.devsite.corp.google.com/devsite/reference/metadata/project?hl=en#showing_surveys