### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/content/en/ilt/pwa/lab-build-a-progressive-web-amp.md
+++ b/src/content/en/ilt/pwa/lab-build-a-progressive-web-amp.md
@@ -771,7 +771,7 @@ Let's make our app shell's code aware of this change. Add a function to `js/app.
 function getContentUri() {
   const hash = window.location.hash;
   if (hash && hash.indexOf('href=') > -1) {
-    return decodeURIComponent(hash.substr(6));
+    return decodeURIComponent(hash.slice(6));
   }
   return window.location;
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `npm test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
