### PR TITLE
Redirects the service worker lifecycle doc to the web.dev version.

### DIFF
--- a/src/content/en/fundamentals/_redirects.yaml
+++ b/src/content/en/fundamentals/_redirects.yaml
@@ -104,7 +104,7 @@ redirects:
   to: /web/fundamentals/
 
 - from: /web/fundamentals/instant-and-offline/service-worker/lifecycle
-  to: /web/fundamentals/primers/service-workers/lifecycle
+  to: https://web.dev/service-worker-lifecycle/
 
 - from: /web/fundamentals/instant-and-offline/service-worker/registration
   to: /web/fundamentals/primers/service-workers/registration

--- a/src/content/en/fundamentals/_toc-base.yaml
+++ b/src/content/en/fundamentals/_toc-base.yaml
@@ -20,7 +20,8 @@ toc:
       - title: Overview
         path: /web/fundamentals/primers/service-workers/
       - title: Life Cycle
-        path: /web/fundamentals/primers/service-workers/lifecycle
+        path: https://web.dev/service-worker-lifecycle/
+        status: external
       - title: Registration
         path: /web/fundamentals/primers/service-workers/registration
       - title: High Performance Loading

--- a/src/content/en/fundamentals/primers/_redirects.yaml
+++ b/src/content/en/fundamentals/primers/_redirects.yaml
@@ -17,7 +17,7 @@ redirects:
   to: https://developer.chrome.com/docs/workbox/caching-strategies-overview/
 
 - from: /web/fundamentals/primers/service-workers/lifecycle
-  to: https://developer.chrome.com/docs/workbox/service-worker-lifecycle/
-  
-- from: /web/fundamentals/primers/service-workers 
+  to: https://web.dev/service-worker-lifecycle/
+
+- from: /web/fundamentals/primers/service-workers
   to: https://developer.chrome.com/docs/workbox/service-worker-overview/


### PR DESCRIPTION
What's changed, or what was fixed?
- Redirects the service worker lifecycle doc to the web.dev version.

**Fixes:** GoogleChrome/developer.chrome.com#2291

- [ ] This has been reviewed and approved by (@rachelandrew)
- [x] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele @jakearchibald @rachelandrew 
