### PR TITLE
Adds missing workbox-sw redirect to d.c.c.

### DIFF
--- a/src/content/en/tools/_redirects.yaml
+++ b/src/content/en/tools/_redirects.yaml
@@ -50,6 +50,9 @@ redirects:
 - from: /web/tools/workbox/guides/service-worker-checklist
   to: /web/fundamentals/primers/service-workers/registration
 
+- from: /web/tools/workbox/reference-docs/latest/workbox
+  to: https://developer.chrome.com/docs/workbox/modules/workbox-sw/
+
 - from: /web/tools/workbox/community
   to: https://twitter.com/workboxjs
 


### PR DESCRIPTION
What's changed, or what was fixed?
- The guide at https://developers.google.com/web/tools/workbox/reference-docs/latest/workbox was deleted, but not redirected anywhere. This PR adds a redirect from that URL to point to https://developer.chrome.com/docs/workbox/modules/workbox-sw/

**Fixes:** #GoogleChrome/workbox#3059

**Target Live Date:** Within the next day or so would be fine.

- [ ] This has been reviewed and approved by (@jeffposnick)
- [x] I have run `npm test` locally and all tests pass (@malchata).
- [ ] I have added the appropriate `type-something` label.
- [x] I've staged the site and manually verified that my content displays correctly (@malchata).

**CC:** @petele @jeffposnick
