### PR TITLE
Hide widget

### DIFF
--- a/src/content/en/_shared/helpful.html
+++ b/src/content/en/_shared/helpful.html
@@ -1,4 +1,7 @@
-<div class="devsite-tracking-question">
+<p>If you have specific ideas on how to improve this page, please
+<a href="https://github.com/google/webfundamentals/issues/new">create an issue</a>.
+
+<!--<div class="devsite-tracking-question">
   <div>Was this page helpful?</div>
   <div class="gc-analytics-event"
        data-category="Helpful" data-value="1"
@@ -106,4 +109,4 @@
       </div>
     </div>
   </div>
-</div>
+</div>-->


### PR DESCRIPTION
Currently broken. Instead, including a link to open an issue to share feedback.

What's changed, or what was fixed?
- The feedback widget is currently broken. This PR hides that HTML in favor of a link to create an issue.

**Target Live Date:** TBD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
