### PR TITLE
Remove reference to dead link

### DIFF
--- a/src/content/en/fundamentals/push-notifications/index.md
+++ b/src/content/en/fundamentals/push-notifications/index.md
@@ -82,9 +82,8 @@ subscriptions, sending messages, and responding to them.
 There are several ways you can play with the features before you completely
 understand how they work, or have to implement them. First, check out
 [our own sample](https://github.com/GoogleChrome/samples/tree/gh-pages/push-messaging-and-notifications).
-Also available are Peter Beverloo's
-[Notification Generator](https://tests.peter.sh/notification-generator/)
-and Mozilla's [Push Payload Demo](https://serviceworke.rs/push-payload_demo.html).
+Also available is Peter Beverloo's
+[Notification Generator](https://tests.peter.sh/notification-generator/).
 
 Note: Unless you're using localhost, the Push API requires HTTPS.
 


### PR DESCRIPTION
**Page Affected:** https://developers.google.com/web/fundamentals/push-notifications

**What needs to be done?**

- [ ] Remove Mozilla's Push Payload Demo, so it does not longer redirect to the parked domain "serviceworke.rs"