### PR TITLE
fix footer partial name

### DIFF
--- a/src/content/en/updates/2017/02/navigation-preload.md
+++ b/src/content/en/updates/2017/02/navigation-preload.md
@@ -269,7 +269,7 @@ const networkContent = Promise.resolve(event.preloadResponse)
 const parts = [
   caches.match('/article-top.include'),
   <strong>networkContent</strong>,
-  caches.match('/article-bottom')
+  caches.match('/article-bottom.include')
 ];
 </pre>
 


### PR DESCRIPTION
What's changed, or what was fixed?
- Inconsistency in partial name. In the first few code samples, the "partial includes" follow the `<partial-name>.include` naming pattern. For reference, [here](https://developers.google.com/web/updates/2017/02/navigation-preload) is the live article.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.
- [x] I've done neither of these ^ things as I've just edited directly via GitHub

**CC:** @petele
