### PR TITLE
Remove "Help, I've been hacked" content

### DIFF
--- a/src/content/en/fundamentals/security/_toc.yaml
+++ b/src/content/en/fundamentals/security/_toc.yaml
@@ -28,4 +28,3 @@ toc:
         path: https://web.dev/fixing-mixed-content
         status: external
         step_group: security-mixed-content
-    - include: /web/fundamentals/security/hacked/_toc.yaml

--- a/src/content/en/fundamentals/security/hacked/_README.md
+++ b/src/content/en/fundamentals/security/hacked/_README.md
@@ -1,1 +1,0 @@
-ATTENTION: The source of truth for this folder is `google3`

--- a/src/content/en/fundamentals/security/hacked/_toc.yaml
+++ b/src/content/en/fundamentals/security/hacked/_toc.yaml
@@ -1,6 +1,0 @@
-toc:
-- title: Help, I've been hacked
-  section:
-  - title: Overview
-    path: /web/fundamentals/security/hacked/
-    status: external


### PR DESCRIPTION
What's changed, or what was fixed?
- Removes TOC items for "Help I've been hacked" content as it's moved to web.dev
