### PR TITLE
Fix broken link

### DIFF
--- a/src/content/en/_footer.yaml
+++ b/src/content/en/_footer.yaml
@@ -24,7 +24,7 @@ footer:
     icon_name: star
     contents:
     - label: Web on Android
-      path: http://developers.google.com/docs/android/
+      path: https://developer.android.com/docs
     - label: Chrome Extension Docs
       path: https://developer.chrome.com/
     - label: Site Kit plugin for WordPress


### PR DESCRIPTION
What's changed, or what was fixed?
- fixed broken link in footer on page https://developers.google.com/web. 
`Footer` `Key Topics` `Web on Android`
<img width="300" alt="Screen Shot 2022-03-02 at 3 15 00 AM" src="https://user-images.githubusercontent.com/28377370/156352266-b96eed8b-fdf3-4e7e-9f7c-ba3c35a6feca.png">


**Fixes:** #9430

**Target Live Date:** 2022-02-08

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [x] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @jeffposnick
