### PR TITLE
Add a "legacy" banner to Workbox docs

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -75,6 +75,10 @@ gulp.task('build:announcement', function() {
   const announcementYaml = jsYaml.safeLoad(fs.readFileSync(file, 'utf8'));
   const showAnnouncement = announcementYaml['enabled'];
   projectYamlFiles.forEach((file) => {
+    // The legacy Workbox site needs its own banner.
+    if (file.indexOf('workbox') !== -1) {
+      return;
+    }
     let projYaml = jsYaml.safeLoad(fs.readFileSync(file, 'utf8'));
     if (showAnnouncement) {
       projYaml.announcement = {};

--- a/src/content/en/tools/workbox/_project.yaml
+++ b/src/content/en/tools/workbox/_project.yaml
@@ -18,21 +18,5 @@ keywords:
   - 'product:Workbox'
 announcement:
   description: |
-    <style>
-      .devsite-banner-announcement {
-        background-color: #e8f0fe;
-        color: #424242;
-      }
-      .devsite-banner-announcement :link,
-      .devsite-banner-announcement :visited {
-        background: #e8f0fe;
-        color: #039BE5;
-      }
-      .devsite-banner-announcement span.material-icons {
-        vertical-align: middle;
-        margin-right: 8px;
-      }
-      .goog-font {
-        font-family: Google Sans,Noto Sans,Noto Sans JP,Noto Sans KR,Noto Naskh Arabic,Noto Sans Thai,Noto Sans Hebrew,Noto Sans Bengali,sans-serif;
-      }
-    </style> <b class="goog-font">Chrome Dev Summit</b> is back! Visit <a href="https://goo.gle/cds2021">goo.gle/cds2021</a> to secure your spot in workshops, office hours and learning lounges!
+    This is the legacy Workbox site.
+    Visit <a href="https://developer.chrome.com/docs/workbox/">the new docs</a>.


### PR DESCRIPTION
This updates the banner on the Workbox pages to point folks to the new docs site:

<img width="662" alt="Screen Shot 2022-03-10 at 11 24 30 AM" src="https://user-images.githubusercontent.com/1749548/157709052-f7dfb03a-eba2-46f1-af59-30ec78a11715.png">

Many of the pages are already automatically redirected to the new site, but for the ones that aren't yet, this will point folks in the right direction (while still preserving the old content).