### PR TITLE
Fixes broken redirect from the Workbox "Getting Started" guide.

### DIFF
--- a/src/content/en/tools/_redirects.yaml
+++ b/src/content/en/tools/_redirects.yaml
@@ -11,6 +11,9 @@ redirects:
 
 # Workbox redirects
 
+- from: /web/tools/workbox/guides/get-started
+  to: https://developer.chrome.com/docs/workbox/the-ways-of-workbox/
+
 - from: /web/tools/service-worker-libraries/
   to: /web/tools/workbox/
 


### PR DESCRIPTION
What's changed, or what was fixed?
- A redirect for the "Getting Started" guide for Workbox was not redirected, resulting in a 404. This was fixed.

**Fixes:** GoogleChrome/workbox#3085

**Target Live Date:** 2022-05-31

- [ ] This has been reviewed and approved by (@jeffposnick).
- [x] I have run `npm test` locally and all tests pass (@malchata).
- [ ] I have added the appropriate `type-something` label (@jeffposnick).
- [x] I've staged the site and manually verified that my content displays correctly (@malchata).

**CC:** @jeffposnick
